### PR TITLE
Add verification and finalize definition of the UI form for adding the provider

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager.rb
@@ -16,5 +16,12 @@ module ManageIQ::Providers::CiscoIntersight
 
     supports :create
 
+    def self.ems_type
+      @ems_type ||= "cisco_intersight".freeze
+    end
+
+    def self.description
+      @description ||= "Cisco Intersight".freeze
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -23,4 +23,4 @@
       :ems_metrics_collector_worker:
         :ems_metrics_collector_worker_cisco_intersight: {}
       :ems_refresh_worker:
-        :ems_refresh_worker_cisco_intersight: {}
+        :ems_refresh_worker_cisco_intersight_physical_infra: {}


### PR DESCRIPTION
This PR enables adding provider through ManageIQ web UI and resolves #2.

Verifying connection by making a `get_iam_api_key_list` request to API. This verification is made when adding a new provider as well as when checking the authentication status of an existing provider.
Removed `hostname` parameter from the form and renamed the "Endpoints" sub-form to "Authentication".
The form requires input of the API key ID and the PEM-formatted private key itself (contents of the key file).

Moved provider type and name definitions to `physical_infra_manager.rb` (according to example from Redfish provider).