### PR TITLE
Refactor IntersightClient ApiClient usage

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -1,21 +1,6 @@
 module ManageIQ::Providers::CiscoIntersight
   class Inventory::Collector::PhysicalInfraManager < ManageIQ::Providers::Inventory::Collector
     def collect
-      # Establish connection. Connection is inside ManagerMixin which sets API key and keyid-d
-      connection
-
-      # Initialize API endpoints
-      firmware_api
-      compute_api
-      equipment_api
-      asset_api
-      adapter_api
-      management_api
-      storage_api
-      network_api
-      port_api
-      ether_api
-
       # Initialize the variables that may be memoized for the duration of the refresh run
       physical_servers
       decomissioned_servers
@@ -112,53 +97,53 @@ module ManageIQ::Providers::CiscoIntersight
 
     # API endpoint declaration
     def firmware_api
-      @firmware_api ||= IntersightClient::FirmwareApi.new(connection)
+      @firmware_api ||= IntersightClient::FirmwareApi.new(api_client)
     end
 
     def compute_api
-      @compute_api ||= IntersightClient::ComputeApi.new(connection)
+      @compute_api ||= IntersightClient::ComputeApi.new(api_client)
     end
 
     def equipment_api
-      @equipment_api ||= IntersightClient::EquipmentApi.new(connection)
+      @equipment_api ||= IntersightClient::EquipmentApi.new(api_client)
     end
 
     def asset_api
-      @asset_api ||= IntersightClient::AssetApi.new(connection)
+      @asset_api ||= IntersightClient::AssetApi.new(api_client)
     end
 
     def adapter_api
-      @adapter_api ||= IntersightClient::AdapterApi.new(connection)
+      @adapter_api ||= IntersightClient::AdapterApi.new(api_client)
     end
 
     def management_api
-      @management_api ||= IntersightClient::ManagementApi.new(connection)
+      @management_api ||= IntersightClient::ManagementApi.new(api_client)
     end
 
     def storage_api
-      @storage_api ||= IntersightClient::StorageApi.new(connection)
+      @storage_api ||= IntersightClient::StorageApi.new(api_client)
     end
 
     def network_api
-      @network_api ||= IntersightClient::NetworkApi.new(connection)
+      @network_api ||= IntersightClient::NetworkApi.new(api_client)
     end
 
     def port_api
-      @port_api ||= IntersightClient::PortApi.new(connection)
+      @port_api ||= IntersightClient::PortApi.new(api_client)
     end
 
     def ether_api
-      @ether_api ||= IntersightClient::EtherApi.new(connection)
+      @ether_api ||= IntersightClient::EtherApi.new(api_client)
     end
 
     def search_api
-      @search_api ||= IntersightClient::SearchApi.new
+      @search_api ||= IntersightClient::SearchApi.new(api_client)
     end
 
     # API key and keyid configuration
-    def connection
+    def api_client
       # Sets API key and keyid for the manager
-      @connection ||= manager.connect
+      @api_client ||= manager.connect
     end
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -112,43 +112,43 @@ module ManageIQ::Providers::CiscoIntersight
 
     # API endpoint declaration
     def firmware_api
-      @firmware_api ||= IntersightClient::FirmwareApi.new
+      @firmware_api ||= IntersightClient::FirmwareApi.new(connection)
     end
 
     def compute_api
-      @compute_api ||= IntersightClient::ComputeApi.new
+      @compute_api ||= IntersightClient::ComputeApi.new(connection)
     end
 
     def equipment_api
-      @equipment_api ||= IntersightClient::EquipmentApi.new
+      @equipment_api ||= IntersightClient::EquipmentApi.new(connection)
     end
 
     def asset_api
-      @asset_api ||= IntersightClient::AssetApi.new
+      @asset_api ||= IntersightClient::AssetApi.new(connection)
     end
 
     def adapter_api
-      @adapter_api ||= IntersightClient::AdapterApi.new
+      @adapter_api ||= IntersightClient::AdapterApi.new(connection)
     end
 
     def management_api
-      @management_api ||= IntersightClient::ManagementApi.new
+      @management_api ||= IntersightClient::ManagementApi.new(connection)
     end
 
     def storage_api
-      @storage_api ||= IntersightClient::StorageApi.new
+      @storage_api ||= IntersightClient::StorageApi.new(connection)
     end
 
     def network_api
-      @network_api ||= IntersightClient::NetworkApi.new
+      @network_api ||= IntersightClient::NetworkApi.new(connection)
     end
 
     def port_api
-      @port_api ||= IntersightClient::PortApi.new
+      @port_api ||= IntersightClient::PortApi.new(connection)
     end
 
     def ether_api
-      @ether_api ||= IntersightClient::EtherApi.new
+      @ether_api ||= IntersightClient::EtherApi.new(connection)
     end
 
     def search_api
@@ -156,7 +156,6 @@ module ManageIQ::Providers::CiscoIntersight
     end
 
     # API key and keyid configuration
-
     def connection
       # Sets API key and keyid for the manager
       @connection ||= manager.connect

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/lifecycle.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/lifecycle.rb
@@ -3,8 +3,8 @@ module ManageIQ::Providers::CiscoIntersight
     def recommission_server(server, _options)
       _log.info("Requesting server recommission #{server.ems_ref}.")
 
-      with_provider_connection do |_client|
-        compute_api = IntersightClient::ComputeApi.new
+      with_provider_connection do |api_client|
+        compute_api = IntersightClient::ComputeApi.new(api_client)
 
         compute_blade_identity = IntersightClient::ComputeBladeIdentity.new(
           :admin_action            => 'Recommission',
@@ -27,8 +27,8 @@ module ManageIQ::Providers::CiscoIntersight
     def decommission_server(server, _options)
       _log.info("Requesting server decommission #{server.ems_ref}.")
 
-      with_provider_connection do |_client|
-        compute_api = IntersightClient::ComputeApi.new
+      with_provider_connection do |api_client|
+        compute_api = IntersightClient::ComputeApi.new(api_client)
 
         # First, get the blade
         blade = compute_api.get_compute_blade_by_moid(server.ems_ref)

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/lifecycle.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/lifecycle.rb
@@ -3,9 +3,7 @@ module ManageIQ::Providers::CiscoIntersight
     def recommission_server(server, _options)
       _log.info("Requesting server recommission #{server.ems_ref}.")
 
-      with_provider_connection do |api_client|
-        compute_api = IntersightClient::ComputeApi.new(api_client)
-
+      with_provider_connection(:service => "ComputeApi") do |compute_api|
         compute_blade_identity = IntersightClient::ComputeBladeIdentity.new(
           :admin_action            => 'Recommission',
           # Have to set this to nil as they are read-only and should not be present in the request payload.
@@ -27,9 +25,7 @@ module ManageIQ::Providers::CiscoIntersight
     def decommission_server(server, _options)
       _log.info("Requesting server decommission #{server.ems_ref}.")
 
-      with_provider_connection do |api_client|
-        compute_api = IntersightClient::ComputeApi.new(api_client)
-
+      with_provider_connection(:service => "ComputeApi") do |compute_api|
         # First, get the blade
         blade = compute_api.get_compute_blade_by_moid(server.ems_ref)
 

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/power.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/power.rb
@@ -48,8 +48,8 @@ module ManageIQ::Providers::CiscoIntersight
 
       _log.info("Requesting #{power_state} for #{server.ems_ref}.")
 
-      with_provider_connection do |_client|
-        compute_api = IntersightClient::ComputeApi.new
+      with_provider_connection do |api_client|
+        compute_api = IntersightClient::ComputeApi.new(api_client)
         _system = compute_api.get_compute_physical_summary_by_moid(server.ems_ref)
 
         # Get the related ComputeServerSettings:

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/power.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/power.rb
@@ -48,8 +48,7 @@ module ManageIQ::Providers::CiscoIntersight
 
       _log.info("Requesting #{power_state} for #{server.ems_ref}.")
 
-      with_provider_connection do |api_client|
-        compute_api = IntersightClient::ComputeApi.new(api_client)
+      with_provider_connection(:service => "ComputeApi") do |compute_api|
         _system = compute_api.get_compute_physical_summary_by_moid(server.ems_ref)
 
         # Get the related ComputeServerSettings:

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager_spec.rb
@@ -8,7 +8,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
   end
 
   let(:ci_module) { class_double("IntersightClient").as_stubbed_const }
-  let(:ci_client) { instance_double("RedfishClient::Root") }
+
   subject(:ems) do
     FactoryBot.create(:ems_cisco_intersight_physical_infra, :auth)
   end
@@ -16,9 +16,10 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
 
   context ".raw_connect" do
     it "connects with key_id and secret key" do
-      expect(ci_module).to receive(:configure).and_yield(config_mock)
+      expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
       expect(config_mock).to receive(:api_key_id=).with("keyid")
       expect(config_mock).to receive(:api_key=).with("secretkey")
+
       described_class.raw_connect("keyid", "secretkey")
     end
   end
@@ -30,9 +31,10 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
     end
 
     it "connects with key_id and secret key" do
-      expect(ci_module).to receive(:configure).and_yield(config_mock)
+      expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
       expect(config_mock).to receive(:api_key_id=).with("keyid")
       expect(config_mock).to receive(:api_key=).with("secretkey")
+
       ems.connect
     end
   end

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager_spec.rb
@@ -7,12 +7,8 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
     expect(described_class.description).to eq("Cisco Intersight")
   end
 
-  let(:ci_module) { class_double("IntersightClient").as_stubbed_const }
-
-  subject(:ems) do
-    FactoryBot.create(:ems_cisco_intersight_physical_infra, :auth)
-  end
-  let(:config_mock) { double }
+  let(:ems)         { FactoryBot.create(:ems_cisco_intersight_physical_infra, :auth) }
+  let(:config_mock) { double("IntersightClient::Configuration") }
 
   context ".raw_connect" do
     it "connects with key_id and secret key" do


### PR DESCRIPTION
Rather than setting `IntersightClient::Configuration.@@default` we can initialize a `IntersightClient::Configuration` object, set the key and key_id, and build an `IntersightClient::ApiClient` based on that

Fixes https://github.com/ManageIQ/manageiq-providers-cisco_intersight/issues/44