### PR TITLE
Fix server-chassis relationship

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -160,7 +160,9 @@ module ManageIQ::Providers::CiscoIntersight
 
       # Obtain data about chassis and racks if they're wired to the server
       physical_rack = nil # TODO: After chassis gets written into the DB, obtain it and write it here as reference using lazy find.
-      physical_chassis = persister.physical_chassis.lazy_find(server.equipment_chassis.moid) if server.equipment_chassis
+      physical_chassis = if server&.parent&.object_type == "equipment.Chassis"
+                           persister.physical_chassis.lazy_find(server&.parent&.moid)
+                         end
       registered_device_moid = get_registered_device_moid(server)
       device_registration = collector.get_asset_device_registration_by_moid(registered_device_moid)
       persister.physical_servers.build(

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
@@ -75,6 +75,9 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     server_ems_ref = "6205743e6176752d366ee76e"
     server = get_physical_server_from_ems_ref(server_ems_ref)
 
+    chassis_ems_ref = "614ceb786176752d35ab8b41"
+    chassis = get_physical_chassis_from_ems_ref(chassis_ems_ref)
+
     expect(server).to(have_attributes(
                         :ems_ref                => server_ems_ref,
                         :hostname               => "C1-B1-UCSX-210C-M6",
@@ -88,7 +91,8 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
                         :raw_power_state        => "",
                         :vendor                 => nil,
                         :health_state           => "Valid",
-                        :power_state            => ""
+                        :power_state            => "",
+                        :physical_chassis       => chassis
                       ))
 
     expect(server.ext_management_system).to(eq(ems))


### PR DESCRIPTION
This PR fixes server-chasses relationship.

In the code below, server is object, obtained from the Intersight gem - it belongs to class `IntersightClient::ComputePhysicalSummary`.

On the Intersight side, server's attribute `equipment_chassis` was removed, making value `server.equipment_chassis.moid` equal to `nil` and consequently, making `physical_chassis` equal to `nil` so there was no relationship between servers and chassis.

Instead, I parsed server's `parent` value and obtained parent's `moid` (unique ID for Intersight objects).