### PR TITLE
Add power management

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -26,7 +26,7 @@ module ManageIQ::Providers::CiscoIntersight
           :physical_chassis => chassis, # nil for now
           :physical_rack    => rack, # nil for now
           :power_state      => s.oper_power_state,
-          :raw_power_state  => s.admin_power_state,
+          :raw_power_state  => s.oper_power_state,
           :type => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServer",
         )
         persister.physical_server_computer_systems.build(

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/power.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/power.rb
@@ -58,13 +58,11 @@ module ManageIQ::Providers::CiscoIntersight
 
         if compute_server_settings_list.empty?
           raise MiqException::Error, "No IntersightClient::ComputeServerSetting object found for ems_ref #{server.ems_ref} . Server might not be Intersight-managed."
-          return
         end
         if compute_server_settings_list.size > 1
           raise MiqException::Error, "Multiple IntersightClient::ComputeServerSetting retrieved for ems_ref #{server.ems_ref}."
-          return
         end
-        compute_server_settings = compute_server_settings_list[0]
+        compute_server_settings = compute_server_settings_list.first
 
         previous_admin_power_state = compute_server_settings.admin_power_state
 

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/power.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/power.rb
@@ -59,9 +59,6 @@ module ManageIQ::Providers::CiscoIntersight
         if compute_server_settings_list.empty?
           raise MiqException::Error, "No IntersightClient::ComputeServerSetting object found for ems_ref #{server.ems_ref} . Server might not be Intersight-managed."
         end
-        if compute_server_settings_list.size > 1
-          raise MiqException::Error, "Multiple IntersightClient::ComputeServerSetting retrieved for ems_ref #{server.ems_ref}."
-        end
         compute_server_settings = compute_server_settings_list.first
 
         previous_admin_power_state = compute_server_settings.admin_power_state

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/power.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/power.rb
@@ -1,33 +1,25 @@
 module ManageIQ::Providers::CiscoIntersight
   module PhysicalInfraManager::Operations::Power
-    # Keep this in sync with app/models/physical_server/operations/power.rb in
-    # core and ResetType enum in CiscoIntersight Resource type. Name of the method
-    # comes from the core and the action name used in the reset call from the
-    # ResetType enum.
-    #
-    # NOTE: Not all reset operations are implemented on all servers, so any of
-    # the methods listed here can fail. We need to find a way to let those
-    # failures bubble up to the user interface somehow or risk having a
-    # completely useless tool.
+    # See app/models/physical_server/operations/power.rb in core.
 
     def power_on(server, _options)
-      trigger_first_valid_power_action(server, %w[On])
+      reset_server(server, "PowerOn")
     end
 
     def power_off(server, _options)
-      trigger_first_valid_power_action(server, %w[GracefulShutdown])
+      reset_server(server, "PowerOff")
     end
 
     def power_off_now(server, _options)
-      trigger_first_valid_power_action(server, %w[ForceOff])
+      reset_server(server, "ForceOff")
     end
 
     def restart(server, _options)
-      trigger_first_valid_power_action(server, %w[GracefulRestart])
+      reset_server(server, "PowerCycle")
     end
 
     def restart_now(server, _options)
-      trigger_first_valid_power_action(server, %w[ForceRestart])
+      reset_server(server, "HardReset")
     end
 
     def restart_to_sys_setup(_args, _options)
@@ -36,62 +28,59 @@ module ManageIQ::Providers::CiscoIntersight
     end
 
     def restart_mgmt_controller(_server, _options)
-      # TODO(tadeboro): This operation is not well defined, since server can
-      # (and usually is) managed by more that one manager.
-      _log.error("Restarting BMC is not supported.")
-      raise MiqException::Error, "Restarting BMC is not supported."
-    end
-
-    # Select any supported method of powering the server down.
-    def power_down(server, _options)
-      trigger_first_valid_power_action(server, %w[ForceOff GracefulShutdown])
-    end
-
-    # Select any supported method of powering the server up.
-    def power_up(server, _options)
-      trigger_first_valid_power_action(server, %w[On ForceOn])
+      reset_server(server, "Reboot");
     end
 
     private
 
-    def trigger_first_valid_power_action(server, rtypes)
-      server.with_provider_object do |system|
-        available_rtypes = get_available_rtypes(system)
-        rtype = rtypes.find { |t| available_rtypes.include?(t) }
-        if rtype.nil?
-          _log.error("#{rtypes} and #{available_rtypes} are disjunct.")
-          raise MiqException::Error, "No acceptable reset type"
+    def reset_server(server, power_state)
+      # Changing the admin_power_state attribute in IntersightClient::ComputeServerSetting object according to power_state
+      # Possible values for admin_power_state:
+      # @see https://github.com/xlab-si/intersight-sdk-ruby/blob/45ec426b9d061502166499a755ac119058002972/lib/intersight_client/models/compute_server_setting.rb#L28
+      #   - admin_power_state == `Policy` - Power state is set to the default value in the policy
+      #     [Meaning: look at result of IntersightClient::PowerApi.new.get_power_policy_list (select the relevant element according to moid of the server)]
+      #   - admin_power_state == `PowerOn` - Power state of the server is set to On.
+      #   - admin_power_state == `PowerOff` - Power state of the server is set to Off.
+      #   - admin_power_state == `PowerCycle` - Power state of the server is reset.
+      #   - admin_power_state == `HardReset` - Power state of the server is hard reset.
+      #   - admin_power_state == `Shutdown` - Operating system on the server is shut down.
+      #   - admin_power_state == `Reboot` - Power state of IMC is rebooted.
+
+      _log.info("Requesting #{power_state} for #{server.ems_ref}.")
+
+      with_provider_connection do |_client|
+        compute_api = IntersightClient::ComputeApi.new
+        system = compute_api.get_compute_physical_summary_by_moid(server.ems_ref)
+
+        # Get the related ComputeServerSettings:
+        # This only works for servers that are Intersight-managed and have a directly related IntersightClient::ComputeServerSetting object
+        compute_server_settings_list = compute_api.get_compute_server_setting_list({:filter => "(Server.Moid eq '#{server.ems_ref}')"}).results
+
+        if compute_server_settings_list.empty?
+          raise MiqException::Error, "No IntersightClient::ComputeServerSetting object found for ems_ref #{server.ems_ref} . Server might not be Intersight-managed."
+          return
         end
+        if compute_server_settings_list.size > 1
+          raise MiqException::Error, "Multiple IntersightClient::ComputeServerSetting retrieved for ems_ref #{server.ems_ref}."
+          return
+        end
+        compute_server_settings = compute_server_settings_list[0]
 
-        execute_reset_action(system, rtype)
+        previous_admin_power_state = compute_server_settings.admin_power_state
+
+        # Use of PATCH method to change the attribute admin_power_state in IntersightClient::ComputeServerSetting object
+        compute_server_setting_updated = IntersightClient::ComputeServerSetting.new(
+          {:admin_power_state => power_state}
+        )
+        begin
+          result = compute_api.patch_compute_server_setting(compute_server_settings.moid, compute_server_setting_updated, {})
+          _log.info("Updated power_state of the server from #{previous_admin_power_state} to #{result.admin_power_state}")
+        rescue IntersightClient::ApiError => e
+          _log.error("#{power_state} for #{server.ems_ref} failed.")
+          raise MiqException::Error, "#{power_state} failed: #{e.response_body}"
+          # Note: errors are not indicated on the MiQ UI
+        end
       end
-    end
-
-    def get_available_rtypes(system)
-      action = system.Actions["#ComputerSystem.Reset"]
-      get_inline_rtypes(action) || get_action_info_rtypes(action) || []
-    end
-
-    def get_inline_rtypes(action)
-      action["ResetType@CiscoIntersight.AllowableValues"]
-    end
-
-    def get_action_info_rtypes(action)
-      params = action["@CiscoIntersight.ActionInfo"]&.Parameters || []
-      params.find { |p| p.Name == "ResetType" }&.AllowableValues
-    end
-
-    def execute_reset_action(system, rtype)
-      _log.info("Attempting to execute #{rtype} reset.")
-      response = system.Actions["#ComputerSystem.Reset"].post(
-        :field => "target", :payload => { "ResetType" => rtype }
-      )
-      unless [200, 202, 204].include?(response.status)
-        raise MiqException::Error, "'#{rtype}' reset failed: #{response.body}."
-      end
-
-      _log.info("#{rtype} reset done.")
-      response
     end
   end
 end

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
@@ -51,7 +51,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
       :model                  => nil,
       :serial_number          => nil,
       :field_replaceable_unit => nil,
-      :raw_power_state        => "policy",
+      :raw_power_state        => "on",
       :vendor                 => nil,
     )
 


### PR DESCRIPTION
This PR resolves #11.

Implemented methods for all ManageIQ power functions except `restart_to_sys_setup`, which is not supported by Intersight.
Intersight-managed servers can now be powered on, shut down, restarted, etc. Note that some servers might have different management modes (e.g. UCSM) and their power cannot be configured through the Intersight API.

Beside adding power operations functions, also changed `parser/physical_infra_manager.rb` to observe `oper_power_state` attribute representing the actual power state instead of `admin_power_state` (which represents the requested state).
Also removed `.idea` directory used by IntelliJ IDE (RubyMine).