### PR TITLE
Add support for lifecycle operations

### DIFF
--- a/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb
+++ b/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb
@@ -1,0 +1,54 @@
+module ManageIQ
+  module Providers
+    module CiscoIntersight
+      module ToolbarOverrides
+        class PhysicalServerCenter < ::ApplicationHelper::Toolbar::Override
+          button_group(
+            'physical_server_policy_choice',
+            [
+              select(
+                :physical_server_lifecycle_choice,
+                nil,
+                t = N_('Cisco Intersight'),
+                t,
+                :enabled => true,
+                :items   => [
+                  api_button(
+                    :physical_server_decommission,
+                    nil,
+                    N_('Decommission server'),
+                    N_('Decommission'),
+                    :icon    => "pficon pficon-off fa-lg",
+                    :api     => {
+                      :action => 'decommission_server',
+                      :entity => 'physical_server'
+                    },
+                    :confirm => N_("Decommission this server?"),
+                    :enabled => true,
+                    :options => {:feature => :decommission}
+                  ),
+                  api_button(
+                    :physical_server_recommission,
+                    nil,
+                    N_('Recommission server'),
+                    N_('Recommission'),
+                    :icon    => "pficon pficon-off fa-lg",
+                    :api     => {
+                      :action => 'recommission_server',
+                      :entity => 'physical_server'
+                    },
+                    :confirm => N_("Recommission this server?"),
+                    :enabled => true,
+                    :options => {:feature => :recommission}
+                  ),
+                ]
+              )
+            ]
+          )
+        end
+      end
+    end
+  end
+end
+
+

--- a/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_servers_center.rb
+++ b/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_servers_center.rb
@@ -1,0 +1,57 @@
+module ManageIQ
+  module Providers
+    module CiscoIntersight
+      module ToolbarOverrides
+        class PhysicalServersCenter < ::ApplicationHelper::Toolbar::Override
+          button_group(
+            'physical_server_policy_choice',
+            [
+              select(
+                :physical_server_lifecycle_choice,
+                nil,
+                t = N_('Cisco Intersight'),
+                t,
+                :enabled => true,
+                :items   => [
+                  api_button(
+                    :physical_server_decommission,
+                    nil,
+                    N_('Decommission server'),
+                    N_('Decommission'),
+                    :icon    => "pficon pficon-off fa-lg",
+                    :api     => {
+                      :action => 'decommission_server',
+                      :entity => 'physical_server'
+                    },
+                    :confirm => N_("Decommission selected servers?"),
+                    :enabled => true,
+		    :onwhen  => "1+",
+                    :options => {:feature => :decommission}
+                  ),
+                  api_button(
+                    :physical_server_recommission,
+                    nil,
+                    N_('Recommission server'),
+                    N_('Recommission'),
+                    :icon    => "pficon pficon-off fa-lg",
+                    :api     => {
+                      :action => 'recommission_server',
+                      :entity => 'physical_server'
+                    },
+                    :confirm => N_("Recommission selected servers?"),
+                    :enabled => true,
+		    :onwhen  => "1+",
+                    :options => {:feature => :recommission}
+                  ),
+                ]
+              )
+            ]
+          )
+        end
+      end
+    end
+  end
+end
+
+
+

--- a/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_servers_center.rb
+++ b/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_servers_center.rb
@@ -25,7 +25,7 @@ module ManageIQ
                     },
                     :confirm => N_("Decommission selected servers?"),
                     :enabled => true,
-		    :onwhen  => "1+",
+                    :onwhen  => "1+",
                     :options => {:feature => :decommission}
                   ),
                   api_button(
@@ -40,7 +40,7 @@ module ManageIQ
                     },
                     :confirm => N_("Recommission selected servers?"),
                     :enabled => true,
-		    :onwhen  => "1+",
+                    :onwhen  => "1+",
                     :options => {:feature => :recommission}
                   ),
                 ]

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -39,7 +39,7 @@ module ManageIQ::Providers::CiscoIntersight
         storage_controllers_list&.each do |storage_controller_reference|
           # build collection physical_server_storage_adapters
           build_physical_server_storage_adapters(hardware, storage_controller_reference)
-        end 
+        end
 
         physical_server_management_device = build_physical_server_management_devices(hardware, server)
         build_physical_server_networks(physical_server_management_device, server)

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -23,10 +23,10 @@ module ManageIQ::Providers::CiscoIntersight
         # Since Intersight's source object is only consolidated view of either object ComputePhysicalSummary of ComputeRackUnit,
         # source object has to be obtained. I store it onto source_object
         source_object = collector.get_source_object_from_physical_server(server)
-        board_unit = collector.get_compute_board_by_moid(source_object.board.moid)
+        board_unit = collector.get_compute_board_by_moid(source_object&.board.moid) if source_object&.board
         # storage_controllers_list is only a list of references to the storage controllers, but not list of intersight's
         # storage controllers itself
-        storage_controllers_list = board_unit.storage_controllers
+        storage_controllers_list = board_unit.storage_controllers if board_unit
         # build collection physical_server_hardwares
         hardware = build_physical_server_hardwares(physical_server_computer_system, server)
 
@@ -36,10 +36,10 @@ module ManageIQ::Providers::CiscoIntersight
           build_physical_server_network_devices(hardware, adapter_unit)
         end
 
-        storage_controllers_list.each do |storage_controller_reference|
+        storage_controllers_list&.each do |storage_controller_reference|
           # build collection physical_server_storage_adapters
           build_physical_server_storage_adapters(hardware, storage_controller_reference)
-        end
+        end 
 
         physical_server_management_device = build_physical_server_management_devices(hardware, server)
         build_physical_server_networks(physical_server_management_device, server)

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations.rb
@@ -5,5 +5,6 @@ module ManageIQ::Providers::CiscoIntersight
     include_concern "Power"
     include_concern "Led"
     include_concern "Firmware"
+    include_concern "Lifecycle"
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/lifecycle.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/lifecycle.rb
@@ -1,0 +1,56 @@
+module ManageIQ::Providers::CiscoIntersight
+  module PhysicalInfraManager::Operations::Lifecycle
+    def recommission_server(server, options)
+      _log.info("Requesting server recommission #{server.ems_ref}.")
+
+      with_provider_connection do |_client|
+        compute_api = IntersightClient::ComputeApi.new
+
+        compute_blade_identity = IntersightClient::ComputeBladeIdentity.new(
+          :admin_action            => 'Recommission',
+          # Have to set this to nil as they are read-only and should not be present in the request payload.
+          :firmware_supportability => nil,
+          :presence                => nil,
+          :lifecycle               => nil
+        )
+
+        begin
+          result = compute_api.update_compute_blade_identity(server.ems_ref, compute_blade_identity, {})
+          _log.info("Server #{server.ems_ref} recommissioned.")
+        rescue IntersightClient::ApiError => e
+          _log.error("Recommission of #{server.ems_ref} failed.")
+          raise MiqException::Error, "Recommission of #{server.ems_ref} failed: #{e.response_body}"
+        end
+      end
+    end
+
+    def decommission_server(server, options)
+      _log.info("Requesting server decommission #{server.ems_ref}.")
+
+      with_provider_connection do |_client|
+        compute_api = IntersightClient::ComputeApi.new
+
+        # First, get the blade
+        blade = compute_api.get_compute_blade_by_moid(server.ems_ref)
+
+        compute_blade_identity = IntersightClient::ComputeBladeIdentity.new(
+          :admin_action            => 'Decommission',
+          # Have to set this to nil as they are read-only and should not be present in the request payload.
+          :firmware_supportability => nil,
+          :presence                => nil,
+          :lifecycle               => nil
+        )
+
+        begin
+          result = compute_api.update_compute_blade_identity(blade.mgmt_identity.moid, compute_blade_identity, {})
+          _log.info("Server #{server.ems_ref} decommissioned.")
+        rescue IntersightClient::ApiError => e
+          _log.error("Recommission of #{server.ems_ref} failed.")
+          raise MiqException::Error, "Decommission of #{server.ems_ref} failed: #{e.response_body}"
+        end
+      end
+    end
+
+  end
+end
+


### PR DESCRIPTION
This commit adds support for decommission and recommission lifecycle
operations of Cisco Intersight provider.

