### PR TITLE
Enhance Inventory's features (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 /spec/reports/
 /tmp/
 
+.DS_Store
 .rubocop-*
 /bundler.d/*
 !/bundler.d/.keep
@@ -16,6 +17,7 @@
 /config/settings/*.local.yml
 /config/environments/*.local.yml
 /spec/manageiq
+.idea/
 
 .idea/
 intersight-client-ruby/

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 /spec/reports/
 /tmp/
 
-.DS_Store
 .rubocop-*
 /bundler.d/*
 !/bundler.d/.keep
@@ -17,8 +16,6 @@
 /config/settings/*.local.yml
 /config/environments/*.local.yml
 /spec/manageiq
-.idea/
 
-.idea/
 intersight-client-ruby/
 intersight-sdk-ruby

--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -54,7 +54,8 @@ module ManageIQ::Providers::CiscoIntersight
     end
 
     def get_device_contract_information_from_device_moid(registered_device_moid)
-      device_contract_informations.select { |c| c.registered_device.moid == registered_device_moid }[0]
+      device_contract_informations.find { |c| c.registered_device.moid == registered_device_moid }
+    end
 
     def get_source_object_from_physical_server(physical_summary)
       # physical_summary represents API object, class IntersightClient::ComputePhysicalSummary
@@ -128,6 +129,7 @@ module ManageIQ::Providers::CiscoIntersight
 
     def port_api
       @port_api = IntersightClient::PortApi.new
+    end
 
     def ether_api
       @ether_api = IntersightClient::EtherApi.new

--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -21,7 +21,7 @@ module ManageIQ::Providers::CiscoIntersight
       # Initialize the variables that may be memoized for the duration of the refresh run
       physical_servers
       physical_racks
-      firmware_inventory
+      firmware_firmware_summaries
       network_elements
       physical_chassis
     end
@@ -37,8 +37,8 @@ module ManageIQ::Providers::CiscoIntersight
       @physical_racks = compute_api.get_compute_rack_unit_list.results
     end
 
-    def firmware_inventory
-      @firmware_inventory = firmware_api.get_firmware_firmware_summary_list.results
+    def firmware_firmware_summaries
+      @firmware_firmware_summaries = firmware_api.get_firmware_firmware_summary_list.results
     end
 
     def physical_servers
@@ -55,6 +55,10 @@ module ManageIQ::Providers::CiscoIntersight
 
     def get_device_contract_information_from_device_moid(registered_device_moid)
       device_contract_informations.find { |c| c.registered_device.moid == registered_device_moid }
+    end
+
+    def get_firmware_firmware_summary_from_server_moid(server_moid)
+      firmware_firmware_summaries.find { |c| c.server.moid == server_moid}
     end
 
     def get_source_object_from_physical_server(physical_summary)

--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -9,7 +9,7 @@ module ManageIQ::Providers::CiscoIntersight
       physical_racks
       physical_server_network_devices
       firmware_inventory
-
+      network_elements
     end
 
     def set_configuration
@@ -48,50 +48,56 @@ module ManageIQ::Providers::CiscoIntersight
       IntersightClient::StorageApi.new
     end
 
+    def get_network_api
+      IntersightClient::NetworkApi.new
+    end
+
+    def get_port_api
+      IntersightClient::PortApi.new
+    end
+
+    def get_ether_api
+      IntersightClient::EtherApi.new
+    end
+
     def get_device_contract_informations
       # Returns an array with objects of type DeviceContractInformation
       get_asset_api.get_asset_device_contract_information_list.results
     end
 
     def get_device_contract_information_from_device_moid(registered_device_moid)
-      get_device_contract_informations.select{|c| c.registered_device.moid == registered_device_moid}[0]
+      get_device_contract_informations.select { |c| c.registered_device.moid == registered_device_moid }[0]
     end
 
-    def get_equipment_locator_led_by_moid(moid)
-      get_equipment_api.get_equipment_locator_led_by_moid(moid)
-    end
+    delegate :get_adapter_ext_eth_interface_by_moid, :to => :get_adapter_api
 
-    def get_storage_controller_by_moid(moid)
-      get_storage_api.get_storage_controller_by_moid(moid)
-    end
+    delegate :get_ether_physical_port_by_moid, :to => :get_ether_api
 
-    def get_compute_board_by_moid(moid)
-      get_compute_api.get_compute_board_by_moid(moid)
-    end
+    delegate :get_port_group_by_moid, :to => :get_port_api
 
-    def get_adapter_unit_by_moid(moid)
-      get_adapter_api.get_adapter_unit_by_moid(moid)
-    end
+    delegate :get_equipment_switch_card_by_moid, :to => :get_equipment_api
 
-    def get_asset_device_registration_by_moid(moid)
-      get_asset_api.get_asset_device_registration_by_moid(moid)
-    end
+    delegate :get_equipment_locator_led_by_moid, :to => :get_equipment_api
+
+    delegate :get_storage_controller_by_moid, :to => :get_storage_api
+
+    delegate :get_compute_board_by_moid, :to => :get_compute_api
+
+    delegate :get_adapter_unit_by_moid, :to => :get_adapter_api
+
+    delegate :get_asset_device_registration_by_moid, :to => :get_asset_api
+
+    delegate :get_firmware_running_firmware_by_moid, :to => :get_firmware_api
 
     def get_rack_unit_from_physical_summary_moid(moid)
       physical_racks.select { |c| c.registered_device.moid == moid }[0]
     end
 
-    def get_management_controller_by_moid(moid)
-      get_management_api.get_management_controller_by_moid(moid)
-    end
+    delegate :get_management_controller_by_moid, :to => :get_management_api
 
-    def get_compute_blade_by_moid(moid)
-      get_compute_api.get_compute_blade_by_moid(moid)
-    end
+    delegate :get_compute_blade_by_moid, :to => :get_compute_api
 
-    def get_compute_rack_unit_by_moid(moid)
-      get_compute_api.get_compute_rack_unit_by_moid(moid)
-    end
+    delegate :get_compute_rack_unit_by_moid, :to => :get_compute_api
 
     def get_source_object_from_physical_server(physical_summary)
       # physical_summary represents API object, class IntersightClient::ComputePhysicalSummary
@@ -100,11 +106,10 @@ module ManageIQ::Providers::CiscoIntersight
       source_object_type = physical_summary.source_object_type
       source_object_moid = physical_summary.moid
       if source_object_type == "compute.Blade"
-        source_object = get_compute_blade_by_moid(source_object_moid)
+        get_compute_blade_by_moid(source_object_moid)
       else
-        source_object = get_compute_rack_unit_by_moid(source_object_moid)
+        get_compute_rack_unit_by_moid(source_object_moid)
       end
-      source_object
     end
 
     def physical_racks
@@ -112,7 +117,7 @@ module ManageIQ::Providers::CiscoIntersight
     end
 
     def physical_server_network_devices
-      get_equipment_api.get_equipment_device_summary_list.results.reject { |c| c.source_object_type == "compute.RackUnit" } # source_object_type == "adapter.Unit"
+      get_equipment_api.get_equipment_device_summary_list.results.reject { |c| c.source_object_type == "compute.RackUnit" }
     end
 
     def firmware_inventory
@@ -130,6 +135,12 @@ module ManageIQ::Providers::CiscoIntersight
     def physical_chassis
       get_equipment_api.get_equipment_chassis_list.results
     end
+
+    def network_elements
+      get_network_api.get_network_element_list.results
+    end
+
+
 
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -94,7 +94,6 @@ module ManageIQ::Providers::CiscoIntersight
     private
 
     # API endpoint declaration
-
     def firmware_api
       @firmware_api = IntersightClient::FirmwareApi.new
     end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -3,7 +3,7 @@ module ManageIQ::Providers::CiscoIntersight
 
     def collect
 
-      # Establish conneciton. Connection in inside ManagerMixin sets API key and keyid-d
+      # Establish connection. Connection is inside ManagerMixin which sets API key and keyid-d
       connection
 
       # Initialize API endpoints

--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -48,8 +48,8 @@ module ManageIQ::Providers::CiscoIntersight
       IntersightClient::StorageApi.new
     end
 
-    def get_network_api
-      IntersightClient::NetworkApi.new
+    def network_api
+      @network_api ||= IntersightClient::NetworkApi.new
     end
 
     def get_port_api
@@ -137,7 +137,7 @@ module ManageIQ::Providers::CiscoIntersight
     end
 
     def network_elements
-      get_network_api.get_network_element_list.results
+      network_api.get_network_element_list.results
     end
 
 

--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -30,27 +30,27 @@ module ManageIQ::Providers::CiscoIntersight
 
     def device_contract_informations
       # Returns an array with objects of type DeviceContractInformation
-      @device_contract_informations = asset_api.get_asset_device_contract_information_list.results
+      @device_contract_informations ||= asset_api.get_asset_device_contract_information_list.results
     end
 
     def physical_racks
-      @physical_racks = compute_api.get_compute_rack_unit_list.results
+      @physical_racks ||= compute_api.get_compute_rack_unit_list.results
     end
 
     def firmware_firmware_summaries
-      @firmware_firmware_summaries = firmware_api.get_firmware_firmware_summary_list.results
+      @firmware_firmware_summaries ||= firmware_api.get_firmware_firmware_summary_list.results
     end
 
     def physical_servers
-      @physical_servers = compute_api.get_compute_physical_summary_list.results
+      @physical_servers ||= compute_api.get_compute_physical_summary_list.results
     end
 
     def physical_chassis
-      @physical_chassis = equipment_api.get_equipment_chassis_list.results
+      @physical_chassis ||= equipment_api.get_equipment_chassis_list.results
     end
 
     def network_elements
-      @network_elements = network_api.get_network_element_list.results
+      @network_elements ||= network_api.get_network_element_list.results
     end
 
     def get_device_contract_information_from_device_moid(registered_device_moid)
@@ -100,43 +100,43 @@ module ManageIQ::Providers::CiscoIntersight
 
     # API endpoint declaration
     def firmware_api
-      @firmware_api = IntersightClient::FirmwareApi.new
+      @firmware_api ||= IntersightClient::FirmwareApi.new
     end
 
     def compute_api
-      @compute_api = IntersightClient::ComputeApi.new
+      @compute_api ||= IntersightClient::ComputeApi.new
     end
 
     def equipment_api
-      @equipment_api = IntersightClient::EquipmentApi.new
+      @equipment_api ||= IntersightClient::EquipmentApi.new
     end
 
     def asset_api
-      @asset_api = IntersightClient::AssetApi.new
+      @asset_api ||= IntersightClient::AssetApi.new
     end
 
     def adapter_api
-      @adapter_api = IntersightClient::AdapterApi.new
+      @adapter_api ||= IntersightClient::AdapterApi.new
     end
 
     def management_api
-      @management_api = IntersightClient::ManagementApi.new
+      @management_api ||= IntersightClient::ManagementApi.new
     end
 
     def storage_api
-      @storage_api = IntersightClient::StorageApi.new
+      @storage_api ||= IntersightClient::StorageApi.new
     end
 
     def network_api
-      @network_api = IntersightClient::NetworkApi.new
+      @network_api ||= IntersightClient::NetworkApi.new
     end
 
     def port_api
-      @port_api = IntersightClient::PortApi.new
+      @port_api ||= IntersightClient::PortApi.new
     end
 
     def ether_api
-      @ether_api = IntersightClient::EtherApi.new
+      @ether_api ||= IntersightClient::EtherApi.new
     end
 
     # API key and keyid configuration

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -3,7 +3,6 @@ module ManageIQ::Providers::CiscoIntersight
 
     def parse
       physical_servers
-      physical_server_firmwares
       physical_racks
       physical_chassis
       physical_switches
@@ -45,17 +44,13 @@ module ManageIQ::Providers::CiscoIntersight
           # build collection physical_server_storage_adapters
           build_physical_server_storage_adapters(hardware, storage_controller_reference)
         end
-      end
-    end
 
-    def physical_server_firmwares
-      collector.firmware_inventory.each do |firmware_summary|
-        firmware_summary.components_fw_inventory.each do |component_fw_inventory|
-          server = persister.physical_servers.lazy_find(firmware_summary.server.moid)
-          computer = persister.physical_server_computer_systems.lazy_find(server)
-          physical_server_hardware = persister.physical_server_hardwares.lazy_find(computer)
+        firmware_firmware_summary = collector.get_firmware_firmware_summary_from_server_moid(server.moid)
+        next unless firmware_firmware_summary
+
+        firmware_firmware_summary.components_fw_inventory.each do |component_fw_inventory|
           # build collection physical_server_firmwares
-          build_physical_server_firmwares(physical_server_hardware, component_fw_inventory)
+          build_physical_server_firmwares(hardware, component_fw_inventory)
         end
       end
     end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -357,12 +357,13 @@ module ManageIQ::Providers::CiscoIntersight
             physical_port = collector.get_ether_physical_port_by_moid(physical_port_reference.moid)
             physical_switch = persister.physical_switches.lazy_find(network_element.moid)
             persister.physical_switch_network_ports.build(
-              :physical_switch => physical_switch,
-              :uid_ems         => physical_port.moid,
-              :port_name       => physical_port.dn,
-              :port_type       => "ethernet",
-              :mac_address     => physical_port.mac_address,
-              :port_index      => physical_port.port_id
+              :physical_switch    => physical_switch,
+              :uid_ems            => physical_port.moid,
+              :port_name          => physical_port.dn,
+              :port_type          => "ethernet",
+              :mac_address        => physical_port.mac_address,
+              :port_index         => physical_port.port_id,
+              :connected_port_uid => physical_port.moid,
             )
           end
         end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -3,239 +3,378 @@ module ManageIQ::Providers::CiscoIntersight
 
     def parse
       physical_servers
-      physical_server_details
-      # physical_racks This function isn't ready yet.
-      server_hardware
-      firmwares
+      physical_server_firmwares
+      physical_racks
       physical_chassis
-      physical_chassis_details
       physical_switches
-      physical_switch_details
-      switch_hardware
-      physical_switch_network_ports
     end
+
+    # Methods that are executed during refresh call
 
     def physical_servers
-      collector.physical_servers.each do |s|
-        registered_device_moid = get_registered_device_moid(s)
-        device_registration = collector.get_asset_device_registration_by_moid(registered_device_moid)
+      # Parses physical servers and its details
+      collector.physical_servers.each do |server|
+        # Obtain data about chassis and racks if they're wired to the server
         # Setting value of chassis and rack to nil for now
-        chassis = nil # TODO: After chassis gets written into the DB, obtain it and write it here as reference using lazy find.
-        rack = nil # TODO: After chassis gets written into the DB, obtain it and write it here as reference using lazy find.
-        server = persister.physical_servers.build(
-          :ems_ref          => s.moid,
-          :health_state     => get_health_state(s), # health_state obtained through atribute s.alarm_summary
-          :hostname         => device_registration.device_hostname[0], # I assume one registered device manages one (and only one) compute element
-          :name             => s.name,
-          :physical_chassis => chassis, # nil for now
-          :physical_rack    => rack, # nil for now
-          :power_state      => s.admin_power_state,
-          :raw_power_state  => s.admin_power_state,
-          :manufacturer     => s.vendor,
-          :type             => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServer"
-        )
-        persister.physical_server_computer_systems.build(
-          :managed_entity => server
-        )
-      end
-    end
+        physical_chassis = nil # TODO: After chassis gets written into the DB, obtain it and write it here as reference using lazy find.
+        physical_rack = nil # TODO: After chassis gets written into the DB, obtain it and write it here as reference using lazy find.
+        # build collection physical_servers
+        physical_server = build_physical_servers(server, physical_rack, physical_chassis)
+        # build collection physical_server_details
+        build_physical_server_details(physical_server, server)
+        # build collection physical_server_computer_systems
+        physical_server_computer_system = build_physical_server_computer_systems(physical_server)
 
-    def physical_server_details
-      collector.physical_servers.each do |s|
-        registered_device_moid = get_registered_device_moid(s)
-        server = persister.physical_servers.lazy_find(s.moid)
-        source_object = collector.get_source_object_from_physical_server(s)
-        device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
-        persister.physical_server_details.build(
-          :description        => get_product_description(device_contract_information_unit),
-          :location           => format_location(device_contract_information_unit),
-          :location_led_state => get_locator_led_state(source_object),
-          :machine_type       => get_machine_type(device_contract_information_unit),
-          :model              => s.model,
-          :product_name       => get_product_name(device_contract_information_unit),
-          :resource           => server,
-          :room               => s.slot_id,
-          :serial_number      => s.serial
-        )
-      end
-    end
-
-    def physical_switches
-      collector.network_elements.each do |network_element|
-        persister.physical_switches.build(
-          :name         => network_element.dn,
-          :uid_ems      => network_element.moid,
-          :switch_uuid  => network_element.moid,
-          :health_state => get_health_state(network_element),
-          :type         => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitch"
-        )
-      end
-    end
-
-    def physical_switch_details
-      collector.network_elements.each do |network_element|
-        registered_device_moid = get_registered_device_moid(network_element)
-        switch = persister.physical_switches.lazy_find(network_element.moid)
-        device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
-        persister.physical_switch_details.build(
-          :description   => get_product_description(device_contract_information_unit),
-          :location      => format_location(device_contract_information_unit),
-          :resource      => switch,
-          :product_name  => get_product_name(device_contract_information_unit),
-          :serial_number => network_element.serial,
-          :manufacturer  => network_element.vendor,
-          :model         => network_element.model,
-          :machine_type  => get_machine_type(device_contract_information_unit)
-        )
-      end
-    end
-
-    def server_hardware
-      collector.physical_servers.each do |s|
-        server = persister.physical_servers.lazy_find(s.moid)
-        computer = persister.physical_server_computer_systems.lazy_find(server)
-        source_object = collector.get_source_object_from_physical_server(s)
+        # Since Intersight's source object is only consolidated view of either object ComputePhysicalSummary of ComputeRackUnit,
+        # source object has to be obtained. I store it onto source_object
+        source_object = collector.get_source_object_from_physical_server(server)
         board_unit = collector.get_compute_board_by_moid(source_object.board.moid)
+        # storage_controllers_list is only a list of references to the storage controllers, but not list of intersight's
+        # storage controllers itself
         storage_controllers_list = board_unit.storage_controllers
-        hardware = persister.physical_server_hardwares.build(
-          :computer_system => computer,
-          :cpu_total_cores => s.num_cpu_cores,
-          :memory_mb       => s.available_memory,
-          :cpu_speed       => s.cpu_capacity
-        )
+        # build collection physical_server_hardwares
+        hardware = build_physical_server_hardwares(physical_server_computer_system, server)
 
         source_object.adapters.each do |adapter|
           adapter_unit = collector.get_adapter_unit_by_moid(adapter.moid)
-          persister.physical_server_network_devices.build(
-            :hardware     => hardware,
-            :device_name  => adapter_unit.adapter_id,
-            :device_type  => "ethernet",
-            :manufacturer => adapter_unit.vendor,
-            :model        => adapter_unit.model,
-            :uid_ems      => adapter_unit.moid
-          )
-
+          # build collection physical_server_network_devices
+          build_physical_server_network_devices(hardware, adapter_unit)
         end
 
         storage_controllers_list.each do |storage_controller_reference|
-          persister.physical_server_storage_adapters.build(
-            :hardware    => hardware,
-            :device_name => s.name,
-            :device_type => "storage",
-            :uid_ems     => storage_controller_reference.moid
-          )
+          # build collection physical_server_storage_adapters
+          build_physical_server_storage_adapters(hardware, storage_controller_reference)
         end
       end
     end
 
-    def switch_hardware
-      collector.network_elements.each do |network_element|
-        physical_switch = persister.physical_switches.lazy_find(network_element.moid)
-        hardware = persister.physical_switch_hardwares.build(
-          :physical_switch => physical_switch,
-          :memory_mb       => network_element.available_memory
-        )
-
-        persister.physical_switch_networks.build(
-          :hardware        => hardware,
-          :ipaddress       => network_element.out_of_band_ip_address,
-          :subnet_mask     => network_element.out_of_band_ip_mask,
-          :ipv6address     => network_element.out_of_band_ipv6_address,
-          :default_gateway => network_element.out_of_band_ip_gateway
-        )
-
-        ucsm_running_firmware = get_ucsm_running_firmware(network_element)
-
-        next unless ucsm_running_firmware
-
-        persister.physical_switch_firmwares.build(
-          :resource     => hardware,
-          :build        => ucsm_running_firmware.package_version,
-          :name         => ucsm_running_firmware.dn,
-          :version      => ucsm_running_firmware.version,
-          :release_date => ucsm_running_firmware.create_time
-        )
-
+    def physical_server_firmwares
+      collector.firmware_inventory.each do |firmware_summary|
+        firmware_summary.components_fw_inventory.each do |component_fw_inventory|
+          server = persister.physical_servers.lazy_find(firmware_summary.server.moid)
+          computer = persister.physical_server_computer_systems.lazy_find(server)
+          physical_server_hardware = persister.physical_server_hardwares.lazy_find(computer)
+          # build collection physical_server_firmwares
+          build_physical_server_firmwares(physical_server_hardware, component_fw_inventory)
+        end
       end
     end
 
     def physical_racks
       collector.physical_racks.each do |r|
-        # No data about the physical_racks yet, so I cannot parse the data about it.
-        persister.physical_racks.build(
-          :ems_ref => r.registered_device.moid,
-          :name    => ""
-        )
-      end
-    end
-
-    def firmwares
-      collector.firmware_inventory.each do |firmware_summary|
-        firmware_summary.components_fw_inventory.each do |component_fw_inventory|
-          server = persister.physical_servers.lazy_find(firmware_summary.server.moid)
-          computer = persister.physical_server_computer_systems.lazy_find(server)
-          hardware = persister.physical_server_hardwares.lazy_find(computer)
-          persister.physical_server_firmwares.build(
-            :resource => hardware,
-            :build    => component_fw_inventory.label,
-            :name     => component_fw_inventory.label,
-            :version  => component_fw_inventory.version
-          )
-        end
+        # No data about the physical_racks yet, so I cannot parse the data about it (explained inside function below).
+        build_physical_racks(r)
       end
     end
 
     def physical_chassis
       collector.physical_chassis.each do |c|
-        persister.physical_chassis.build(
-          :ems_ref      => c.moid,
-          :health_state => get_health_state(c),
-          :name         => c.name
-        )
+        # build collection physical_chassis
+        build_physical_chassis(c)
+        # build collection physical_chassis_details
+        build_physical_chassis_details(c)
       end
     end
 
-    def physical_chassis_details
-      collector.physical_chassis.each do |c|
-        registered_device_moid = get_registered_device_moid(c)
-        device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
-        chassis = persister.physical_chassis.lazy_find(c.moid)
-        persister.physical_chassis_details.build(
-          :description        => get_product_description(device_contract_information_unit),
-          :location           => format_location(device_contract_information_unit),
-          :location_led_state => get_locator_led_state(c),
-          :model              => c.model,
-          :part_number        => c.part_number,
-          :resource           => chassis,
-          :serial_number      => c.serial,
-          :product_name       => get_product_name(device_contract_information_unit),
-          :machine_type       => get_machine_type(device_contract_information_unit)
-        )
-      end
-    end
-
-    def physical_switch_network_ports
+    def physical_switches
       collector.network_elements.each do |network_element|
-        network_element.cards.each do |switch_card_reference|
-          switch_card = collector.get_equipment_switch_card_by_moid(switch_card_reference.moid)
-          switch_card.port_groups.each do |port_group_reference|
-            port_group = collector.get_port_group_by_moid(port_group_reference.moid)
-            port_group.ethernet_ports.each do |physical_port_reference|
-              physical_port = collector.get_ether_physical_port_by_moid(physical_port_reference.moid)
-              physical_switch = persister.physical_switches.lazy_find(network_element.moid)
-              persister.physical_switch_network_ports.build(
-                :physical_switch => physical_switch,
-                :uid_ems         => physical_port.moid,
-                :port_name       => physical_port.dn,
-                :port_type       => "ethernet",
-                :mac_address     => physical_port.mac_address,
-                :port_index      => physical_port.port_id
-              )
-            end
+        # build collection physical_switches
+        build_physical_switches(network_element)
+        # build collection physical_switch_details
+        build_physical_switch_details(network_element)
+        # build collection physical_switch_hardwares
+        hardware = build_physical_switch_hardwares(network_element)
+        # build collection physical_switch_networks
+        build_physical_switch_networks(hardware, network_element)
+        # build collection physical_switch_network_ports
+        # Note that for every networking element (fabric interconnect) there may be (and probably are) multiple network ports.
+        build_physical_switch_network_ports(network_element)
+        # If there's data about the running firmware, build collection build_physical_switch_firmwares
+        ucsm_running_firmware = get_ucsm_running_firmware(network_element)
+        next unless ucsm_running_firmware
+
+        build_physical_switch_firmwares(hardware, ucsm_running_firmware)
+      end
+    end
+
+    private
+
+    # Methods that directly build out inventory collections
+
+    def build_physical_chassis(chassis)
+      # Builds out collection physical_chassis
+      # Object types:
+      #   - chassis - EquipmentChassis, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalChassis
+      persister.physical_chassis.build(
+        :ems_ref      => chassis.moid,
+        :health_state => get_health_state(chassis),
+        :name         => chassis.name
+      )
+    end
+
+    def build_physical_chassis_details(chassis)
+      # Builds out collection physical_chassis
+      # Object types:
+      #   - chassis - EquipmentChassis, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssetDetails
+      physical_chassis = persister.physical_chassis.lazy_find(chassis.moid)
+      registered_device_moid = get_registered_device_moid(chassis)
+      device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
+      persister.physical_chassis_details.build(
+        :description        => get_product_description(device_contract_information_unit),
+        :location           => format_location(device_contract_information_unit),
+        :location_led_state => get_locator_led_state(chassis),
+        :model              => chassis.model,
+        :part_number        => chassis.part_number,
+        :resource           => physical_chassis,
+        :serial_number      => chassis.serial,
+        :product_name       => get_product_name(device_contract_information_unit),
+        :machine_type       => get_machine_type(device_contract_information_unit)
+      )
+    end
+
+    def build_physical_racks(rack)
+      # Was not able to test it yet due to not having physical racks written on the intersight side with the current lab rights
+      # TODO: Find out which API call should be used here (after racks are viewable on the API viewer).
+      # Builds out collection physical_racks
+      # Object types:
+      #   - rack - <I don't know yet>, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalChassis
+
+      persister.physical_racks.build(
+        :ems_ref => rack.moid,
+        :name    => ""
+      )
+    end
+
+    def build_physical_servers(server, physical_rack, physical_chassis)
+      # Builds out collection physical_servers
+      # Object types:
+      #   - server - ComputePhysicalSummary, object obtained by intersight client
+      #   - physical_rack - ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalRacks
+      #   - physical_chassis - ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalChassis
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServers
+      registered_device_moid = get_registered_device_moid(server)
+      device_registration = collector.get_asset_device_registration_by_moid(registered_device_moid)
+      persister.physical_servers.build(
+        :ems_ref          => server.moid,
+        :health_state     => get_health_state(server), # health_state obtained through atribute s.alarm_summary
+        :hostname         => device_registration.device_hostname[0], # I assume one registered device manages one (and only one) compute element
+        :name             => server.name,
+        :physical_chassis => physical_chassis, # nil for now
+        :physical_rack    => physical_rack, # nil for now
+        :power_state      => server.admin_power_state,
+        :raw_power_state  => server.admin_power_state,
+        :manufacturer     => server.vendor,
+        :type             => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServer"
+      )
+    end
+
+    def build_physical_server_details(physical_server, server)
+      # Builds out collection physical_server_details
+      # Object types:
+      #   - physical_server - ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServers
+      #   - server - ComputePhysicalSummary, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssetDetails
+      registered_device_moid = get_registered_device_moid(server)
+      source_object = collector.get_source_object_from_physical_server(server)
+      device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
+      persister.physical_server_details.build(
+        :description        => get_product_description(device_contract_information_unit),
+        :location           => format_location(device_contract_information_unit),
+        :location_led_state => get_locator_led_state(source_object),
+        :machine_type       => get_machine_type(device_contract_information_unit),
+        :model              => server.model,
+        :product_name       => get_product_name(device_contract_information_unit),
+        :resource           => physical_server,
+        :room               => server.slot_id,
+        :serial_number      => server.serial
+      )
+    end
+
+    def build_physical_server_computer_systems(physical_server)
+      # Builds out collection physical_server_computer_systems
+      # Object types:
+      #   - physical_server - ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServers
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServerComputerSystems
+      persister.physical_server_computer_systems.build(
+        :managed_entity => physical_server
+      )
+    end
+
+    def build_physical_server_hardwares(computer_system, server)
+      # Builds out collection physical_server_hardwares
+      # Object types:
+      #   - computer_system - ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServerComputerSystems
+      #   - server - ComputePhysicalSummary, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServerHardwares
+      persister.physical_server_hardwares.build(
+        :computer_system => computer_system,
+        :cpu_total_cores => server.num_cpu_cores,
+        :memory_mb       => server.available_memory,
+        :cpu_speed       => server.cpu_capacity
+      )
+    end
+
+    def build_physical_server_network_devices(physical_server_hardware, adapter_unit)
+      # Builds out collection physical_server_network_devices
+      # Object types:
+      #   - computer_system - ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServerHardwares
+      #   - adapter_unit - AdapterUnit, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServerNetworkDevices
+      persister.physical_server_network_devices.build(
+        :hardware     => physical_server_hardware,
+        :device_name  => adapter_unit.adapter_id,
+        :device_type  => "ethernet",
+        :manufacturer => adapter_unit.vendor,
+        :model        => adapter_unit.model,
+        :uid_ems      => adapter_unit.moid
+      )
+    end
+
+    def build_physical_server_storage_adapters(physical_server_hardware, storage_controller_ref)
+      # TODO: replace controller refererence with an actual one.
+      # Builds out collection physical_server_storage_adapters
+      # Object types:
+      #   - physical_server_hardware - ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServerHardwares
+      #   - storage_controller - StorageController, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServerNetworkDevices
+      persister.physical_server_storage_adapters.build(
+        :hardware    => physical_server_hardware,
+        # :device_name => s.name, TODO: Find the device name of the storage adapter
+        :device_type => "storage",
+        :uid_ems     => storage_controller_ref.moid
+      )
+    end
+
+    def build_physical_server_firmwares(physical_server_hardware, component_fw_inventory)
+      # Builds out collection physical_server_firmwares
+      # Object types:
+      #   - physical_server_hardware - ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServerHardwares
+      #   - component_fw_inventory - FirmwareFirmwareSummary, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServerFirmwares
+      persister.physical_server_firmwares.build(
+        :resource => physical_server_hardware,
+        :build    => component_fw_inventory.label,
+        :name     => component_fw_inventory.label,
+        :version  => component_fw_inventory.version
+      )
+    end
+
+    def build_physical_switches(network_element)
+      # Builds out collection physical_switches
+      # Object types:
+      #   - network_element - NetworkElements, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitches
+      persister.physical_switches.build(
+        :name         => network_element.dn,
+        :uid_ems      => network_element.moid,
+        :switch_uuid  => network_element.moid,
+        :health_state => get_health_state(network_element),
+        :type         => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitch"
+      )
+    end
+
+    def build_physical_switch_details(network_element)
+      # Builds out collection physical_switches
+      # Object types:
+      #   - network_element - NetworkElements, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssetDetails
+      registered_device_moid = get_registered_device_moid(network_element)
+      switch = persister.physical_switches.lazy_find(network_element.moid)
+      device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
+      persister.physical_switch_details.build(
+        :description   => get_product_description(device_contract_information_unit),
+        :location      => format_location(device_contract_information_unit),
+        :resource      => switch,
+        :product_name  => get_product_name(device_contract_information_unit),
+        :serial_number => network_element.serial,
+        :manufacturer  => network_element.vendor,
+        :model         => network_element.model,
+        :machine_type  => get_machine_type(device_contract_information_unit)
+      )
+    end
+
+    def build_physical_switch_hardwares(network_element)
+      # Builds out collection physical_switches
+      # Object types:
+      #   - network_element - NetworkElements, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitchHardwares
+      physical_switch = persister.physical_switches.lazy_find(network_element.moid)
+      persister.physical_switch_hardwares.build(
+        :physical_switch => physical_switch,
+        :memory_mb       => network_element.available_memory
+      )
+    end
+
+    def build_physical_switch_networks(physical_switch_hardware, network_element)
+      # Builds out collection physical_switches
+      # Object types:
+      #   - network_element - NetworkElements, object obtained by intersight client
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitchNetworks
+      persister.physical_switch_networks.build(
+        :hardware        => physical_switch_hardware,
+        :ipaddress       => network_element.out_of_band_ip_address,
+        :subnet_mask     => network_element.out_of_band_ip_mask,
+        :ipv6address     => network_element.out_of_band_ipv6_address,
+        :default_gateway => network_element.out_of_band_ip_gateway
+      )
+    end
+
+    def build_physical_switch_firmwares(physical_switch_hardware, firmware_running_firmware)
+      # Builds out collection physical_switch_firmwares
+      # Object types:
+      #   - firmware_running_firmware - FirmwareRunningFirmware, object obtained by intersight client
+      #   - physical_switch_hardware - ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitchHardwares
+      # Returns:
+      #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitchFirmwares
+      persister.physical_switch_firmwares.build(
+        :resource     => physical_switch_hardware,
+        :build        => firmware_running_firmware.package_version,
+        :name         => firmware_running_firmware.dn,
+        :version      => firmware_running_firmware.version,
+        :release_date => firmware_running_firmware.create_time
+      )
+    end
+
+    def build_physical_switch_network_ports(network_element)
+      # Parses and stores all physical switch network ports for the specific networking element (Fabric interconnect)
+      network_element.cards.each do |switch_card_reference|
+        switch_card = collector.get_equipment_switch_card_by_moid(switch_card_reference.moid)
+        switch_card.port_groups.each do |port_group_reference|
+          port_group = collector.get_port_group_by_moid(port_group_reference.moid)
+          port_group.ethernet_ports.each do |physical_port_reference|
+            physical_port = collector.get_ether_physical_port_by_moid(physical_port_reference.moid)
+            physical_switch = persister.physical_switches.lazy_find(network_element.moid)
+            persister.physical_switch_network_ports.build(
+              :physical_switch => physical_switch,
+              :uid_ems         => physical_port.moid,
+              :port_name       => physical_port.dn,
+              :port_type       => "ethernet",
+              :mac_address     => physical_port.mac_address,
+              :port_index      => physical_port.port_id
+            )
           end
         end
       end
     end
+
+    # Helper methods to the ones that directly build inventory collections
 
     def get_health_state(object)
       alarm_summary = object.alarm_summary

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -5,10 +5,14 @@ module ManageIQ::Providers::CiscoIntersight
       physical_servers
       physical_server_details
       physical_racks
-      hardwares
+      server_hardware
       firmwares
       physical_chassis
       physical_chassis_details
+      physical_switches
+      physical_switch_details
+      switch_hardware
+      physical_switch_network_ports
     end
 
     def physical_servers
@@ -25,9 +29,10 @@ module ManageIQ::Providers::CiscoIntersight
           :name             => s.name,
           :physical_chassis => chassis, # nil for now
           :physical_rack    => rack, # nil for now
-          :power_state      => s.oper_power_state,
-          :raw_power_state  => s.oper_power_state,
-          :type => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServer",
+          :power_state      => s.admin_power_state,
+          :raw_power_state  => s.admin_power_state,
+          :manufacturer     => s.vendor,
+          :type             => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServer"
         )
         persister.physical_server_computer_systems.build(
           :managed_entity => server
@@ -42,45 +47,74 @@ module ManageIQ::Providers::CiscoIntersight
         source_object = collector.get_source_object_from_physical_server(s)
         device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
         persister.physical_server_details.build(
-          :description        => device_contract_information_unit.product.description,
+          :description        => get_product_description(device_contract_information_unit),
           :location           => format_location(device_contract_information_unit),
           :location_led_state => get_locator_led_state(source_object),
-          :machine_type       => device_contract_information_unit.device_type,
+          :machine_type       => get_machine_type(device_contract_information_unit),
           :model              => s.model,
-          :product_name       => s.name,
+          :product_name       => get_product_name(device_contract_information_unit),
           :resource           => server,
           :room               => s.slot_id,
-          :serial_number      => s.serial,
+          :serial_number      => s.serial
         )
       end
     end
 
-    def hardwares
+    def physical_switches
+      collector.network_elements.each do |network_element|
+        persister.physical_switches.build(
+          :name         => network_element.dn,
+          :uid_ems      => network_element.moid,
+          :switch_uuid  => network_element.moid,
+          :health_state => get_health_state(network_element),
+          :type         => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitch"
+        )
+      end
+    end
+
+    def physical_switch_details
+      collector.network_elements.each do |network_element|
+        registered_device_moid = get_registered_device_moid(network_element)
+        switch = persister.physical_switches.lazy_find(network_element.moid)
+        device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
+        persister.physical_switch_details.build(
+          :description   => get_product_description(device_contract_information_unit),
+          :location      => format_location(device_contract_information_unit),
+          :resource      => switch,
+          :product_name  => get_product_name(device_contract_information_unit),
+          :serial_number => network_element.serial,
+          :manufacturer  => network_element.vendor,
+          :model         => network_element.model,
+          :machine_type  => get_machine_type(device_contract_information_unit)
+        )
+      end
+    end
+
+    def server_hardware
       collector.physical_servers.each do |s|
         server = persister.physical_servers.lazy_find(s.moid)
         computer = persister.physical_server_computer_systems.lazy_find(server)
         source_object = collector.get_source_object_from_physical_server(s)
         board_unit = collector.get_compute_board_by_moid(source_object.board.moid)
         storage_controllers_list = board_unit.storage_controllers
-        # disk_capacity and disk_free_space aren't finished yet. Setting their value to -1
         hardware = persister.physical_server_hardwares.build(
           :computer_system => computer,
           :cpu_total_cores => s.num_cpu_cores,
           :memory_mb       => s.available_memory,
-          :cpu_speed       => s.cpu_capacity,
+          :cpu_speed       => s.cpu_capacity
         )
 
         source_object.adapters.each do |adapter|
           adapter_unit = collector.get_adapter_unit_by_moid(adapter.moid)
-          management_controller_unit = collector.get_management_controller_by_moid(adapter_unit.controller.moid)
           persister.physical_server_network_devices.build(
             :hardware     => hardware,
-            :device_name  => s.name,
+            :device_name  => adapter_unit.adapter_id,
             :device_type  => "ethernet",
-            :manufacturer => get_manufacturer_from_management_controller(management_controller_unit),
-            :model        => management_controller_unit.model,
+            :manufacturer => adapter_unit.vendor,
+            :model        => adapter_unit.model,
             :uid_ems      => adapter_unit.moid
           )
+
         end
 
         storage_controllers_list.each do |storage_controller_reference|
@@ -91,6 +125,37 @@ module ManageIQ::Providers::CiscoIntersight
             :uid_ems     => storage_controller_reference.moid
           )
         end
+      end
+    end
+
+    def switch_hardware
+      collector.network_elements.each do |network_element|
+        physical_switch = persister.physical_switches.lazy_find(network_element.moid)
+        hardware = persister.physical_switch_hardwares.build(
+          :physical_switch => physical_switch,
+          :memory_mb       => network_element.available_memory
+        )
+
+        persister.physical_switch_networks.build(
+          :hardware        => hardware,
+          :ipaddress       => network_element.out_of_band_ip_address,
+          :subnet_mask     => network_element.out_of_band_ip_mask,
+          :ipv6address     => network_element.out_of_band_ipv6_address,
+          :default_gateway => network_element.out_of_band_ip_gateway
+        )
+
+        ucsm_running_firmware = get_ucsm_running_firmware(network_element)
+
+        next unless ucsm_running_firmware
+
+        persister.physical_switch_firmwares.build(
+          :resource     => hardware,
+          :build        => ucsm_running_firmware.package_version,
+          :name         => ucsm_running_firmware.dn,
+          :version      => ucsm_running_firmware.version,
+          :release_date => ucsm_running_firmware.create_time
+        )
+
       end
     end
 
@@ -136,40 +201,51 @@ module ManageIQ::Providers::CiscoIntersight
         device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
         chassis = persister.physical_chassis.lazy_find(c.moid)
         persister.physical_chassis_details.build(
-          :description        => device_contract_information_unit.product.description,
+          :description        => get_product_description(device_contract_information_unit),
           :location           => format_location(device_contract_information_unit),
           :location_led_state => get_locator_led_state(c),
           :model              => c.model,
           :part_number        => c.part_number,
           :resource           => chassis,
-          :serial_number      => c.serial
+          :serial_number      => c.serial,
+          :product_name       => get_product_name(device_contract_information_unit),
+          :machine_type       => get_machine_type(device_contract_information_unit)
         )
       end
     end
 
+    def physical_switch_network_ports
+      collector.network_elements.each do |network_element|
+        network_element.cards.each do |switch_card_reference|
+          switch_card = collector.get_equipment_switch_card_by_moid(switch_card_reference.moid)
+          switch_card.port_groups.each do |port_group_reference|
+            port_group = collector.get_port_group_by_moid(port_group_reference.moid)
+            port_group.ethernet_ports.each do |physical_port_reference|
+              physical_port = collector.get_ether_physical_port_by_moid(physical_port_reference.moid)
+              physical_switch = persister.physical_switches.lazy_find(network_element.moid)
+              persister.physical_switch_network_ports.build(
+                :physical_switch => physical_switch,
+                :uid_ems         => physical_port.moid,
+                :port_name       => physical_port.dn,
+                :port_type       => "ethernet",
+                :mac_address     => physical_port.mac_address,
+                :port_index      => physical_port.port_id
+              )
+            end
+          end
+        end
+      end
+    end
 
     def get_health_state(object)
       alarm_summary = object.alarm_summary
       if alarm_summary.critical > 0
-        health = "Critical"
+        "Critical"
       elsif alarm_summary.warning > 0
-        health = "Warning"
+        "Warning"
       else
-        health = "Valid"
+        "Valid"
       end
-      health
-    end
-
-    def get_manufacturer_from_management_controller(management_controller_unit)
-      model = management_controller_unit.model
-      if (model.include? "Cisco") or (model.include? "cisco")
-        manufacturer = "Cisco"
-      elsif (model.include? "Intel") or (model.include? "intel")
-        manufacturer = "Intel"
-      else
-        manufacturer = "unknown"
-      end
-      manufacturer
     end
 
     def get_registered_device_moid(intersight_api_object)
@@ -177,26 +253,53 @@ module ManageIQ::Providers::CiscoIntersight
     end
 
     def format_location(device_contract_information_object)
-      shipping_info = device_contract_information_object.product.ship_to
+      address = device_contract_information_object.end_customer.address
+      # Regex gsub(/\s+/, ' ') replaces multiple spaces with one. This happens if one of the elements
+      # in the array is equal to empty string.
       [
-        shipping_info.name,
-        shipping_info.address1,
-        shipping_info.postal_code,
-        shipping_info.postal_code,
-        shipping_info.city,
-        shipping_info.country
-      ].join(", ")
+        address.address1,
+        address.address2,
+        address.address3,
+        address.city,
+        address.country,
+        address.county,
+        address.location,
+        address.name,
+        address.postal_code,
+        address.province,
+        address.state
+      ].join(" ").gsub(/\s+/, ' ')
+    end
+
+    def get_ucsm_running_firmware(network_element)
+      # Helper method to method switch_hardwares
+      # network_element is Intersight's object of class NetworkElement. Depending whether firmware is null or not,
+      # returns object of class FirmwareRunningFirmware.
+      if network_element.ucsm_running_firmware
+        collector.get_firmware_running_firmware_by_moid(network_element.ucsm_running_firmware.moid)
+      end
     end
 
     def get_locator_led_state(object)
       # object represents either ComputeBlade or EquipmentChassis type objects, that are given as response from the client
       if object.locator_led
         collector.get_equipment_locator_led_by_moid(object.locator_led.moid).oper_state
-      else
-        nil
       end
     end
 
+    def get_product_name(device_contract_information_unit)
+      # Helper function :AssetDetails type of collections (functions with name ..._details)
+      device_contract_information_unit.product.bill_to.name
+    end
 
+    def get_product_description(device_contract_information_unit)
+      # Helper function :AssetDetails type of collections (functions with name ..._details)
+      device_contract_information_unit.product.description
+    end
+
+    def get_machine_type(device_contract_information_unit)
+      # Helper function :AssetDetails type of collections (functions with name ..._details)
+      device_contract_information_unit.device_type
+    end
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -4,7 +4,7 @@ module ManageIQ::Providers::CiscoIntersight
     def parse
       physical_servers
       physical_server_details
-      physical_racks
+      # physical_racks This function isn't ready yet.
       server_hardware
       firmwares
       physical_chassis

--- a/app/models/manageiq/providers/cisco_intersight/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/persister/definitions/physical_infra_collections.rb
@@ -21,11 +21,8 @@ module ManageIQ::Providers::CiscoIntersight::Inventory::Persister::Definitions::
       add_collection(physical_infra, name)
 
       add_physical_network_ports
-
       add_physical_server_networks
-
       add_physical_switch_networks
-
       add_physical_server_management_devices
     end
   end
@@ -53,10 +50,9 @@ module ManageIQ::Providers::CiscoIntersight::Inventory::Persister::Definitions::
   def add_physical_server_management_devices
     add_collection(physical_infra, :physical_server_management_devices) do |builder|
       builder.add_properties(
-        :model_class                  => ::Network,
-        :manager_ref                  => %i[guest_device ipaddress ipv6address],
-        :manager_ref_allowed_nil      => %i[ipaddress ipv6address],
-        :parent_inventory_collections => [:physical_server]
+        :model_class                  => ::GuestDevice,
+        :manager_ref                  => %i[device_type hardware],
+        :parent_inventory_collections => %i[physical_servers]
       )
     end
   end
@@ -67,7 +63,7 @@ module ManageIQ::Providers::CiscoIntersight::Inventory::Persister::Definitions::
         :model_class                  => ::Network,
         :manager_ref                  => %i[guest_device ipaddress ipv6address],
         :manager_ref_allowed_nil      => %i[ipaddress ipv6address],
-        :parent_inventory_collections => %i[physical_server]
+        :parent_inventory_collections => %i[physical_server_management_devices]
       )
     end
   end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/persister/definitions/physical_infra_collections.rb
@@ -25,6 +25,8 @@ module ManageIQ::Providers::CiscoIntersight::Inventory::Persister::Definitions::
       add_physical_server_networks
 
       add_physical_switch_networks
+
+      add_physical_server_management_devices
     end
   end
 
@@ -48,11 +50,22 @@ module ManageIQ::Providers::CiscoIntersight::Inventory::Persister::Definitions::
     end
   end
 
+  def add_physical_server_management_devices
+    add_collection(physical_infra, :physical_server_management_devices) do |builder|
+      builder.add_properties(
+        :model_class                  => ::Network,
+        :manager_ref                  => %i[guest_device ipaddress ipv6address],
+        :manager_ref_allowed_nil      => %i[ipaddress ipv6address],
+        :parent_inventory_collections => [:physical_server]
+      )
+    end
+  end
+
   def add_physical_server_networks
     add_collection(physical_infra, :physical_server_networks) do |builder|
       builder.add_properties(
         :model_class                  => ::Network,
-        :manager_ref                  => %i[guest_device ipaddress ipv6address], # changed from guest_devices to hardware
+        :manager_ref                  => %i[guest_device ipaddress ipv6address],
         :manager_ref_allowed_nil      => %i[ipaddress ipv6address],
         :parent_inventory_collections => %i[physical_server]
       )

--- a/app/models/manageiq/providers/cisco_intersight/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/persister/definitions/physical_infra_collections.rb
@@ -2,21 +2,71 @@ module ManageIQ::Providers::CiscoIntersight::Inventory::Persister::Definitions::
   include ActiveSupport::Concern
 
   def initialize_physical_infra_collections
-    %i(
+    %i[
       physical_servers
       physical_server_details
       physical_server_computer_systems
       physical_racks
       physical_server_hardwares
       physical_server_network_devices
-      physical_server_firmwares      
+      physical_server_firmwares
       physical_server_storage_adapters
       physical_chassis
       physical_chassis_details
-    ).each do |name|
+      physical_switches
+      physical_switch_details
+      physical_switch_hardwares
+      physical_switch_firmwares
+    ].each do |name|
       add_collection(physical_infra, name)
 
+      add_physical_network_ports
+
+      add_physical_server_networks
+
+      add_physical_switch_networks
+    end
+  end
+
+  def add_physical_network_ports
+    %i[physical_server
+       physical_switch].each do |network_port_assoc|
+
+      add_collection(physical_infra, "#{network_port_assoc}_network_ports".to_sym) do |builder|
+        builder.add_properties(
+          :model_class                  => ::PhysicalNetworkPort,
+          :parent_inventory_collections => [network_port_assoc.to_s.pluralize.to_sym]
+        )
+
+        manager_ref = case network_port_assoc
+                      when :physical_server then %i[port_type uid_ems]
+                      when :physical_switch then %i[port_type port_name physical_switch]
+                      else []
+                      end
+        builder.add_properties(:manager_ref => manager_ref)
+      end
+    end
+  end
+
+  def add_physical_server_networks
+    add_collection(physical_infra, :physical_server_networks) do |builder|
+      builder.add_properties(
+        :model_class                  => ::Network,
+        :manager_ref                  => %i[guest_device ipaddress ipv6address], # changed from guest_devices to hardware
+        :manager_ref_allowed_nil      => %i[ipaddress ipv6address],
+        :parent_inventory_collections => %i[physical_server]
+      )
+    end
+  end
+
+  def add_physical_switch_networks
+    add_collection(physical_infra, :physical_switch_networks) do |builder|
+      builder.add_properties(
+        :model_class                  => ::Network,
+        :manager_ref                  => %i[hardware ipaddress ipv6address],
+        :manager_ref_allowed_nil      => %i[ipaddress ipv6address],
+        :parent_inventory_collections => %i[physical_switches]
+      )
     end
   end
 end
-

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_switch.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_switch.rb
@@ -1,0 +1,8 @@
+module ManageIQ::Providers::CiscoIntersight
+  class PhysicalInfraManager::PhysicalSwitch < ::PhysicalSwitch
+
+    def self.display_name(number = 1)
+      n_('Physical Switch (CiscoIntersight)', 'Physical Switches (CiscoIntersight)', number)
+    end
+  end
+end

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_switch_network_ports.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_switch_network_ports.rb
@@ -1,0 +1,8 @@
+module ManageIQ::Providers::CiscoIntersight
+  class PhysicalInfraManager::PhysicalSwitchNetworkPort < ::PhysicalSwitchNetworkPort
+
+    def self.display_name(number = 1)
+      n_('Physical Switch Network Port (CiscoIntersight)', 'Physical Switches Network Ports (CiscoIntersight)', number)
+    end
+  end
+end

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
@@ -37,201 +37,201 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
 
   def assert_ems
     # physical server's collections
-    expect(ems.physical_servers.count).to eq(4)
-    expect(ems.physical_server_details.count).to eq(4)
-    expect(ems.physical_server_computer_systems.count).to eq(4)
-    expect(ems.physical_server_hardwares.count).to eq(4)
-    expect(ems.physical_server_network_devices.count).to eq(4)
-    expect(ems.physical_server_firmwares.count).to eq(56)
-    expect(ems.physical_server_storage_adapters.count).to eq(7)
+    expect(ems.physical_servers.count).to(eq(4))
+    expect(ems.physical_server_details.count).to(eq(4))
+    expect(ems.physical_server_computer_systems.count).to(eq(4))
+    expect(ems.physical_server_hardwares.count).to(eq(4))
+    expect(ems.physical_server_network_devices.count).to(eq(4))
+    expect(ems.physical_server_firmwares.count).to(eq(56))
+    expect(ems.physical_server_storage_adapters.count).to(eq(5))
 
     # physical rack's collections
     # In our available lab, we have informations about racks yet.
-    expect(ems.physical_racks.count).to eq(0)
+    expect(ems.physical_racks.count).to(eq(0))
 
     # physical chassis' collections
-    expect(ems.physical_chassis.count).to eq(1)
-    expect(ems.physical_chassis_details.count).to eq(7)
+    expect(ems.physical_chassis.count).to(eq(1))
+    expect(ems.physical_chassis_details.count).to(eq(1))
 
     # physical switch's collections
-    expect(ems.physical_switches.count).to eq(2)
-    expect(ems.physical_switch_details.count).to eq(2)
-    expect(ems.physical_switch_hardwares.count).to eq(2)
-    expect(ems.physical_switch_firmwares.count).to eq(2)
+    expect(ems.physical_switches.count).to(eq(2))
+    expect(ems.physical_switch_details.count).to(eq(2))
+    expect(ems.physical_switch_hardwares.count).to(eq(2))
+    expect(ems.physical_switch_firmwares.count).to(eq(2))
 
-    expect(ems.physical_switch_network_ports.count).to eq(108)
-    expect(ems.physical_switch_networks.count).to eq(2)
+    expect(ems.physical_switch_network_ports.count).to(eq(108))
+    expect(ems.physical_switch_networks.count).to(eq(2))
 
   end
 
   # Asserting specific objects type of tests
 
   def assert_specific_physical_server
-    server_ems_ref = "614cec406176752d35abe2dc"
+    server_ems_ref = "614cec416176752d35abe368"
     server = get_physical_server_from_ems_ref(server_ems_ref)
 
-    expect(server).to have_attributes(
-      :ems_ref                => server_ems_ref,
-      :hostname               => "C1-B2-UCSX-210C-M6",
-      :type                   => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServer",
-      :product_name           => nil,
-      :manufacturer           => "Cisco Systems Inc",
-      :machine_type           => nil,
-      :model                  => nil,
-      :serial_number          => nil,
-      :field_replaceable_unit => nil,
-      :raw_power_state        => "",
-      :vendor                 => nil,
-      :health_state           => "Valid",
-      :power_state            => ""
-    )
+    expect(server).to(have_attributes(
+                        :ems_ref                => server_ems_ref,
+                        :hostname               => "C1-B4-UCSX-210C-M6",
+                        :type                   => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServer",
+                        :product_name           => nil,
+                        :manufacturer           => "Cisco Systems Inc",
+                        :machine_type           => nil,
+                        :model                  => nil,
+                        :serial_number          => nil,
+                        :field_replaceable_unit => nil,
+                        :raw_power_state        => "",
+                        :vendor                 => nil,
+                        :health_state           => "Valid",
+                        :power_state            => ""
+    ))
 
-    expect(server.ext_management_system).to eq(ems)
+    expect(server.ext_management_system).to(eq(ems))
   end
 
   def assert_specific_physical_server_details
-    server_ems_ref = "614cec406176752d35abe2dc"
+    server_ems_ref = "614cec416176752d35abe368"
     server = get_physical_server_from_ems_ref(server_ems_ref)
     asset_detail = AssetDetail.find_by!(:resource => server)
 
-    expect(asset_detail).to have_attributes(
-      :description => "UCS 210c M6 Compute Node w/o CPU,  Memory, Storage, Mezz",
-      :contact => nil,
-      :location => "3800 ZANKER ROAD SAN JOSE US 95134 CA",
-      :room => "2",
-      :rack_name => nil,
-      :lowest_rack_unit => nil,
-      :resource_type => "PhysicalServer",
-      :product_name => "CISCO SYSTEMS INC FOR US INTERNAL DEMO EVAL ONLY",
-      :machine_type => "CiscoUcsServer",
-      :model => "UCSX-210C-M6",
-      :serial_number => "FCH250671HR",
-      :field_replaceable_unit => nil,
-      :part_number => nil,
-      :location_led_ems_ref => nil,
-      :location_led_state => "off",
-    )
+    expect(asset_detail).to(have_attributes(
+                              :description            => "UCS 210c M6 Compute Node w/o CPU,  Memory, Storage, Mezz",
+                              :contact                => nil,
+                              :location               => "3800 ZANKER ROAD SAN JOSE US 95134 CA",
+                              :room                   => "4",
+                              :rack_name              => nil,
+                              :lowest_rack_unit       => nil,
+                              :resource_type          => "PhysicalServer",
+                              :product_name           => "CISCO SYSTEMS INC FOR US INTERNAL DEMO EVAL ONLY",
+                              :machine_type           => "CiscoUcsServer",
+                              :model                  => "UCSX-210C-M6",
+                              :serial_number          => "FCH250671QU",
+                              :field_replaceable_unit => nil,
+                              :part_number            => nil,
+                              :location_led_ems_ref   => nil,
+                              :location_led_state     => "off"
+    ))
   end
 
   def assert_specific_physical_server_hardwares
-    server_ems_ref = "614cec406176752d35abe2dc"
+    server_ems_ref = "614cec416176752d35abe368"
     server = get_physical_server_from_ems_ref(server_ems_ref)
     hardware = server.hardware
 
-    expect(hardware).to have_attributes(
-      :virtual_hw_version   => nil,
-      :config_version       => nil,
-      :guest_os             => nil,
-      :cpu_sockets          => 1,
-      :bios                 => nil,
-      :bios_location        => nil,
-      :time_sync            => nil,
-      :annotation           => nil,
-      :vm_or_template_id    => nil,
-      :memory_mb            => 512,
-      :host_id              => nil,
-      :cpu_speed            => 145,
-      :cpu_type             => nil,
-      :size_on_disk         => nil,
-      :manufacturer         => "",
-      :model                => "",
-      :number_of_nics       => nil,
-      :cpu_usage            => nil,
-      :memory_usage         => nil,
-      :cpu_cores_per_socket => nil,
-      :cpu_total_cores      => 56,
-      :vmotion_enabled      => nil,
-      :disk_free_space      => nil,
-      :disk_capacity        => nil,
-      :guest_os_full_name   => nil,
-      :memory_console       => nil,
-      :bitness              => nil,
-      :virtualization_type  => nil,
-      :root_device_type     => nil,
-      :disk_size_minimum    => nil,
-      :memory_mb_minimum    => nil,
-      :introspected         => nil,
-      :provision_state      => nil,
-      :serial_number        => nil,
-      :switch_id            => nil,
-      :firmware_type        => nil,
-      :canister_id          => nil
-    )
+    expect(hardware).to(have_attributes(
+                          :virtual_hw_version   => nil,
+                          :config_version       => nil,
+                          :guest_os             => nil,
+                          :cpu_sockets          => 1,
+                          :bios                 => nil,
+                          :bios_location        => nil,
+                          :time_sync            => nil,
+                          :annotation           => nil,
+                          :vm_or_template_id    => nil,
+                          :memory_mb            => 512,
+                          :host_id              => nil,
+                          :cpu_speed            => 145,
+                          :cpu_type             => nil,
+                          :size_on_disk         => nil,
+                          :manufacturer         => "",
+                          :model                => "",
+                          :number_of_nics       => nil,
+                          :cpu_usage            => nil,
+                          :memory_usage         => nil,
+                          :cpu_cores_per_socket => nil,
+                          :cpu_total_cores      => 56,
+                          :vmotion_enabled      => nil,
+                          :disk_free_space      => nil,
+                          :disk_capacity        => nil,
+                          :guest_os_full_name   => nil,
+                          :memory_console       => nil,
+                          :bitness              => nil,
+                          :virtualization_type  => nil,
+                          :root_device_type     => nil,
+                          :disk_size_minimum    => nil,
+                          :memory_mb_minimum    => nil,
+                          :introspected         => nil,
+                          :provision_state      => nil,
+                          :serial_number        => nil,
+                          :switch_id            => nil,
+                          :firmware_type        => nil,
+                          :canister_id          => nil
+    ))
 
   end
 
   def assert_specific_physical_server_firmwares
-    server_ems_ref = "614cec406176752d35abe2dc"
+    server_ems_ref = "614cec416176752d35abe368"
     server = get_physical_server_from_ems_ref(server_ems_ref)
     firmware = server.hardware.firmwares.first
 
-    expect(firmware).to have_attributes(
-      :name            => "BIOS",
-      :build           => "BIOS",
-      :version         => "X210M6.5.0.1d.0.0816211754",
-      :release_date    => nil,
-      :resource_type   => "Hardware",
-      :guest_device_id => nil,
-    )
+    expect(firmware).to(have_attributes(
+                          :name            => "BIOS",
+                          :build           => "BIOS",
+                          :version         => "X210M6.5.0.1d.0.0816211754",
+                          :release_date    => nil,
+                          :resource_type   => "Hardware",
+                          :guest_device_id => nil
+    ))
   end
 
   def assert_specific_physical_server_network_devices
-    server_ems_ref = "614cec406176752d35abe2dc"
+    server_ems_ref = "614cec416176752d35abe368"
     server = get_physical_server_from_ems_ref(server_ems_ref)
     nic = server.hardware.nics.first
 
-    expect(nic).to have_attributes(
-      :device_name            => "LAB02D02F01-1-2",
-      :device_type            => "ethernet",
-      :location               => nil,
-      :filename               => nil,
-      :mode                   => nil,
-      :controller_type        => nil,
-      :size                   => nil,
-      :free_space             => nil,
-      :size_on_disk           => nil,
-      :address                => nil,
-      :switch_id              => nil,
-      :lan_id                 => nil,
-      :model                  => "",
-      :iscsi_name             => nil,
-      :iscsi_alias            => nil,
-      :present                => true,
-      :start_connected        => true,
-      :auto_detect            => nil,
-      :uid_ems                => "614cec8c6176752d35ac0525",
-      :chap_auth_enabled      => nil,
-      :manufacturer           => "unknown",
-      :field_replaceable_unit => nil,
-      :parent_device_id       => nil,
-      :vlan_key               => nil,
-      :vlan_enabled           => nil,
-      :peer_mac_address       => nil,
-      :speed                  => nil
-    )
+    expect(nic).to(have_attributes(
+                     :device_name            => "UCSX-V4-Q25GML_FCH2505713A",
+                     :device_type            => "ethernet",
+                     :location               => nil,
+                     :filename               => nil,
+                     :mode                   => nil,
+                     :controller_type        => nil,
+                     :size                   => nil,
+                     :free_space             => nil,
+                     :size_on_disk           => nil,
+                     :address                => nil,
+                     :switch_id              => nil,
+                     :lan_id                 => nil,
+                     :model                  => "UCSX-V4-Q25GML",
+                     :iscsi_name             => nil,
+                     :iscsi_alias            => nil,
+                     :present                => true,
+                     :start_connected        => true,
+                     :auto_detect            => nil,
+                     :uid_ems                => "614cec8e6176752d35ac0743",
+                     :chap_auth_enabled      => nil,
+                     :manufacturer           => "Cisco Systems Inc",
+                     :field_replaceable_unit => nil,
+                     :parent_device_id       => nil,
+                     :vlan_key               => nil,
+                     :vlan_enabled           => nil,
+                     :peer_mac_address       => nil,
+                     :speed                  => nil
+    ))
   end
 
   def assert_specific_physical_chassis
     chassis_ems_ref = "614ceb786176752d35ab8b41"
     chassis = get_physical_chassis_from_ems_ref(chassis_ems_ref)
 
-    expect(chassis).to have_attributes(
-      :uid_ems                      => nil,
-      :ems_ref                      => chassis_ems_ref,
-      :physical_rack_id             => nil,
-      :name                         => "LAB02D02F01-1",
-      :vendor                       => nil,
-      :type                         => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalChassis",
-      :health_state                 => "Valid",
-      :overall_health_state         => nil,
-      :management_module_slot_count => nil,
-      :switch_slot_count            => nil,
-      :fan_slot_count               => nil,
-      :blade_slot_count             => nil,
-      :powersupply_slot_count       => nil,
-     )
+    expect(chassis).to(have_attributes(
+                         :uid_ems                      => nil,
+                         :ems_ref                      => chassis_ems_ref,
+                         :physical_rack_id             => nil,
+                         :name                         => "LAB02D02F01-1",
+                         :vendor                       => nil,
+                         :type                         => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalChassis",
+                         :health_state                 => "Valid",
+                         :overall_health_state         => nil,
+                         :management_module_slot_count => nil,
+                         :switch_slot_count            => nil,
+                         :fan_slot_count               => nil,
+                         :blade_slot_count             => nil,
+                         :powersupply_slot_count       => nil
+     ))
 
-    expect(chassis.ext_management_system).to eq(ems)
+    expect(chassis.ext_management_system).to(eq(ems))
   end
 
   def assert_specific_physical_chassis_details
@@ -239,43 +239,43 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     chassis = get_physical_chassis_from_ems_ref(chassis_ems_ref)
     asset_detail = AssetDetail.find_by!(:resource => chassis)
 
-    expect(asset_detail).to have_attributes(
-      :description            => "UCS Fabric Interconnect 6454",
-      :location               => "CISCO SYSTEMS INC, 3800 ZANKER ROAD, 95134, 95134, SAN JOSE, US",
-      :room                   => nil,
-      :contact                => nil,
-      :rack_name              => nil,
-      :lowest_rack_unit       => nil,
-      :resource_type          => "PhysicalChassis",
-      :product_name           => nil,
-      :manufacturer           => nil,
-      :machine_type           => nil,
-      :model                  => "UCSX-9508",
-      :serial_number          => "FOX2510P5HJ",
-      :field_replaceable_unit => nil,
-      :part_number            => "68-6847-03  ",
-      :location_led_ems_ref   => nil,
-      :location_led_state     => "off",
-     )
+    expect(asset_detail).to(have_attributes(
+                              :description            => "UCS Fabric Interconnect 6454",
+                              :location               => "3800 ZANKER ROAD SAN JOSE US 95134 CA",
+                              :room                   => nil,
+                              :contact                => nil,
+                              :rack_name              => nil,
+                              :lowest_rack_unit       => nil,
+                              :resource_type          => "PhysicalChassis",
+                              :product_name           => "CISCO SYSTEMS INC FOR US INTERNAL DEMO EVAL ONLY",
+                              :manufacturer           => nil,
+                              :machine_type           => "CiscoUcsFI",
+                              :model                  => "UCSX-9508",
+                              :serial_number          => "FOX2510P5HJ",
+                              :field_replaceable_unit => nil,
+                              :part_number            => "68-6847-03  ",
+                              :location_led_ems_ref   => nil,
+                              :location_led_state     => "off"
+     ))
   end
 
   def assert_specific_physical_switch
     switch_uid_ems = "614ce2a16176752d35a7ec96"
     switch = get_physical_switch_from_uid_ems(switch_uid_ems)
 
-    expect(switch).to have_attributes(
-      :name              => "switch-FDO244106VJ",
-      :ports             => nil,
-      :uid_ems           => switch_uid_ems,
-      :allow_promiscuous => nil,
-      :forged_transmits  => nil,
-      :mac_changes       => nil,
-      :mtu               => nil,
-      :type              => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitch",
-      :health_state      => "Warning",
-      :power_state       => nil
-    )
-    expect(switch.ext_management_system).to eq(ems)
+    expect(switch).to(have_attributes(
+                        :name              => "switch-FDO244106VJ",
+                        :ports             => nil,
+                        :uid_ems           => switch_uid_ems,
+                        :allow_promiscuous => nil,
+                        :forged_transmits  => nil,
+                        :mac_changes       => nil,
+                        :mtu               => nil,
+                        :type              => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitch",
+                        :health_state      => "Warning",
+                        :power_state       => nil
+    ))
+    expect(switch.ext_management_system).to(eq(ems))
   end
 
   def assert_specific_physical_switch_details
@@ -283,24 +283,24 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     switch = get_physical_switch_from_uid_ems(switch_uid_ems)
     asset_detail = AssetDetail.find_by!(:resource => switch)
 
-    expect(asset_detail).to have_attributes(
-      :description            => "UCS Fabric Interconnect 6454",
-      :location               => "3800 ZANKER ROAD SAN JOSE US 95134 CA",
-      :room                   => nil,
-      :contact                => nil,
-      :rack_name              => nil,
-      :lowest_rack_unit       => nil,
-      :resource_type          => "Switch",
-      :product_name           => "CISCO SYSTEMS INC FOR US INTERNAL DEMO EVAL ONLY",
-      :manufacturer           => "Cisco Systems, Inc.",
-      :machine_type           => "CiscoUcsFI",
-      :model                  => "UCS-FI-6454",
-      :serial_number          => "FDO244106VJ",
-      :field_replaceable_unit => nil,
-      :part_number            => nil,
-      :location_led_ems_ref   => nil,
-      :location_led_state     => nil
-    )
+    expect(asset_detail).to(have_attributes(
+                              :description            => "UCS Fabric Interconnect 6454",
+                              :location               => "3800 ZANKER ROAD SAN JOSE US 95134 CA",
+                              :room                   => nil,
+                              :contact                => nil,
+                              :rack_name              => nil,
+                              :lowest_rack_unit       => nil,
+                              :resource_type          => "Switch",
+                              :product_name           => "CISCO SYSTEMS INC FOR US INTERNAL DEMO EVAL ONLY",
+                              :manufacturer           => "Cisco Systems, Inc.",
+                              :machine_type           => "CiscoUcsFI",
+                              :model                  => "UCS-FI-6454",
+                              :serial_number          => "FDO244106VJ",
+                              :field_replaceable_unit => nil,
+                              :part_number            => nil,
+                              :location_led_ems_ref   => nil,
+                              :location_led_state     => nil
+    ))
 
   end
 
@@ -309,45 +309,44 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     switch = get_physical_switch_from_uid_ems(switch_uid_ems)
     hardware = switch.hardware
 
-    expect(hardware).to have_attributes(
-      :virtual_hw_version   => nil,
-      :config_version       => nil,
-      :guest_os             => nil,
-      :cpu_sockets          => 1,
-      :bios                 => nil,
-      :bios_location        => nil,
-      :time_sync            => nil,
-      :annotation           => nil,
-      :vm_or_template_id    => nil,
-      :memory_mb            => nil,
-      :host_id              => nil,
-      :cpu_speed            => nil,
-      :cpu_type             => nil,
-      :size_on_disk         => nil,
-      :manufacturer         => "",
-      :model                => "",
-      :number_of_nics       => nil,
-      :cpu_usage            => nil,
-      :memory_usage         => nil,
-      :cpu_cores_per_socket => nil,
-      :cpu_total_cores      => nil,
-      :vmotion_enabled      => nil,
-      :disk_free_space      => nil,
-      :disk_capacity        => nil,
-      :guest_os_full_name   => nil,
-      :memory_console       => nil,
-      :bitness              => nil,
-      :virtualization_type  => nil,
-      :root_device_type     => nil,
-      :disk_size_minimum    => nil,
-      :memory_mb_minimum    => nil,
-      :introspected         => nil,
-      :provision_state      => nil,
-      :serial_number        => nil,
-      :switch_id            => 7,
-      :firmware_type        => nil,
-      :canister_id          => nil
-    )
+    expect(hardware).to(have_attributes(
+                          :virtual_hw_version   => nil,
+                          :config_version       => nil,
+                          :guest_os             => nil,
+                          :cpu_sockets          => 1,
+                          :bios                 => nil,
+                          :bios_location        => nil,
+                          :time_sync            => nil,
+                          :annotation           => nil,
+                          :vm_or_template_id    => nil,
+                          :memory_mb            => nil,
+                          :host_id              => nil,
+                          :cpu_speed            => nil,
+                          :cpu_type             => nil,
+                          :size_on_disk         => nil,
+                          :manufacturer         => "",
+                          :model                => "",
+                          :number_of_nics       => nil,
+                          :cpu_usage            => nil,
+                          :memory_usage         => nil,
+                          :cpu_cores_per_socket => nil,
+                          :cpu_total_cores      => nil,
+                          :vmotion_enabled      => nil,
+                          :disk_free_space      => nil,
+                          :disk_capacity        => nil,
+                          :guest_os_full_name   => nil,
+                          :memory_console       => nil,
+                          :bitness              => nil,
+                          :virtualization_type  => nil,
+                          :root_device_type     => nil,
+                          :disk_size_minimum    => nil,
+                          :memory_mb_minimum    => nil,
+                          :introspected         => nil,
+                          :provision_state      => nil,
+                          :serial_number        => nil,
+                          :firmware_type        => nil,
+                          :canister_id          => nil
+    ))
   end
 
   def assert_specific_physical_switch_firmwares
@@ -355,34 +354,33 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     switch = get_physical_switch_from_uid_ems(switch_uid_ems)
     firmware = switch.hardware.firmwares.first
 
-    expect(firmware).to have_attributes(
-      :name            => "switch-FDO244106VJ/mgmt/fw-system",
-      :build           => "9.3(5)I42(1f)",
-      :version         => "9.3(5)I42(1f)",
-      :resource_type   => "Hardware",
-      :guest_device_id => nil
-    )
+    expect(firmware).to(have_attributes(
+                          :name            => "switch-FDO244106VJ/mgmt/fw-system",
+                          :build           => "9.3(5)I42(1f)",
+                          :version         => "9.3(5)I42(1f)",
+                          :resource_type   => "Hardware",
+                          :guest_device_id => nil
+    ))
   end
 
   def assert_specific_physical_switch_network_ports
     switch_uid_ems = "614ce25c4630312d42bf1d67"
-    physical_switch_network_port = get_switch_network_port_from_port_uid(switch_uid_ems)
+    physical_switch_network_port = PhysicalNetworkPort.find_by(:uid_ems => switch_uid_ems)
 
-    expect(physical_switch_network_port).to have_attributes(
-      :ems_ref            => nil,
-      :uid_ems            => switch_uid_ems,
-      :type               => nil,
-      :port_name          => "switch-FDO244106VJ/slot-1/switch-ether/port-42",
-      :port_type          => "ethernet",
-      :peer_mac_address   => nil,
-      :vlan_key           => nil,
-      :mac_address        => "00:3A:9C:DA:78:F1",
-      :port_index         => 42,
-      :vlan_enabled       => nil,
-      :guest_device_id    => nil,
-      :switch_id          => 7,
-      :connected_port_uid => switch_uid_ems
-    )
+    expect(physical_switch_network_port).to(have_attributes(
+                                              :ems_ref            => nil,
+                                              :uid_ems            => switch_uid_ems,
+                                              :type               => nil,
+                                              :port_name          => "switch-FDO244106VJ/slot-1/switch-ether/port-42",
+                                              :port_type          => "ethernet",
+                                              :peer_mac_address   => nil,
+                                              :vlan_key           => nil,
+                                              :mac_address        => "00:3A:9C:DA:78:F1",
+                                              :port_index         => 42,
+                                              :vlan_enabled       => nil,
+                                              :guest_device_id    => nil,
+                                              :connected_port_uid => switch_uid_ems
+    ))
   end
 
   def assert_specific_physical_switch_networks
@@ -391,23 +389,22 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     hardware = switch.hardware
     network = Network.find_by(:hardware => hardware)
 
-    expect(physical_switch_network_port).to have_attributes(
-      :hardware_id     => 99,
-      :device_id       => nil,
-      :description     => nil,
-      :guid            => nil,
-      :dhcp_enabled    => nil,
-      :ipaddress       => "100.66.11.142",
-      :subnet_mask     => "255.255.255.192",
-      :lease_obtained  => nil,
-      :lease_expires   => nil,
-      :default_gateway => "100.66.11.129",
-      :dhcp_server     => nil,
-      :dns_server      => nil,
-      :hostname        => nil,
-      :domain          => nil,
-      :ipv6address     => ""
-    )
+    expect(network).to(have_attributes(
+                         :device_id       => nil,
+                         :description     => nil,
+                         :guid            => nil,
+                         :dhcp_enabled    => nil,
+                         :ipaddress       => "100.66.11.142",
+                         :subnet_mask     => "255.255.255.192",
+                         :lease_obtained  => nil,
+                         :lease_expires   => nil,
+                         :default_gateway => "100.66.11.129",
+                         :dhcp_server     => nil,
+                         :dns_server      => nil,
+                         :hostname        => nil,
+                         :domain          => nil,
+                         :ipv6address     => ""
+    ))
   end
 
   # Helper methods

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
@@ -26,9 +26,9 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
         # switches tests
 
         assert_specific_physical_switch
-        # assert_specific_physical_switch_details
-        # assert_specific_physical_switch_hardwares
-        # assert_specific_physical_switch_firmwares
+        assert_specific_physical_switch_details
+        assert_specific_physical_switch_hardwares
+        assert_specific_physical_switch_firmwares
         # assert_specific_physical_switch_network_ports
         # assert_specific_physical_switch_networks
       end
@@ -63,6 +63,8 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     expect(ems.physical_switch_networks.count).to eq(2)
 
   end
+
+  # Asserting specific objects type of tests
 
   def assert_specific_physical_server
     server_ems_ref = "614cec406176752d35abe2dc"
@@ -261,21 +263,108 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     switch_uid_ems = "614ce2a16176752d35a7ec96"
     switch = get_physical_switch_from_uid_ems(switch_uid_ems)
 
-    expect(server).to have_attributes(
-      :name               => "switch-FDO244106VJ",
-      :ports => nil,
-      :uid_ems => switch_uid_ems,
+    expect(switch).to have_attributes(
+      :name              => "switch-FDO244106VJ",
+      :ports             => nil,
+      :uid_ems           => switch_uid_ems,
       :allow_promiscuous => nil,
-      :forged_transmits => nil,
-      :mac_changes => nil,
-      mtu => nil,
-      :type                   => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitch",
-      :health_state => "Warning",
-      :power_state => nil
+      :forged_transmits  => nil,
+      :mac_changes       => nil,
+      :mtu               => nil,
+      :type              => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitch",
+      :health_state      => "Warning",
+      :power_state       => nil
+    )
+    expect(switch.ext_management_system).to eq(ems)
+  end
+
+  def assert_specific_physical_switch_details
+    switch_uid_ems = "614ce2a16176752d35a7ec96"
+    switch = get_physical_switch_from_uid_ems(switch_uid_ems)
+    asset_detail = AssetDetail.find_by!(:resource => switch)
+
+    expect(asset_detail).to have_attributes(
+      :description            => "UCS Fabric Interconnect 6454",
+      :location               => "3800 ZANKER ROAD SAN JOSE US 95134 CA",
+      :room                   => nil,
+      :contact                => nil,
+      :rack_name              => nil,
+      :lowest_rack_unit       => nil,
+      :resource_type          => "Switch",
+      :product_name           => "CISCO SYSTEMS INC FOR US INTERNAL DEMO EVAL ONLY",
+      :manufacturer           => "Cisco Systems, Inc.",
+      :machine_type           => "CiscoUcsFI",
+      :model                  => "UCS-FI-6454",
+      :serial_number          => "FDO244106VJ",
+      :field_replaceable_unit => nil,
+      :part_number            => nil,
+      :location_led_ems_ref   => nil,
+      :location_led_state     => nil
     )
 
-    expect(server.ext_management_system).to eq(ems)
   end
+
+  def assert_specific_physical_switch_hardwares
+    switch_uid_ems = "614ce2a16176752d35a7ec96"
+    switch = get_physical_switch_from_uid_ems(switch_uid_ems)
+    hardware = switch.hardware
+
+    expect(hardware).to have_attributes(
+      :virtual_hw_version   => nil,
+      :config_version       => nil,
+      :guest_os             => nil,
+      :cpu_sockets          => 1,
+      :bios                 => nil,
+      :bios_location        => nil,
+      :time_sync            => nil,
+      :annotation           => nil,
+      :vm_or_template_id    => nil,
+      :memory_mb            => nil,
+      :host_id              => nil,
+      :cpu_speed            => nil,
+      :cpu_type             => nil,
+      :size_on_disk         => nil,
+      :manufacturer         => "",
+      :model                => "",
+      :number_of_nics       => nil,
+      :cpu_usage            => nil,
+      :memory_usage         => nil,
+      :cpu_cores_per_socket => nil,
+      :cpu_total_cores      => nil,
+      :vmotion_enabled      => nil,
+      :disk_free_space      => nil,
+      :disk_capacity        => nil,
+      :guest_os_full_name   => nil,
+      :memory_console       => nil,
+      :bitness              => nil,
+      :virtualization_type  => nil,
+      :root_device_type     => nil,
+      :disk_size_minimum    => nil,
+      :memory_mb_minimum    => nil,
+      :introspected         => nil,
+      :provision_state      => nil,
+      :serial_number        => nil,
+      :switch_id            => 7,
+      :firmware_type        => nil,
+      :canister_id          => nil
+    )
+  end
+
+  def assert_specific_physical_switch_firmwares
+    switch_uid_ems = "614ce2a16176752d35a7ec96"
+    switch = get_physical_switch_from_uid_ems(switch_uid_ems)
+    firmware = switch.hardware.firmwares.first
+
+    expect(firmware).to have_attributes(
+      :name            => "switch-FDO244106VJ/mgmt/fw-system",
+      :build           => "9.3(5)I42(1f)",
+      :version         => "9.3(5)I42(1f)",
+      :resource_type   => "Hardware",
+      :guest_device_id => nil
+    )
+  end
+
+  # Helper methods
 
   def get_physical_switch_from_uid_ems(uid_ems)
     PhysicalSwitch.find_by(:uid_ems => uid_ems)

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
@@ -29,8 +29,8 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
         assert_specific_physical_switch_details
         assert_specific_physical_switch_hardwares
         assert_specific_physical_switch_firmwares
-        # assert_specific_physical_switch_network_ports
-        # assert_specific_physical_switch_networks
+        assert_specific_physical_switch_network_ports
+        assert_specific_physical_switch_networks
       end
     end
   end
@@ -119,43 +119,43 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     hardware = server.hardware
 
     expect(hardware).to have_attributes(
-      :virtual_hw_version => nil,
-      :config_version => nil,
-      :guest_os => nil,
-      :cpu_sockets => 1,
-      :bios => nil,
-      :bios_location => nil,
-      :time_sync => nil,
-      :annotation => nil,
-      :vm_or_template_id => nil,
-      :memory_mb => 512,
-      :host_id => nil,
-      :cpu_speed => 145,
-      :cpu_type => nil,
-      :size_on_disk => nil,
-      :manufacturer => "",
-      :model => "",
-      :number_of_nics => nil,
-      :cpu_usage => nil,
-      :memory_usage => nil,
+      :virtual_hw_version   => nil,
+      :config_version       => nil,
+      :guest_os             => nil,
+      :cpu_sockets          => 1,
+      :bios                 => nil,
+      :bios_location        => nil,
+      :time_sync            => nil,
+      :annotation           => nil,
+      :vm_or_template_id    => nil,
+      :memory_mb            => 512,
+      :host_id              => nil,
+      :cpu_speed            => 145,
+      :cpu_type             => nil,
+      :size_on_disk         => nil,
+      :manufacturer         => "",
+      :model                => "",
+      :number_of_nics       => nil,
+      :cpu_usage            => nil,
+      :memory_usage         => nil,
       :cpu_cores_per_socket => nil,
-      :cpu_total_cores => 56,
-      :vmotion_enabled => nil,
-      :disk_free_space => nil,
-      :disk_capacity => nil,
-      :guest_os_full_name => nil,
-      :memory_console => nil,
-      :bitness => nil,
-      :virtualization_type => nil,
-      :root_device_type => nil,
-      :disk_size_minimum => nil,
-      :memory_mb_minimum => nil,
-      :introspected => nil,
-      :provision_state => nil,
-      :serial_number => nil,
-      :switch_id => nil,
-      :firmware_type => nil,
-      :canister_id => nil
+      :cpu_total_cores      => 56,
+      :vmotion_enabled      => nil,
+      :disk_free_space      => nil,
+      :disk_capacity        => nil,
+      :guest_os_full_name   => nil,
+      :memory_console       => nil,
+      :bitness              => nil,
+      :virtualization_type  => nil,
+      :root_device_type     => nil,
+      :disk_size_minimum    => nil,
+      :memory_mb_minimum    => nil,
+      :introspected         => nil,
+      :provision_state      => nil,
+      :serial_number        => nil,
+      :switch_id            => nil,
+      :firmware_type        => nil,
+      :canister_id          => nil
     )
 
   end
@@ -216,19 +216,19 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     chassis = get_physical_chassis_from_ems_ref(chassis_ems_ref)
 
     expect(chassis).to have_attributes(
-     :uid_ems                      => nil,
-     :ems_ref                      => chassis_ems_ref,
-     :physical_rack_id             => nil,
-     :name                         => "LAB02D02F01-1",
-     :vendor                       => nil,
-     :type                         => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalChassis",
-     :health_state                 => "Valid",
-     :overall_health_state         => nil,
-     :management_module_slot_count => nil,
-     :switch_slot_count            => nil,
-     :fan_slot_count               => nil,
-     :blade_slot_count             => nil,
-     :powersupply_slot_count       => nil,
+      :uid_ems                      => nil,
+      :ems_ref                      => chassis_ems_ref,
+      :physical_rack_id             => nil,
+      :name                         => "LAB02D02F01-1",
+      :vendor                       => nil,
+      :type                         => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalChassis",
+      :health_state                 => "Valid",
+      :overall_health_state         => nil,
+      :management_module_slot_count => nil,
+      :switch_slot_count            => nil,
+      :fan_slot_count               => nil,
+      :blade_slot_count             => nil,
+      :powersupply_slot_count       => nil,
      )
 
     expect(chassis.ext_management_system).to eq(ems)
@@ -240,22 +240,22 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     asset_detail = AssetDetail.find_by!(:resource => chassis)
 
     expect(asset_detail).to have_attributes(
-     :description            => "UCS Fabric Interconnect 6454",
-     :location               => "CISCO SYSTEMS INC, 3800 ZANKER ROAD, 95134, 95134, SAN JOSE, US",
-     :room                   => nil,
-     :contact                => nil,
-     :rack_name              => nil,
-     :lowest_rack_unit       => nil,
-     :resource_type          => "PhysicalChassis",
-     :product_name           => nil,
-     :manufacturer           => nil,
-     :machine_type           => nil,
-     :model                  => "UCSX-9508",
-     :serial_number          => "FOX2510P5HJ",
-     :field_replaceable_unit => nil,
-     :part_number            => "68-6847-03  ",
-     :location_led_ems_ref   => nil,
-     :location_led_state     => "off",
+      :description            => "UCS Fabric Interconnect 6454",
+      :location               => "CISCO SYSTEMS INC, 3800 ZANKER ROAD, 95134, 95134, SAN JOSE, US",
+      :room                   => nil,
+      :contact                => nil,
+      :rack_name              => nil,
+      :lowest_rack_unit       => nil,
+      :resource_type          => "PhysicalChassis",
+      :product_name           => nil,
+      :manufacturer           => nil,
+      :machine_type           => nil,
+      :model                  => "UCSX-9508",
+      :serial_number          => "FOX2510P5HJ",
+      :field_replaceable_unit => nil,
+      :part_number            => "68-6847-03  ",
+      :location_led_ems_ref   => nil,
+      :location_led_state     => "off",
      )
   end
 
@@ -364,6 +364,52 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     )
   end
 
+  def assert_specific_physical_switch_network_ports
+    switch_uid_ems = "614ce25c4630312d42bf1d67"
+    physical_switch_network_port = get_switch_network_port_from_port_uid(switch_uid_ems)
+
+    expect(physical_switch_network_port).to have_attributes(
+      :ems_ref            => nil,
+      :uid_ems            => switch_uid_ems,
+      :type               => nil,
+      :port_name          => "switch-FDO244106VJ/slot-1/switch-ether/port-42",
+      :port_type          => "ethernet",
+      :peer_mac_address   => nil,
+      :vlan_key           => nil,
+      :mac_address        => "00:3A:9C:DA:78:F1",
+      :port_index         => 42,
+      :vlan_enabled       => nil,
+      :guest_device_id    => nil,
+      :switch_id          => 7,
+      :connected_port_uid => switch_uid_ems
+    )
+  end
+
+  def assert_specific_physical_switch_networks
+    switch_uid_ems = "614ce2a16176752d35a7ec96"
+    switch = get_physical_switch_from_uid_ems(switch_uid_ems)
+    hardware = switch.hardware
+    network = Network.find_by(:hardware => hardware)
+
+    expect(physical_switch_network_port).to have_attributes(
+      :hardware_id     => 99,
+      :device_id       => nil,
+      :description     => nil,
+      :guid            => nil,
+      :dhcp_enabled    => nil,
+      :ipaddress       => "100.66.11.142",
+      :subnet_mask     => "255.255.255.192",
+      :lease_obtained  => nil,
+      :lease_expires   => nil,
+      :default_gateway => "100.66.11.129",
+      :dhcp_server     => nil,
+      :dns_server      => nil,
+      :hostname        => nil,
+      :domain          => nil,
+      :ipv6address     => ""
+    )
+  end
+
   # Helper methods
 
   def get_physical_switch_from_uid_ems(uid_ems)
@@ -378,6 +424,8 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     PhysicalChassis.find_by(:ems_ref => ems_ref)
   end
 
-
+  def get_switch_network_port_from_uid_ems(uid_ems)
+    PhysicalNetworkPort.find_by(:connected_port_uid => uid_ems)
+  end
 end
 

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
@@ -11,70 +11,99 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
         ems.reload
 
         assert_ems
+
+        # servers tests
         assert_specific_physical_server
         assert_specific_physical_server_details
         assert_specific_physical_server_hardwares
         assert_specific_physical_server_firmwares
         assert_specific_physical_server_network_devices
+
+        # chasses tests
         assert_specific_physical_chassis
         assert_specific_physical_chassis_details
+
+        # switches tests
+
+        assert_specific_physical_switch
+        # assert_specific_physical_switch_details
+        # assert_specific_physical_switch_hardwares
+        # assert_specific_physical_switch_firmwares
+        # assert_specific_physical_switch_network_ports
+        # assert_specific_physical_switch_networks
       end
     end
   end
 
   def assert_ems
-    expect(ems.physical_servers.count).to eq(29)
-    expect(ems.physical_server_details.count).to eq(29)
-    expect(ems.physical_server_computer_systems.count).to eq(29)
-    expect(ems.physical_server_hardwares.count).to eq(29)
-    expect(ems.physical_server_firmwares.count).to eq(45)
+    # physical server's collections
+    expect(ems.physical_servers.count).to eq(4)
+    expect(ems.physical_server_details.count).to eq(4)
+    expect(ems.physical_server_computer_systems.count).to eq(4)
+    expect(ems.physical_server_hardwares.count).to eq(4)
+    expect(ems.physical_server_network_devices.count).to eq(4)
+    expect(ems.physical_server_firmwares.count).to eq(56)
+    expect(ems.physical_server_storage_adapters.count).to eq(7)
 
-    # In our available lab, we don't yet have a rack information.
+    # physical rack's collections
+    # In our available lab, we have informations about racks yet.
     expect(ems.physical_racks.count).to eq(0)
 
-    expect(ems.physical_chassis.count).to eq(7)
+    # physical chassis' collections
+    expect(ems.physical_chassis.count).to eq(1)
     expect(ems.physical_chassis_details.count).to eq(7)
-    expect(ems.physical_server_network_devices.count).to eq(55)
+
+    # physical switch's collections
+    expect(ems.physical_switches.count).to eq(2)
+    expect(ems.physical_switch_details.count).to eq(2)
+    expect(ems.physical_switch_hardwares.count).to eq(2)
+    expect(ems.physical_switch_firmwares.count).to eq(2)
+
+    expect(ems.physical_switch_network_ports.count).to eq(108)
+    expect(ems.physical_switch_networks.count).to eq(2)
+
   end
 
   def assert_specific_physical_server
-    server_ems_ref = "5ed10e4a6176752d31a406fc"
+    server_ems_ref = "614cec406176752d35abe2dc"
     server = get_physical_server_from_ems_ref(server_ems_ref)
 
     expect(server).to have_attributes(
-      :ems_ref                => "5ed10e4a6176752d31a406fc",
-      :hostname               => "CLABS000D000F001",
+      :ems_ref                => server_ems_ref,
+      :hostname               => "C1-B2-UCSX-210C-M6",
       :type                   => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServer",
       :product_name           => nil,
-      :manufacturer           => nil,
+      :manufacturer           => "Cisco Systems Inc",
       :machine_type           => nil,
       :model                  => nil,
       :serial_number          => nil,
       :field_replaceable_unit => nil,
-      :raw_power_state        => "on",
+      :raw_power_state        => "",
       :vendor                 => nil,
+      :health_state           => "Valid",
+      :power_state            => ""
     )
 
     expect(server.ext_management_system).to eq(ems)
   end
 
   def assert_specific_physical_server_details
-    server_ems_ref = "5ed10e4a6176752d31a406fc"
+    server_ems_ref = "614cec406176752d35abe2dc"
     server = get_physical_server_from_ems_ref(server_ems_ref)
     asset_detail = AssetDetail.find_by!(:resource => server)
 
     expect(asset_detail).to have_attributes(
-      :description => "UCS 6332-16UP 1RU FI/No PSU/24 QSFP+ 16UP/4x40G Lic/8xUP Lic",
+      :description => "UCS 210c M6 Compute Node w/o CPU,  Memory, Storage, Mezz",
       :contact => nil,
-      :location => "IBM TUCSON LAB 11619032-1, 9000 S RITA RD, 85744-0002, 85744-0002, TUCSON, US",
+      :location => "3800 ZANKER ROAD SAN JOSE US 95134 CA",
       :room => "2",
       :rack_name => nil,
       :lowest_rack_unit => nil,
       :resource_type => "PhysicalServer",
-      :product_name => "CLABS000D000F001-2-2",
-      :machine_type => "CiscoUcsFI",
-      :model => "UCSB-B200-M5",
-      :serial_number => "FLM23490685",
+      :product_name => "CISCO SYSTEMS INC FOR US INTERNAL DEMO EVAL ONLY",
+      :machine_type => "CiscoUcsServer",
+      :model => "UCSX-210C-M6",
+      :serial_number => "FCH250671HR",
       :field_replaceable_unit => nil,
       :part_number => nil,
       :location_led_ems_ref => nil,
@@ -83,7 +112,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
   end
 
   def assert_specific_physical_server_hardwares
-    server_ems_ref = "5ed10e4a6176752d31a406fc"
+    server_ems_ref = "614cec406176752d35abe2dc"
     server = get_physical_server_from_ems_ref(server_ems_ref)
     hardware = server.hardware
 
@@ -92,13 +121,14 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
       :config_version => nil,
       :guest_os => nil,
       :cpu_sockets => 1,
-      :bios => nil, :bios_location => nil,
+      :bios => nil,
+      :bios_location => nil,
       :time_sync => nil,
       :annotation => nil,
       :vm_or_template_id => nil,
-      :memory_mb => 393216,
+      :memory_mb => 512,
       :host_id => nil,
-      :cpu_speed => 100,
+      :cpu_speed => 145,
       :cpu_type => nil,
       :size_on_disk => nil,
       :manufacturer => "",
@@ -107,7 +137,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
       :cpu_usage => nil,
       :memory_usage => nil,
       :cpu_cores_per_socket => nil,
-      :cpu_total_cores => 40,
+      :cpu_total_cores => 56,
       :vmotion_enabled => nil,
       :disk_free_space => nil,
       :disk_capacity => nil,
@@ -136,7 +166,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     expect(firmware).to have_attributes(
       :name            => "BIOS",
       :build           => "BIOS",
-      :version         => "B210M6.4.1.5a.0.0324212030",
+      :version         => "X210M6.5.0.1d.0.0816211754",
       :release_date    => nil,
       :resource_type   => "Hardware",
       :guest_device_id => nil,
@@ -180,11 +210,15 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
   end
 
   def assert_specific_physical_chassis
-    chassis_ems_ref = "5ed10e4b6176752d31a40743"
+    chassis_ems_ref = "614ceb786176752d35ab8b41"
     chassis = get_physical_chassis_from_ems_ref(chassis_ems_ref)
 
     expect(chassis).to have_attributes(
      :uid_ems                      => nil,
+     :ems_ref                      => chassis_ems_ref,
+     :physical_rack_id             => nil,
+     :name                         => "LAB02D02F01-1",
+     :vendor                       => nil,
      :type                         => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalChassis",
      :health_state                 => "Valid",
      :overall_health_state         => nil,
@@ -193,20 +227,19 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
      :fan_slot_count               => nil,
      :blade_slot_count             => nil,
      :powersupply_slot_count       => nil,
-     :parent_physical_chassis_id   => nil,
      )
 
     expect(chassis.ext_management_system).to eq(ems)
   end
 
   def assert_specific_physical_chassis_details
-    chassis_ems_ref = "5ed10e4b6176752d31a40743"
+    chassis_ems_ref = "614ceb786176752d35ab8b41"
     chassis = get_physical_chassis_from_ems_ref(chassis_ems_ref)
     asset_detail = AssetDetail.find_by!(:resource => chassis)
 
     expect(asset_detail).to have_attributes(
-     :description            => "UCS 6332-16UP 1RU FI/No PSU/24 QSFP+ 16UP/4x40G Lic/8xUP Lic",
-     :location               => "IBM TUCSON LAB 11619032-1, 9000 S RITA RD, 85744-0002, 85744-0002, TUCSON, US",
+     :description            => "UCS Fabric Interconnect 6454",
+     :location               => "CISCO SYSTEMS INC, 3800 ZANKER ROAD, 95134, 95134, SAN JOSE, US",
      :room                   => nil,
      :contact                => nil,
      :rack_name              => nil,
@@ -215,13 +248,37 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
      :product_name           => nil,
      :manufacturer           => nil,
      :machine_type           => nil,
-     :model                  => "UCSB-5108-AC2",
-     :serial_number          => "FOX2337P25E",
+     :model                  => "UCSX-9508",
+     :serial_number          => "FOX2510P5HJ",
      :field_replaceable_unit => nil,
-     :part_number            => "68-5091-06",
+     :part_number            => "68-6847-03  ",
      :location_led_ems_ref   => nil,
-     :location_led_state     => nil,
+     :location_led_state     => "off",
      )
+  end
+
+  def assert_specific_physical_switch
+    switch_uid_ems = "614ce2a16176752d35a7ec96"
+    switch = get_physical_switch_from_uid_ems(switch_uid_ems)
+
+    expect(server).to have_attributes(
+      :name               => "switch-FDO244106VJ",
+      :ports => nil,
+      :uid_ems => switch_uid_ems,
+      :allow_promiscuous => nil,
+      :forged_transmits => nil,
+      :mac_changes => nil,
+      mtu => nil,
+      :type                   => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitch",
+      :health_state => "Warning",
+      :power_state => nil
+    )
+
+    expect(server.ext_management_system).to eq(ems)
+  end
+
+  def get_physical_switch_from_uid_ems(uid_ems)
+    PhysicalSwitch.find_by(:uid_ems => uid_ems)
   end
 
   def get_physical_server_from_ems_ref(ems_ref)
@@ -231,6 +288,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
   def get_physical_chassis_from_ems_ref(ems_ref)
     PhysicalChassis.find_by(:ems_ref => ems_ref)
   end
+
 
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,12 +9,12 @@ Dir[File.join(__dir__, "support/**/*.rb")].sort.each { |f| require f }
 require "manageiq-providers-cisco_intersight"
 
 VCR.configure do |config|
-  config.ignore_hosts 'codeclimate.com' if ENV['CI']
+  config.ignore_hosts('codeclimate.com') if ENV['CI']
   config.cassette_library_dir = File.join(ManageIQ::Providers::CiscoIntersight::Engine.root, 'spec/vcr_cassettes')
 
   config.configure_rspec_metadata!
   config.default_cassette_options = {
-    :match_requests_on            => %i(method uri body),
+    :match_requests_on            => %i[method uri body],
     :update_content_length_header => true
   }
 


### PR DESCRIPTION
This PR includes new server and switch physical infrastructure into the inventory.
To be more specific, the following changes have been made regarding inventory:

Minor changes in inventory in general (such as parse new data in already existing collections)
- Include switches' details (into the collection physical_switch_details)
- Include switch's hardware (into the collection physical_switch_hardwares)
- Include switch's firmware (into the collection physical_switch_firmwares)
- Include switch's ports in inventory (into the collection physical_switch_network_ports).
- switch's networks (into the collection physical_switch_networks)
- Include physical switches (into the collection physical_switches)

**Additional comments for persister collection physical_switch_network_ports and physical_switch_networks:**
I wasn't able to include this collection as I has all the other ones, but I had to do so by manually calling ...add_collection(...) in function add_physical_network_ports (for details, see file where inventory collection are included).

I think this is because this isn't done manually in core in this file: https://github.com/ManageIQ/manageiq/blob/master/app/models/manageiq/providers/inventory/persister/builder/physical_infra_manager.rb. In a similar fashion that I did inside my persister class.

If necessary, I could propose these changes in inventory and create additional pull request in ManageIQ core.

This is WIP pull request because we want to present new features to the customer.

Test, additional comments and other networking features will come in the following pull requests.

Regards, Tjaž