### PR TITLE
Enhance Inventory's features - follow-up

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -53,12 +53,16 @@ module ManageIQ::Providers::CiscoIntersight
       @network_elements ||= network_api.get_network_element_list.results
     end
 
-    def get_device_contract_information_from_device_moid(registered_device_moid)
-      device_contract_informations.find { |c| c.registered_device.moid == registered_device_moid }
+    def device_contract_informations_by_moid
+      @device_contract_informations_by_moid ||= device_contract_informations.index_by do
+        |dev_contract_info| dev_contract_info.registered_device.moid
+      end
     end
 
-    def get_firmware_firmware_summary_from_server_moid(server_moid)
-      firmware_firmware_summaries.find { |c| c.server.moid == server_moid}
+    def firmware_firmware_summary_by_moid
+      @firmware_firmware_summary_by_moid ||= firmware_firmware_summaries.index_by do
+        |firmware_firmware_summary| firmware_firmware_summary.server.moid
+      end
     end
 
     def get_source_object_from_physical_server(physical_summary)

--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -54,8 +54,8 @@ module ManageIQ::Providers::CiscoIntersight
     end
 
     def device_contract_informations_by_moid
-      @device_contract_informations_by_moid ||= device_contract_informations.index_by do
-        |dev_contract_info| dev_contract_info.registered_device.moid
+      @device_contract_informations_by_moid ||= device_contract_informations.index_by do |dev_contract_info|
+        dev_contract_info.registered_device.moid
       end
     end
 

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -168,8 +168,7 @@ module ManageIQ::Providers::CiscoIntersight
         :physical_rack    => physical_rack, # nil for now
         :power_state      => server.admin_power_state,
         :raw_power_state  => server.admin_power_state,
-        :manufacturer     => server.vendor,
-        :type             => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServer"
+        :manufacturer     => server.vendor
       )
     end
 
@@ -310,8 +309,7 @@ module ManageIQ::Providers::CiscoIntersight
         :name         => network_element.dn,
         :uid_ems      => network_element.moid,
         :switch_uuid  => network_element.moid,
-        :health_state => get_health_state(network_element),
-        :type         => "ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitch"
+        :health_state => get_health_state(network_element)
       )
     end
 

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -14,7 +14,7 @@ module ManageIQ::Providers::CiscoIntersight
       # Parses physical servers and its details
       collector.physical_servers.each do |server|
         # build collection physical_servers
-        physical_server = build_physical_servers(server)
+        physical_server = build_physical_server(server)
         # build collection physical_server_details
         build_physical_server_details(physical_server, server)
         # build collection physical_server_computer_systems
@@ -145,7 +145,7 @@ module ManageIQ::Providers::CiscoIntersight
       )
     end
 
-    def build_physical_servers(server)
+    def build_physical_server(server)
       # Builds out collection physical_servers
       # Object types:
       #   - server - ComputePhysicalSummary, object obtained by intersight client

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -18,7 +18,7 @@ module ManageIQ::Providers::CiscoIntersight
         # build collection physical_server_details
         build_physical_server_details(physical_server, server)
         # build collection physical_server_computer_systems
-        physical_server_computer_system = build_physical_server_computer_systems(physical_server)
+        physical_server_computer_system = build_physical_server_computer_system(physical_server)
 
         # Since Intersight's source object is only consolidated view of either object ComputePhysicalSummary of ComputeRackUnit,
         # source object has to be obtained. I store it onto source_object
@@ -196,7 +196,7 @@ module ManageIQ::Providers::CiscoIntersight
       )
     end
 
-    def build_physical_server_computer_systems(physical_server)
+    def build_physical_server_computer_system(physical_server)
       # Builds out collection physical_server_computer_systems
       # Object types:
       #   - physical_server - ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalServers

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -44,7 +44,7 @@ module ManageIQ::Providers::CiscoIntersight
         physical_server_management_device = build_physical_server_management_devices(hardware, server)
         build_physical_server_networks(physical_server_management_device, server)
 
-        firmware_firmware_summary = collector.get_firmware_firmware_summary_from_server_moid(server.moid)
+        firmware_firmware_summary = collector.firmware_firmware_summary_by_moid[server.moid]
         next unless firmware_firmware_summary
 
         firmware_firmware_summary.components_fw_inventory.each do |component_fw_inventory|
@@ -116,7 +116,7 @@ module ManageIQ::Providers::CiscoIntersight
       #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssetDetails
       physical_chassis = persister.physical_chassis.lazy_find(chassis.moid)
       registered_device_moid = get_registered_device_moid(chassis)
-      device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
+      device_contract_information_unit = collector.device_contract_informations_by_moid[registered_device_moid]
       persister.physical_chassis_details.build(
         :description        => get_product_description(device_contract_information_unit),
         :location           => format_location(device_contract_information_unit),
@@ -182,7 +182,7 @@ module ManageIQ::Providers::CiscoIntersight
       #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssetDetails
       registered_device_moid = get_registered_device_moid(server)
       source_object = collector.get_source_object_from_physical_server(server)
-      device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
+      device_contract_information_unit = collector.device_contract_informations_by_moid[registered_device_moid]
       persister.physical_server_details.build(
         :description        => get_product_description(device_contract_information_unit),
         :location           => format_location(device_contract_information_unit),
@@ -323,7 +323,7 @@ module ManageIQ::Providers::CiscoIntersight
       #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssetDetails
       registered_device_moid = get_registered_device_moid(network_element)
       switch = persister.physical_switches.lazy_find(network_element.moid)
-      device_contract_information_unit = collector.get_device_contract_information_from_device_moid(registered_device_moid)
+      device_contract_information_unit = collector.device_contract_informations_by_moid[registered_device_moid]
       persister.physical_switch_details.build(
         :description   => get_product_description(device_contract_information_unit),
         :location      => format_location(device_contract_information_unit),

--- a/app/models/manageiq/providers/cisco_intersight/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/persister/definitions/physical_infra_collections.rb
@@ -20,30 +20,20 @@ module ManageIQ::Providers::CiscoIntersight::Inventory::Persister::Definitions::
     ].each do |name|
       add_collection(physical_infra, name)
 
-      add_physical_network_ports
+      add_physical_switch_network_ports
       add_physical_server_networks
       add_physical_switch_networks
       add_physical_server_management_devices
     end
   end
 
-  def add_physical_network_ports
-    %i[physical_server
-       physical_switch].each do |network_port_assoc|
-
-      add_collection(physical_infra, "#{network_port_assoc}_network_ports".to_sym) do |builder|
-        builder.add_properties(
-          :model_class                  => ::PhysicalNetworkPort,
-          :parent_inventory_collections => [network_port_assoc.to_s.pluralize.to_sym]
-        )
-
-        manager_ref = case network_port_assoc
-                      when :physical_server then %i[port_type uid_ems]
-                      when :physical_switch then %i[port_type port_name physical_switch]
-                      else []
-                      end
-        builder.add_properties(:manager_ref => manager_ref)
-      end
+  def add_physical_switch_network_ports
+    add_collection(physical_infra, "physical_switch_network_ports".to_sym) do |builder|
+      builder.add_properties(
+        :model_class                  => ::PhysicalNetworkPort,
+        :manager_ref                  => %i[port_type port_name physical_switch],
+        :parent_inventory_collections => %i[physical_switches]
+      )
     end
   end
 

--- a/app/models/manageiq/providers/cisco_intersight/inventory/persister/definitions/physical_infra_collections.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/persister/definitions/physical_infra_collections.rb
@@ -28,7 +28,7 @@ module ManageIQ::Providers::CiscoIntersight::Inventory::Persister::Definitions::
   end
 
   def add_physical_switch_network_ports
-    add_collection(physical_infra, "physical_switch_network_ports".to_sym) do |builder|
+    add_collection(physical_infra, :physical_switch_network_ports) do |builder|
       builder.add_properties(
         :model_class                  => ::PhysicalNetworkPort,
         :manager_ref                  => %i[port_type port_name physical_switch],

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
@@ -240,7 +240,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     asset_detail = AssetDetail.find_by!(:resource => chassis)
 
     expect(asset_detail).to(have_attributes(
-                              :description            => "UCS Fabric Interconnect 6454",
+                              :description            => "UCS 9508 Chassis Configured",
                               :location               => "3800 ZANKER ROAD SAN JOSE US 95134 CA",
                               :room                   => nil,
                               :contact                => nil,
@@ -249,7 +249,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
                               :resource_type          => "PhysicalChassis",
                               :product_name           => "CISCO SYSTEMS INC FOR US INTERNAL DEMO EVAL ONLY",
                               :manufacturer           => nil,
-                              :machine_type           => "CiscoUcsFI",
+                              :machine_type           => "CiscoUcsChassis",
                               :model                  => "UCSX-9508",
                               :serial_number          => "FOX2510P5HJ",
                               :field_replaceable_unit => nil,
@@ -284,7 +284,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     asset_detail = AssetDetail.find_by!(:resource => switch)
 
     expect(asset_detail).to(have_attributes(
-                              :description            => "UCS Fabric Interconnect 6454",
+                              :description            => "UCS 9508 Chassis Configured",
                               :location               => "3800 ZANKER ROAD SAN JOSE US 95134 CA",
                               :room                   => nil,
                               :contact                => nil,
@@ -293,7 +293,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
                               :resource_type          => "Switch",
                               :product_name           => "CISCO SYSTEMS INC FOR US INTERNAL DEMO EVAL ONLY",
                               :manufacturer           => "Cisco Systems, Inc.",
-                              :machine_type           => "CiscoUcsFI",
+                              :machine_type           => "CiscoUcsChassis",
                               :model                  => "UCS-FI-6454",
                               :serial_number          => "FDO244106VJ",
                               :field_replaceable_unit => nil,


### PR DESCRIPTION
This PR is a follow-up PR to https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/35. It address code style comments in the original pull request, made by @agrare. 

To summarize, the following changes have been made:
- [Replace find_by with index_by function for the sake of efficiency](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/commit/59d87818f76334ed23b85455a1c31cd1af69aa95)
- [Renamed function build_physical_servers to singular](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/commit/91a3880f2fca3f4b9b35d347987c8c1d2840a1f7)
- [Renamed function build_physical_server_computer_systems to singular](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/commit/8e00ad36cee35dfd30a05a073a32856f96ccfe90)
- [Removed :type attribute in persister as this is done automatically in ManageIQ core](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/commit/abcb1fc64a94de4ec5e9fc6556668253fc18422d). The attribute :type is included in inventory tests.
- [Removed inclusion of collection physical_server_network_ports](https://github.com/ManageIQ/manageiq-providers-cisco_intersight/commit/20a1adde1b41069a8747a1883980ea142babbfe1)

The changes don't change the actual data in inventory. Consequently, no new tests had to be written.