### PR TITLE
Changed the name of physical switches

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector/physical_infra_manager.rb
@@ -108,6 +108,8 @@ module ManageIQ::Providers::CiscoIntersight
 
     delegate :get_compute_rack_unit_by_moid, :to => :compute_api
 
+    delegate :get_network_element_summary_by_moid, :to => :network_api
+
     private
 
     # API endpoint declaration

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -76,8 +76,11 @@ module ManageIQ::Providers::CiscoIntersight
 
     def physical_switches
       collector.network_elements.each do |network_element|
+        # object network_element_summary has the same moid as network_element.
+        # network_element_summary is needed to obtain info about switch's name
+        network_element_summary = collector.get_network_element_summary_by_moid(network_element.moid)
         # build collection physical_switches
-        build_physical_switches(network_element)
+        build_physical_switches(network_element, network_element_summary)
         # build collection physical_switch_details
         build_physical_switch_details(network_element)
         # build collection physical_switch_hardwares
@@ -303,14 +306,15 @@ module ManageIQ::Providers::CiscoIntersight
       )
     end
 
-    def build_physical_switches(network_element)
+    def build_physical_switches(network_element, network_element_summary)
       # Builds out collection physical_switches
       # Object types:
       #   - network_element - NetworkElements, object obtained by intersight client
+      #   - network_element_summary - NetworkElementSummary, object obtained by intersight client
       # Returns:
       #   ManageIQ's object ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::PhysicalSwitches
       persister.physical_switches.build(
-        :name         => network_element.dn,
+        :name         => network_element_summary.name,
         :uid_ems      => network_element.moid,
         :switch_uuid  => network_element.moid,
         :health_state => get_health_state(network_element)

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
@@ -363,7 +363,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
     switch = get_physical_switch_from_uid_ems(switch_uid_ems)
 
     expect(switch).to(have_attributes(
-                        :name              => "switch-FDO244106VJ",
+                        :name              => "LAB02D02F01 FI-B",
                         :ports             => nil,
                         :uid_ems           => switch_uid_ems,
                         :allow_promiscuous => nil,

--- a/spec/vcr_cassettes/ManageIQ_Providers_CiscoIntersight_PhysicalInfraManager_Refresher/refresh/will_perform_a_full_refresh.yml
+++ b/spec/vcr_cassettes/ManageIQ_Providers_CiscoIntersight_PhysicalInfraManager_Refresher/refresh/will_perform_a_full_refresh.yml
@@ -15,9 +15,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCICt7ocEh4eLpu4uU7VVMVtksJQgrCYOyiej/4vJUODR5AiEA19lMNkbtvuVZWl4F2u+pToz/0K4vab3Wmd6rUUo0z64="
+        host date digest",signature="MEUCIGZ5RLjUeCc0otlrnceeaEOOhnINJo3OPYZzBdds0h/SAiEAru1/d3RIWtxXPOkjMIuYL3N5XXAltNBqdb5BMpYEtIk="
       Date:
-      - Tue, 26 Apr 2022 05:03:04 GMT
+      - Wed, 27 Apr 2022 06:19:10 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -30,16 +30,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:05 GMT
+      - Wed, 27 Apr 2022 06:19:10 GMT
       Set-Cookie:
-      - AWSALB=pOjTK+mZYc7i+7a8DdIdqERWSla0LtxctpcDODg4Ym1PH/ZRYLkrCffEjdLcurg591igqyFStITJrBBA9bz2uHR45DmKTKmP/a+gTJ06tWH7lpPtJgNbDdgV/2yX;
-        Expires=Tue, 03 May 2022 05:03:05 GMT; Path=/
-      - AWSALBCORS=pOjTK+mZYc7i+7a8DdIdqERWSla0LtxctpcDODg4Ym1PH/ZRYLkrCffEjdLcurg591igqyFStITJrBBA9bz2uHR45DmKTKmP/a+gTJ06tWH7lpPtJgNbDdgV/2yX;
-        Expires=Tue, 03 May 2022 05:03:05 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ptXpfbCiymzsZrwNnJKiZgFn7yoDtzeqXd0KFlGjDJ0tT7UxZp3ZibfitdrFxU1ILks7veToqrbD6hdkcsN81NccPpaUqHJzdk26DsZJTu9X6HURhq7567DOG4MQ;
+        Expires=Wed, 04 May 2022 06:19:10 GMT; Path=/
+      - AWSALBCORS=ptXpfbCiymzsZrwNnJKiZgFn7yoDtzeqXd0KFlGjDJ0tT7UxZp3ZibfitdrFxU1ILks7veToqrbD6hdkcsN81NccPpaUqHJzdk26DsZJTu9X6HURhq7567DOG4MQ;
+        Expires=Wed, 04 May 2022 06:19:10 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd6e5087796ba658e3c7cf56ebe622e9d
+      - NB25dfe7959a4d888d1ceccdd5ad24d5cc
       Pragma:
       - no-cache
       Cache-Control:
@@ -69,11 +69,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - z2bOzMQTHtn5REElWg4imQDA-pUbz45gsdtTqMVs4m9ZTP55aoiGhA==
+      - iNGt665FJc80-iOZ_12HWVoZAic1DNGQT2rr6mLtsvu6wz7ZCgflPA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -258,7 +258,7 @@ http_interactions:
               "ManagementMode": "Intersight",
               "MemorySpeed": "3200",
               "MgmtIpAddress": "100.66.11.155",
-              "ModTime": "2022-04-26T05:01:15.117Z",
+              "ModTime": "2022-04-27T06:12:47.046Z",
               "Model": "UCSX-210C-M6",
               "Moid": "62558eb26176752d36f43a77",
               "Name": "LAB02D02F01-1-2",
@@ -363,27 +363,11 @@ http_interactions:
               "HardwareUuid": "D0D77522-FA5B-4B24-A183-66BF636342FE",
               "InventoryDeviceInfo": null,
               "Ipv4Address": "127.0.0.1",
-              "KvmIpAddresses": [
-                {
-                  "Address": "100.66.11.151",
-                  "Category": "Equipment",
-                  "ClassId": "compute.IpAddress",
-                  "DefaultGateway": "100.66.11.129",
-                  "Dn": "",
-                  "HttpPort": 80,
-                  "HttpsPort": 443,
-                  "KvmPort": 2068,
-                  "KvmVlan": 0,
-                  "Name": "Outband",
-                  "ObjectType": "compute.IpAddress",
-                  "Subnet": "255.255.255.192",
-                  "Type": "MgmtInterface"
-                }
-              ],
+              "KvmIpAddresses": [],
               "ManagementMode": "Intersight",
               "MemorySpeed": "3200",
-              "MgmtIpAddress": "100.66.11.151",
-              "ModTime": "2022-04-26T05:02:26.78Z",
+              "MgmtIpAddress": "",
+              "ModTime": "2022-04-27T05:52:51.759Z",
               "Model": "UCSX-210C-M6",
               "Moid": "6266ce226176752d36c8fe12",
               "Name": "LAB02D02F01-1-3",
@@ -395,7 +379,7 @@ http_interactions:
               "NumFcHostInterfaces": 0,
               "NumThreads": 112,
               "ObjectType": "compute.PhysicalSummary",
-              "OperPowerState": "on",
+              "OperPowerState": "off",
               "OperReason": [],
               "OperState": "",
               "Operability": "",
@@ -458,7 +442,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:05 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:11 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/search/SearchItems?$filter=(Lifecycle%20eq%20%27Decommissioned%27)%20and%20(IndexMotypes%20eq%20%20%27equipment.Identity%27)
@@ -474,9 +458,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDzkK3vVdksaop22dVBu2+2nKtXQixxPXyyAtT8TdfF9AIgb+P6gOUwzIfgMkL8/bxN6z8ws6gGAQiWKT6lUC4lCeo="
+        host date digest",signature="MEUCIAX6TIDB0nqog86cOuagnkvtL48O1c1oqSdz9wrEl+UDAiEA0ppL3Bji+HccsiOanIc6luwUU0thxIq9u3RDm+ggNag="
       Date:
-      - Tue, 26 Apr 2022 05:03:05 GMT
+      - Wed, 27 Apr 2022 06:19:11 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -493,16 +477,16 @@ http_interactions:
       Vary:
       - Accept-Encoding
       Date:
-      - Tue, 26 Apr 2022 05:03:05 GMT
+      - Wed, 27 Apr 2022 06:19:11 GMT
       Set-Cookie:
-      - AWSALB=TyyTrJ09G7/3N+yGd0Xz4SDycCPd8SIAOrK1U0kiCdlCRA5R9FIMuzsPw9/OqBhHcER4m/y4lPyE+cPvqBvjkcPMr362w1FXJgZalL2UWvBqEaaN6G+ffn1O6rdR;
-        Expires=Tue, 03 May 2022 05:03:05 GMT; Path=/
-      - AWSALBCORS=TyyTrJ09G7/3N+yGd0Xz4SDycCPd8SIAOrK1U0kiCdlCRA5R9FIMuzsPw9/OqBhHcER4m/y4lPyE+cPvqBvjkcPMr362w1FXJgZalL2UWvBqEaaN6G+ffn1O6rdR;
-        Expires=Tue, 03 May 2022 05:03:05 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=9B9GAEDxSey3N7hHfYdibRTnFNyRWZSrFhr2b3oUCFueCbiZH7ZHVufjrVs1Tqnza73UIval3IkEZ2rdHGYfQUzAaKLmyufgbtk0L2Cxio5Q6TZu4OHwEmwvYy8i;
+        Expires=Wed, 04 May 2022 06:19:11 GMT; Path=/
+      - AWSALBCORS=9B9GAEDxSey3N7hHfYdibRTnFNyRWZSrFhr2b3oUCFueCbiZH7ZHVufjrVs1Tqnza73UIval3IkEZ2rdHGYfQUzAaKLmyufgbtk0L2Cxio5Q6TZu4OHwEmwvYy8i;
+        Expires=Wed, 04 May 2022 06:19:11 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB9b4921b64035e89322e113e169b3c799
+      - NB055abd1897d1b787903b2a22a71943db
       Pragma:
       - no-cache
       Cache-Control:
@@ -532,11 +516,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - s4knkoK8Cmk5c_bKND65bhmHAMKYGvhM3pVYNT0wBLkIRC2TB9-r5g==
+      - hBFBcpIL2QnbX_4AAZ29II95_KKWnV5vNkWdKVBj6sT8xP7pyPaROA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -597,7 +581,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:05 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:11 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/RackUnits
@@ -613,9 +597,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCxWohw2GAi/jmdGsyqQmdARo0C4ISBTwZWqa2MCeZx7wIhALwtNanj6H2gETQZ4fUNWj54phSUoLKc4hrzqZW2d21F"
+        host date digest",signature="MEYCIQDP9Vx139OoJ1ZCYCS/hJkGGZq/LjJ78k0tUkkoLCF5QQIhAPBJNTQmMQvZBACWU/eeNUcDuWGKn8fhZojXhdCiDjNf"
       Date:
-      - Tue, 26 Apr 2022 05:03:05 GMT
+      - Wed, 27 Apr 2022 06:19:11 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -630,16 +614,16 @@ http_interactions:
       Content-Length:
       - '60'
       Date:
-      - Tue, 26 Apr 2022 05:03:06 GMT
+      - Wed, 27 Apr 2022 06:19:11 GMT
       Set-Cookie:
-      - AWSALB=heihhPduN4bMZHTwsA/+EeSXBoXouTyqvFE2UFBV0GMm3fnsoPcl4CxUG4/FNS3m28SOY3uvwota036VcdWATsCXs0B/F9NOF5eRAaanmdJ+DU7ih8ZIpSzBg9+B;
-        Expires=Tue, 03 May 2022 05:03:06 GMT; Path=/
-      - AWSALBCORS=heihhPduN4bMZHTwsA/+EeSXBoXouTyqvFE2UFBV0GMm3fnsoPcl4CxUG4/FNS3m28SOY3uvwota036VcdWATsCXs0B/F9NOF5eRAaanmdJ+DU7ih8ZIpSzBg9+B;
-        Expires=Tue, 03 May 2022 05:03:06 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=/f5LXWK7+R/GuzoD7ejXSoTSYTBUur7YPRSiQsjExMZRIjPZOI4LF0AIGuIxtW1xnJWykZfGMmKR7xY0HIzBezSTuQfcQ/QBKyiav/NgTsxBeSg6+d37aU7K00td;
+        Expires=Wed, 04 May 2022 06:19:11 GMT; Path=/
+      - AWSALBCORS=/f5LXWK7+R/GuzoD7ejXSoTSYTBUur7YPRSiQsjExMZRIjPZOI4LF0AIGuIxtW1xnJWykZfGMmKR7xY0HIzBezSTuQfcQ/QBKyiav/NgTsxBeSg6+d37aU7K00td;
+        Expires=Wed, 04 May 2022 06:19:11 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0b0822811d3e88a1ff0d310e16860645
+      - NB1c36e3e5a7ff0c682c57779b59acdb1e
       Pragma:
       - no-cache
       Cache-Control:
@@ -669,11 +653,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - aWYnhqjfC2_JIacLgOO9euBBJfRFmkv31sj6v4K2aiisgJtHb4iBSA==
+      - l5i19N6nAU-tIwvbZqsvaEl9yVb_-i9zFsSfo0LIe3-h_I-HyV1Yig==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -682,7 +666,7 @@ http_interactions:
           "Results": []
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:06 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:12 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/firmware/FirmwareSummaries
@@ -698,9 +682,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDwBJRdgE5wysqBxbtX2LEY5kk1e5Wz4gh67yboveewhAIhALhLYGyXLe8cU7QpJpRXRi4XC9iIJrhP7lSds7xEJUNN"
+        host date digest",signature="MEQCIA95v9cKzjmaSrSSijVD2S7vANlPPbjakLaXrqWESh/WAiA6e7sEI2ixmZF3Ye9n+28xfvfdYXRQdtZ+N2/RxTurxw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:06 GMT
+      - Wed, 27 Apr 2022 06:19:12 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -713,16 +697,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:06 GMT
+      - Wed, 27 Apr 2022 06:19:12 GMT
       Set-Cookie:
-      - AWSALB=j7lsIsS4e1fQRmgFjA85gvYGUXVijO/92brcqfz4FgcpAxvG2l7kMUm4V+b3hahmVLGq71LR2/ar+otKVFmIya2QluhQ4l1RBI7yJjw+QgCp6G+6HBmPVTfioExw;
-        Expires=Tue, 03 May 2022 05:03:06 GMT; Path=/
-      - AWSALBCORS=j7lsIsS4e1fQRmgFjA85gvYGUXVijO/92brcqfz4FgcpAxvG2l7kMUm4V+b3hahmVLGq71LR2/ar+otKVFmIya2QluhQ4l1RBI7yJjw+QgCp6G+6HBmPVTfioExw;
-        Expires=Tue, 03 May 2022 05:03:06 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=LxMjtp5ya+L4gavHXW8zx7H1aJb8vj+ixX83ltD9KswNLkXJkeF0fhVEFLyi+mR/wyhzLMKLJfOKv8714F7/xN8JRJzxwnMOzrPkhPNmlnyePGDNR3Wo6Yf++yMB;
+        Expires=Wed, 04 May 2022 06:19:12 GMT; Path=/
+      - AWSALBCORS=LxMjtp5ya+L4gavHXW8zx7H1aJb8vj+ixX83ltD9KswNLkXJkeF0fhVEFLyi+mR/wyhzLMKLJfOKv8714F7/xN8JRJzxwnMOzrPkhPNmlnyePGDNR3Wo6Yf++yMB;
+        Expires=Wed, 04 May 2022 06:19:12 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc50e73f5e6f38c449ad1c7e89aa494c7
+      - NB07f06173b800d56b6cbaaed6eaa0ec27
       Pragma:
       - no-cache
       Cache-Control:
@@ -752,11 +736,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 5g3eZvLsImRvoBPqD1U32vfX4bNYa6TBnpMJeWQ6m6FZyIvp4PS6fA==
+      - IwMHsXTby5xhpW4uR-jA_EwyjIREENFNh4fSFF6GA9xcwnukQHQwpQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -1296,7 +1280,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:06 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:12 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/network/Elements
@@ -1312,9 +1296,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIERGNVfJGfHf4XaFmEpnGzIjVbIaymAVaSps0K6gkNHpAiB37aRUIUgwJqNpzq8I8viB2W2xs7jbIymkO/kYwfWdNA=="
+        host date digest",signature="MEUCIAIjpXNnQ3SPzx2I4q18yXaMEPjAb44lLXXZqe73LwERAiEAiO2DKzBSPJlWofd1rBMYRcREAHth+tSjsR/ORk+soNg="
       Date:
-      - Tue, 26 Apr 2022 05:03:06 GMT
+      - Wed, 27 Apr 2022 06:19:12 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -1327,16 +1311,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:07 GMT
+      - Wed, 27 Apr 2022 06:19:13 GMT
       Set-Cookie:
-      - AWSALB=wVtDcQS/I6TZSHvBusNnfH166ZcbpwI/rGxaiBjCL4VCVHr97myOB9W3ycGpMzv1v5ReERQPqd68oEcxo3jnYAa9R2lyTr8Qk1FeWNPGDgWH7H3Wix7H5YBi+R+l;
-        Expires=Tue, 03 May 2022 05:03:07 GMT; Path=/
-      - AWSALBCORS=wVtDcQS/I6TZSHvBusNnfH166ZcbpwI/rGxaiBjCL4VCVHr97myOB9W3ycGpMzv1v5ReERQPqd68oEcxo3jnYAa9R2lyTr8Qk1FeWNPGDgWH7H3Wix7H5YBi+R+l;
-        Expires=Tue, 03 May 2022 05:03:07 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=CYdEIOLvD2MMToevW2FssNQM81IESYv+xJFeE8zXrC/HRUCTFWVz8uzs5GXqZVPmN/i9Xj76nfLzuixn3WNLzRzfSzv9WCZuS16D5kYFtvJ6VaoSvtlZ9cdqbOjG;
+        Expires=Wed, 04 May 2022 06:19:13 GMT; Path=/
+      - AWSALBCORS=CYdEIOLvD2MMToevW2FssNQM81IESYv+xJFeE8zXrC/HRUCTFWVz8uzs5GXqZVPmN/i9Xj76nfLzuixn3WNLzRzfSzv9WCZuS16D5kYFtvJ6VaoSvtlZ9cdqbOjG;
+        Expires=Wed, 04 May 2022 06:19:13 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB83ae63c1b75583fb6f2561717f1edf55
+      - NB9e7f24717d5f567fceb0427a5e726526
       Pragma:
       - no-cache
       Cache-Control:
@@ -1366,11 +1350,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - cPCD-r0w3MDSTTr8qWCDgZz_XE5oquAI_fcJKVg5ynE042ZiiIABWQ==
+      - JxAfrScYX67MTBUAOoXjMzpXq3pO26UZtpt1VTPWP63y4BzITXMqXQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -1454,7 +1438,7 @@ http_interactions:
               },
               "ManagementEntity": null,
               "ManagementMode": "Intersight",
-              "ModTime": "2022-04-26T05:02:29.61Z",
+              "ModTime": "2022-04-27T06:18:30.57Z",
               "Model": "UCS-FI-6454",
               "Moid": "614ce2a16176752d35a7ec96",
               "NetworkFcZoneInfo": null,
@@ -1670,7 +1654,7 @@ http_interactions:
               },
               "ManagementEntity": null,
               "ManagementMode": "Intersight",
-              "ModTime": "2022-04-26T05:03:05.271Z",
+              "ModTime": "2022-04-27T06:19:06.133Z",
               "Model": "UCS-FI-6454",
               "Moid": "614ce2a36176752d35a7edbd",
               "NetworkFcZoneInfo": null,
@@ -1812,7 +1796,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:07 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:13 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/equipment/Chasses
@@ -1828,9 +1812,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHfh7ekZXvdGXnxRgomBY/E83CVXXEUiEJKH+VqA5HqqAiEAyQMDkwTfMGgk58Xe4usu45AI/LBBw+Dicwlq4v/k72A="
+        host date digest",signature="MEUCIQC2ewUJhQp203Jo0JlhcH7/a1eDyijQUNMbBunaqORVqwIgYgJj25gNXSOGB0w2/wQyS1F+/ChChFBLWL5ziv1cY+E="
       Date:
-      - Tue, 26 Apr 2022 05:03:07 GMT
+      - Wed, 27 Apr 2022 06:19:13 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -1843,16 +1827,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:07 GMT
+      - Wed, 27 Apr 2022 06:19:13 GMT
       Set-Cookie:
-      - AWSALB=6DcpBOA8wSITxn37DUisSTPbY670cYET0cBS43ISIZzJ+sMfJxAkafpgjLF7SkDGUV3n4G8FLZyyIa9arbsU8u1kLaRMoAA81MMdPzAdioFXMFBfsmUnkxefRYUn;
-        Expires=Tue, 03 May 2022 05:03:07 GMT; Path=/
-      - AWSALBCORS=6DcpBOA8wSITxn37DUisSTPbY670cYET0cBS43ISIZzJ+sMfJxAkafpgjLF7SkDGUV3n4G8FLZyyIa9arbsU8u1kLaRMoAA81MMdPzAdioFXMFBfsmUnkxefRYUn;
-        Expires=Tue, 03 May 2022 05:03:07 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=Jv0pZiz77q3aQsJle5ruM42NK9eZ4ldeAxgcYlQerDPmqdx+cR1UQ85MQ0xfzy1V4XTtlmFn7D0F+YI+y/TFKn9S+DEmChxJUD8zmFJv2/UzoOhbytLaAUJZq9Nz;
+        Expires=Wed, 04 May 2022 06:19:13 GMT; Path=/
+      - AWSALBCORS=Jv0pZiz77q3aQsJle5ruM42NK9eZ4ldeAxgcYlQerDPmqdx+cR1UQ85MQ0xfzy1V4XTtlmFn7D0F+YI+y/TFKn9S+DEmChxJUD8zmFJv2/UzoOhbytLaAUJZq9Nz;
+        Expires=Wed, 04 May 2022 06:19:13 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4b0cd8b1ae89152ec3bbe79d5e5d66bf
+      - NBd3f6de64bcd08be217421c9bb971bf7d
       Pragma:
       - no-cache
       Cache-Control:
@@ -1882,11 +1866,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - NLMqIbGItjAxhFu1M1eVsdQsOgFn5fRxZXXdoYp1_UFOz00We3k8bg==
+      - r3K1pkeEE5hse5yeQIbH8U4ObTaUPLZFpm9bLjlhjGg_AYKRYFE4PA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -2109,7 +2093,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:07 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:13 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/asset/DeviceRegistrations/620574346f72612d33f2d664
@@ -2125,9 +2109,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCrhQszWxgbb6pWF1Ei0aGjlCvtZMjzcjwWUHVBowGlGAIhALgLrzTqcbv1AXqbXClQ63choc1/fKPKZxCKQEXCyAtZ"
+        host date digest",signature="MEUCIQCQCpP0AbCYckhWaLxdnZYpPN7mkyMjyPneU+Avd59otAIgZZ5HAcuCtn7BWeezgP2gkE0bRok0KGpFftNIWk1Rjwc="
       Date:
-      - Tue, 26 Apr 2022 05:03:07 GMT
+      - Wed, 27 Apr 2022 06:19:13 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -2140,16 +2124,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:08 GMT
+      - Wed, 27 Apr 2022 06:19:14 GMT
       Set-Cookie:
-      - AWSALB=OyQEWxrwHU4ibgVDwMy0PTXmcI+7uhA6WADTbJS8Tad4Ehg2Bi5676ZQ5cxpFS2Q34CfDBOw7Vh4WsV6xQbt89BI5lAsaLeF5Zn9q+90EwWk6g9kBnRrj9jTOqAm;
-        Expires=Tue, 03 May 2022 05:03:08 GMT; Path=/
-      - AWSALBCORS=OyQEWxrwHU4ibgVDwMy0PTXmcI+7uhA6WADTbJS8Tad4Ehg2Bi5676ZQ5cxpFS2Q34CfDBOw7Vh4WsV6xQbt89BI5lAsaLeF5Zn9q+90EwWk6g9kBnRrj9jTOqAm;
-        Expires=Tue, 03 May 2022 05:03:08 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=jw/k+PCTe6PWFnvXVKRkXiY4cTI0zj2cddSlw9LZFKVyGmyh+p/ctki/45lOIoA1LUVKaUuSpC1Lc6ipnIyGC6UIZzWhn9hN/svLoXuscO3iYIL4tK9x3Q40QwBV;
+        Expires=Wed, 04 May 2022 06:19:13 GMT; Path=/
+      - AWSALBCORS=jw/k+PCTe6PWFnvXVKRkXiY4cTI0zj2cddSlw9LZFKVyGmyh+p/ctki/45lOIoA1LUVKaUuSpC1Lc6ipnIyGC6UIZzWhn9hN/svLoXuscO3iYIL4tK9x3Q40QwBV;
+        Expires=Wed, 04 May 2022 06:19:13 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb85718201ff700298e1fdfdbcd5aebd1
+      - NBeb13505c764ec04edcc866071331add0
       Pragma:
       - no-cache
       Cache-Control:
@@ -2179,11 +2163,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - I3vY3QkLES2zJ6h1Zj0Y-E5STJcdqTFkYdUaGVutuCjOP0E2CaCjSw==
+      - ciN0rx4f9IPckWk8abYaaOHNAp1j1uto2WQWJ7Zi_qcNhhWDbEMUmw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -2297,7 +2281,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:08 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:14 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/6205743e6176752d366ee76e
@@ -2313,9 +2297,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCH2IFnWjeM4qUM1YOgRVmQnfPrCsoIx1o5sSuWy9rzm0CIQDbcE1qUqpLzMZ6R1a4iJMtoGW5/XNZRQxRdu3ND6bGHA=="
+        host date digest",signature="MEUCIB6LTbl3xbAOJdNpcjb22gdsceiIeHWzDOLNOkKNo2xOAiEAkr/SykbqZ3Arj2pZC5Lrewb7tmoT17sH2rE4ceaYJ8c="
       Date:
-      - Tue, 26 Apr 2022 05:03:08 GMT
+      - Wed, 27 Apr 2022 06:19:14 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -2328,16 +2312,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:08 GMT
+      - Wed, 27 Apr 2022 06:19:14 GMT
       Set-Cookie:
-      - AWSALB=jWvuJuDZGkmevmjArxQRepZw4SETUChHzk3iGJqvACH56RpCiLsgHRAnFirX4fPRSIhRrYjL98z3YzBnoikujryyIbDqsxB/BlWBPqpdQrtea7JB70q+2aA62zbI;
-        Expires=Tue, 03 May 2022 05:03:08 GMT; Path=/
-      - AWSALBCORS=jWvuJuDZGkmevmjArxQRepZw4SETUChHzk3iGJqvACH56RpCiLsgHRAnFirX4fPRSIhRrYjL98z3YzBnoikujryyIbDqsxB/BlWBPqpdQrtea7JB70q+2aA62zbI;
-        Expires=Tue, 03 May 2022 05:03:08 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ZoCrs02vDUYb9MCX+yA4mIbrgrrcMB/w5VhUCQcWP8HkogLEJhLbVdWe592HuwpJNNyyUEChjECyNB83K6zyHJWyYHSrsUyG7/MgdQ1ra+Au9V1Io7VLMV/hbnKi;
+        Expires=Wed, 04 May 2022 06:19:14 GMT; Path=/
+      - AWSALBCORS=ZoCrs02vDUYb9MCX+yA4mIbrgrrcMB/w5VhUCQcWP8HkogLEJhLbVdWe592HuwpJNNyyUEChjECyNB83K6zyHJWyYHSrsUyG7/MgdQ1ra+Au9V1Io7VLMV/hbnKi;
+        Expires=Wed, 04 May 2022 06:19:14 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc83f1db4fde7d5ad7c1aed26ed852439
+      - NB7b072828026ed9d0575479384557b87a
       Pragma:
       - no-cache
       Cache-Control:
@@ -2367,11 +2351,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - xyU3dsaScMSauYJqqvzwu1dgWgIpiPjW7FKvwBTL1D_CXfIszZd7zQ==
+      - sUpZPSMcsetzoI4eZyUVmZuqHQicBnsNtYpUqCYTiRc7XPVgNhYAKQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -2599,7 +2583,7 @@ http_interactions:
           }
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:08 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:14 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/asset/DeviceContractInformations
@@ -2615,9 +2599,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCICWTdhiylRR34MoPvQc0RjAMnpvnEKvbK6KfplGQlhVmAiAA6eEZh6drnPZ/RZpima0Et9j7hhtgDnnwKFaRt9Ls6Q=="
+        host date digest",signature="MEUCIDvOmtQwq29MOxfesBK70dGVO04vVLFfY6wftTi4hpQnAiEAybzcVaY75ClUITygeTHm1tt8PSUvey0MPXyvjBCPbHU="
       Date:
-      - Tue, 26 Apr 2022 05:03:08 GMT
+      - Wed, 27 Apr 2022 06:19:14 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -2630,16 +2614,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:09 GMT
+      - Wed, 27 Apr 2022 06:19:14 GMT
       Set-Cookie:
-      - AWSALB=44WP4IamNw/OSrX9z5EVksmHM5BbQknEhZuittOK1lvNTGO0WaE/sXoiRCFMvE1hcw9E40CnoSE7n5LyOjn+jkOPBPC3vpu6XcQ7xLw89+U2gXq2xM7hJ15YGGJ6;
-        Expires=Tue, 03 May 2022 05:03:09 GMT; Path=/
-      - AWSALBCORS=44WP4IamNw/OSrX9z5EVksmHM5BbQknEhZuittOK1lvNTGO0WaE/sXoiRCFMvE1hcw9E40CnoSE7n5LyOjn+jkOPBPC3vpu6XcQ7xLw89+U2gXq2xM7hJ15YGGJ6;
-        Expires=Tue, 03 May 2022 05:03:09 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=A+qtaq263btr7qcEuoo8W/ad9MBYJyojqCpLTM6P15c7M3WKL12/9+i8Yd+z2V36xbSnuuUjlMRDQ3SCOZFz5yV8ZzjWn+Dz7HVWd3UdkOuAkzVjiXkjFUI4zniS;
+        Expires=Wed, 04 May 2022 06:19:14 GMT; Path=/
+      - AWSALBCORS=A+qtaq263btr7qcEuoo8W/ad9MBYJyojqCpLTM6P15c7M3WKL12/9+i8Yd+z2V36xbSnuuUjlMRDQ3SCOZFz5yV8ZzjWn+Dz7HVWd3UdkOuAkzVjiXkjFUI4zniS;
+        Expires=Wed, 04 May 2022 06:19:14 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd6a16c64c2ebecdce4123b820cde78f3
+      - NBeea6a8fbbcc9d290f16a581c83269288
       Pragma:
       - no-cache
       Cache-Control:
@@ -2669,11 +2653,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - "-hkxO5wJKNT8vz1Y-nqDgiMiOrU9dZ8KmLcfRH5ZZhiHxW7LjafPLg=="
+      - mBkfGIlfTg5uofEc4rqqiNSnpxQ_wzujoP5twFG6HlJghN3YptXa1g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -2714,7 +2698,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 0,
-              "ContractUpdatedTime": "2022-04-25T19:34:18.844Z",
+              "ContractUpdatedTime": "2022-04-26T19:14:20.539Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2021-09-23T20:25:04.245Z",
               "DeviceId": "FDO2441072Q",
@@ -2751,7 +2735,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T19:34:19.654Z",
+              "ModTime": "2022-04-26T19:14:21.375Z",
               "Moid": "614ce2a06265722d300a2fba",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -2877,7 +2861,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 0,
-              "ContractUpdatedTime": "2022-04-25T19:34:18.844Z",
+              "ContractUpdatedTime": "2022-04-26T19:14:20.539Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2021-09-23T20:25:04.258Z",
               "DeviceId": "FDO244106VJ",
@@ -2914,7 +2898,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T19:34:19.651Z",
+              "ModTime": "2022-04-26T19:14:21.373Z",
               "Moid": "614ce2a06265722d300a2fbd",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -3040,7 +3024,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 0,
-              "ContractUpdatedTime": "2022-04-25T19:14:17.174Z",
+              "ContractUpdatedTime": "2022-04-26T18:54:20.602Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2021-09-23T21:02:49.27Z",
               "DeviceId": "FOX2510P5HJ",
@@ -3077,7 +3061,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T19:14:17.694Z",
+              "ModTime": "2022-04-26T18:54:21.76Z",
               "Moid": "614ceb796265722d300ba340",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -3203,7 +3187,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 1,
-              "ContractUpdatedTime": "2022-04-25T05:54:16.862Z",
+              "ContractUpdatedTime": "2022-04-27T05:14:03.802Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2022-02-10T20:23:16.499Z",
               "DeviceId": "FCH25057ANX",
@@ -3240,7 +3224,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T05:54:18.154Z",
+              "ModTime": "2022-04-27T05:14:04.85Z",
               "Moid": "620574346265722d307aad85",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -3367,7 +3351,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 0,
-              "ContractUpdatedTime": "2022-04-25T09:04:40.938Z",
+              "ContractUpdatedTime": "2022-04-26T08:44:54.36Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2022-04-12T14:37:29.703Z",
               "DeviceId": "FCH250671HR",
@@ -3404,7 +3388,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T09:04:41.842Z",
+              "ModTime": "2022-04-26T08:44:54.478Z",
               "Moid": "62558ea96265722d30dbc05b",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -3531,7 +3515,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 0,
-              "ContractUpdatedTime": "2022-04-25T16:36:56.693Z",
+              "ContractUpdatedTime": "2022-04-26T16:24:20.957Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2022-04-25T16:36:41.966Z",
               "DeviceId": "FCH250671KU",
@@ -3568,7 +3552,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T16:36:56.714Z",
+              "ModTime": "2022-04-26T16:24:22.247Z",
               "Moid": "6266ce196265722d30834541",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -3664,7 +3648,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:09 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:14 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/equipment/LocatorLeds/62057dfe6176752d36708b2a
@@ -3680,9 +3664,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDbIU8ilDlJUTtSCDvCCZJzcES72+mRKW/tY4txSwqJ8wIhAJahpNyMwf6E7jhoJU8COlt+AQIQMKFYrtAnEoOViSmC"
+        host date digest",signature="MEQCID+eiJc1vDuNbsyRCDicwEhiuEQEafdeWso2itcXpqfaAiAEz4HgEm4Z8ovFG8pGeTEp0p9UqGvx04dvokpewZdRgA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:09 GMT
+      - Wed, 27 Apr 2022 06:19:14 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -3695,16 +3679,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:09 GMT
+      - Wed, 27 Apr 2022 06:19:14 GMT
       Set-Cookie:
-      - AWSALB=sh+yidXcRNSUa+o/eJYOn1tNfSWc0tcC2uO7xQvB41pl1mAKniW+d5ID7jPEmLrOWoha3w4YjkDKQLU7vIKC+2y1GhAZjUU9timilkSY4qUJtK83Q2fsOnwwauW2;
-        Expires=Tue, 03 May 2022 05:03:09 GMT; Path=/
-      - AWSALBCORS=sh+yidXcRNSUa+o/eJYOn1tNfSWc0tcC2uO7xQvB41pl1mAKniW+d5ID7jPEmLrOWoha3w4YjkDKQLU7vIKC+2y1GhAZjUU9timilkSY4qUJtK83Q2fsOnwwauW2;
-        Expires=Tue, 03 May 2022 05:03:09 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=RJyRw/S4HH0kswI0e4gDmnGUv7+fyjkzFqOdoI7EsC/Ev2aV5ecc2GnAwZQ0Au5UfhpyXMT+FaCa0dSLwQLwdVli7ocvEf/N4p1K2TEpU0b5NvH1JlTMdxWIfjqo;
+        Expires=Wed, 04 May 2022 06:19:14 GMT; Path=/
+      - AWSALBCORS=RJyRw/S4HH0kswI0e4gDmnGUv7+fyjkzFqOdoI7EsC/Ev2aV5ecc2GnAwZQ0Au5UfhpyXMT+FaCa0dSLwQLwdVli7ocvEf/N4p1K2TEpU0b5NvH1JlTMdxWIfjqo;
+        Expires=Wed, 04 May 2022 06:19:14 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB7bad02bbedf9c77dbcf5ee2774692b82
+      - NB3f253806ee0678b244f01b1fd0749a2e
       Pragma:
       - no-cache
       Cache-Control:
@@ -3734,11 +3718,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 4ob34iISM90pRcySrNOxUb8qaaz0UlhGZ4Abz29UAfdEhMDWl6kw4w==
+      - 6nLfx6rUM2Vf-Qnxg1hmaccNailOJajvRDQ2WE9hx9mLrHxYINsF4g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -3815,7 +3799,7 @@ http_interactions:
           "Tags": []
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:09 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:15 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/6205743e6176752d366ee76e
@@ -3831,9 +3815,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIHCgMTaOQA+Sd+dbeS9l6khQOI2Zhmvh3h3GuUGmWY91AiAKREXRRB9i3tcnYmbL03v8xrSa6oFB+YaNyxm+r1DsAA=="
+        host date digest",signature="MEUCIGlU6g4M5W9rNwuMJSYtAeb+okFlxIMc8ZiaKxn0lOs1AiEAyTIKGVdOj0jEPhd3ijWUy8thYz+3BL6ePRnf/TnuCHU="
       Date:
-      - Tue, 26 Apr 2022 05:03:09 GMT
+      - Wed, 27 Apr 2022 06:19:15 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -3846,16 +3830,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:09 GMT
+      - Wed, 27 Apr 2022 06:19:15 GMT
       Set-Cookie:
-      - AWSALB=WsMx1f9sGzQKZ+Xb2s+FTC4vIaUcO4QobG9Ho8HIiHVrJ7OSXWSY/3DjxQeZvV+gFvngPFhZgq4TGmCCmLyZP8aNrbE9HGwISd4mE/6YPr9L6n0RgZ1cjGtlZB7O;
-        Expires=Tue, 03 May 2022 05:03:09 GMT; Path=/
-      - AWSALBCORS=WsMx1f9sGzQKZ+Xb2s+FTC4vIaUcO4QobG9Ho8HIiHVrJ7OSXWSY/3DjxQeZvV+gFvngPFhZgq4TGmCCmLyZP8aNrbE9HGwISd4mE/6YPr9L6n0RgZ1cjGtlZB7O;
-        Expires=Tue, 03 May 2022 05:03:09 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=aKa9l03ov/Sv9fvvPwSPW3eimUf5hg7OhkNinv20O6mU14/PDiHE6/068Fbw4yPFYVEHtub9JTVJbbtnRZtsaMRgezL3q5g+Q9rgKHG4c0r7+ahym0n36XzO9pej;
+        Expires=Wed, 04 May 2022 06:19:15 GMT; Path=/
+      - AWSALBCORS=aKa9l03ov/Sv9fvvPwSPW3eimUf5hg7OhkNinv20O6mU14/PDiHE6/068Fbw4yPFYVEHtub9JTVJbbtnRZtsaMRgezL3q5g+Q9rgKHG4c0r7+ahym0n36XzO9pej;
+        Expires=Wed, 04 May 2022 06:19:15 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe3c14a4d02b43431387cacbe99c822bb
+      - NB76fc30dec43a222189295117e403a6ba
       Pragma:
       - no-cache
       Cache-Control:
@@ -3885,11 +3869,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - lCqe3SluRIzynBavTUEUujTW-CZIFZohM9Sn4vOZJSUTU8rQVVcjvw==
+      - nNqklrJGM1VJlqP_3V0Sqp-qtMVUOvET0OgR7UIiPS0SDNu4ablxsA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -4117,7 +4101,7 @@ http_interactions:
           }
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:09 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:15 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Boards/620587946176752d3672361d
@@ -4133,9 +4117,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDqBjDZZ1ZK7C4ic92LsIRbbvQqcZBhpmvzK/Q1lT1cFgIhAKwrYh4yKzaO7pLRQFCTmGeaaDo7koB1s6NgaGSK1D04"
+        host date digest",signature="MEUCIQCFers0sZXSuoODmrjsxG37mIonnGH/KfPKeRgYW4W99wIgXH/YjQzqMcxwPpcTWA3sIb5ddvA0wpsHqkDOP7cHb5U="
       Date:
-      - Tue, 26 Apr 2022 05:03:09 GMT
+      - Wed, 27 Apr 2022 06:19:15 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -4148,16 +4132,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:10 GMT
+      - Wed, 27 Apr 2022 06:19:15 GMT
       Set-Cookie:
-      - AWSALB=fO4tz4eNiPc50dCjlCEXqTJAXbvhs8KfSRjbz4p4mfgVCP+OTooUagnsdyvpcUuVDM3kv8vD7wTqtYnkAOzI2hT/TFBLM6D6waPnMuGbxeKGymgPEr5vJD7wDcfY;
-        Expires=Tue, 03 May 2022 05:03:10 GMT; Path=/
-      - AWSALBCORS=fO4tz4eNiPc50dCjlCEXqTJAXbvhs8KfSRjbz4p4mfgVCP+OTooUagnsdyvpcUuVDM3kv8vD7wTqtYnkAOzI2hT/TFBLM6D6waPnMuGbxeKGymgPEr5vJD7wDcfY;
-        Expires=Tue, 03 May 2022 05:03:10 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=acDiDrqz9IBvmciAOyynWXH5JtmVki7s4/OUlrf0djVvW8YkTgWz5FDgIluneXcV/0eK9mxGox8nh0aVREm7rGuFaInAZACuAKXpfrFJvoY699YvgYL/cxB68Fo1;
+        Expires=Wed, 04 May 2022 06:19:15 GMT; Path=/
+      - AWSALBCORS=acDiDrqz9IBvmciAOyynWXH5JtmVki7s4/OUlrf0djVvW8YkTgWz5FDgIluneXcV/0eK9mxGox8nh0aVREm7rGuFaInAZACuAKXpfrFJvoY699YvgYL/cxB68Fo1;
+        Expires=Wed, 04 May 2022 06:19:15 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb80852d8472ae5dadbe1fd0eb075d62d
+      - NBee58cc8baab8cbad1a1cb3b4331ddd3b
       Pragma:
       - no-cache
       Cache-Control:
@@ -4187,11 +4171,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Nal839ZC7DcpbRAearPaAkNWBm0N3Powa9ZhP6cKzoH-Hdu0jwYVdg==
+      - 5p6aATS-rOzX3Ub_OHeLGUVSuFYIrDjMFX2PAoyBZ7-V3SINEucAyQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -4319,7 +4303,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:10 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:15 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/adapter/Units/620587956176752d3672375f
@@ -4335,9 +4319,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDN1sxOvA5cfO8pd4yYG8qA0zfXWX2Adfw2UMUPitoaUwIhAIBnpwn8CpZay0OOUKF5CvH5xgVmf6RjoBxQ1a3ViP++"
+        host date digest",signature="MEQCIF/PGcwNoMTqba3uA1vGSVx5YcqO37xnHG7BIKkqiqysAiB4El02EWRHQGR7W4uNar+oRGwoB9II1C+vjj3AYTx8Dg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:10 GMT
+      - Wed, 27 Apr 2022 06:19:15 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -4350,16 +4334,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:10 GMT
+      - Wed, 27 Apr 2022 06:19:16 GMT
       Set-Cookie:
-      - AWSALB=kR8uB5BKmepCMu2WK9iC15briBwG7jwFWehVoG41A1vWaortZHo7jzzSLf7U8MlT4x3cYMAPpTlz7LNSqjQo9imxdkwiFxMbho35JdkTRbxNpSvQzla815mPpV3f;
-        Expires=Tue, 03 May 2022 05:03:10 GMT; Path=/
-      - AWSALBCORS=kR8uB5BKmepCMu2WK9iC15briBwG7jwFWehVoG41A1vWaortZHo7jzzSLf7U8MlT4x3cYMAPpTlz7LNSqjQo9imxdkwiFxMbho35JdkTRbxNpSvQzla815mPpV3f;
-        Expires=Tue, 03 May 2022 05:03:10 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=YQw5M66HbKaSt67DqDXB4Xp/nMQgLkgTbpQqXgK41C24/Z3xzdx9u9au74JRUGbqedp5rKw87WPTX673ebXn0JNMsFpiCKvRRE2Qf6iPfDX6YNlCl4YH88WvMmLL;
+        Expires=Wed, 04 May 2022 06:19:16 GMT; Path=/
+      - AWSALBCORS=YQw5M66HbKaSt67DqDXB4Xp/nMQgLkgTbpQqXgK41C24/Z3xzdx9u9au74JRUGbqedp5rKw87WPTX673ebXn0JNMsFpiCKvRRE2Qf6iPfDX6YNlCl4YH88WvMmLL;
+        Expires=Wed, 04 May 2022 06:19:16 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB481c357f52111b034753271871f7e104
+      - NBb6c33a10288e9bc81be2eec3ddeacaa8
       Pragma:
       - no-cache
       Cache-Control:
@@ -4389,11 +4373,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - vLfw1uqdUC1DuRFUnMh7daTnRp1EUthuMpuTSp6ue49k4eTWb0wSqg==
+      - Q-ynXaUstcux4Hn720YwltWaJWpj7VBCkzfbsiB7fWkwboE1u0OjyQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -4539,7 +4523,7 @@ http_interactions:
           "Vid": ""
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:10 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:16 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/asset/DeviceRegistrations/62558ea96f72612d33c6b0c9
@@ -4555,9 +4539,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHLZPvrrFottnIRtnJ0J+8YaRuR6KffqSl9yZ4l3uo6UAiEA/nEtCiK1THXsTKOSScdF+shSzStRideACUjRkjeoC0M="
+        host date digest",signature="MEUCIQCI13+O7PYzYsiVvquChi3rNVIHIsa5/V9dxBs1mZjp6AIgbHCxqb6wFhRSHWz2VaL2w49NsbOmEtWbiRkj6WHsmOU="
       Date:
-      - Tue, 26 Apr 2022 05:03:10 GMT
+      - Wed, 27 Apr 2022 06:19:16 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -4570,16 +4554,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:11 GMT
+      - Wed, 27 Apr 2022 06:19:16 GMT
       Set-Cookie:
-      - AWSALB=2HIQG7u9yidGgSIROXeS5lYGP0jQjeixKgvcZskdQI5U6qtfho5/GlWLyXuR94DP7LSUZROR7ewLnUzD9NKIp+2Nu14Bkc11OtxhzKl+THMDw5S7coYPTgmSH2tv;
-        Expires=Tue, 03 May 2022 05:03:11 GMT; Path=/
-      - AWSALBCORS=2HIQG7u9yidGgSIROXeS5lYGP0jQjeixKgvcZskdQI5U6qtfho5/GlWLyXuR94DP7LSUZROR7ewLnUzD9NKIp+2Nu14Bkc11OtxhzKl+THMDw5S7coYPTgmSH2tv;
-        Expires=Tue, 03 May 2022 05:03:11 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=O8oeY+PniNNQ9eletIxjPd9w4pW10N4U8mm9kfBJV/c0AuF+lEnhE5/q2nNB/zLwcuROzfECSJ2gz29gvGW8CSa14XenBrIgLbYYcjqC+DRdm92U2s9y6KklGpgz;
+        Expires=Wed, 04 May 2022 06:19:16 GMT; Path=/
+      - AWSALBCORS=O8oeY+PniNNQ9eletIxjPd9w4pW10N4U8mm9kfBJV/c0AuF+lEnhE5/q2nNB/zLwcuROzfECSJ2gz29gvGW8CSa14XenBrIgLbYYcjqC+DRdm92U2s9y6KklGpgz;
+        Expires=Wed, 04 May 2022 06:19:16 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB970dde8de28ae4cb8014c437991cfff2
+      - NB32da087232390ef0262b34d490f9e0de
       Pragma:
       - no-cache
       Cache-Control:
@@ -4609,11 +4593,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - YPvM0iimEj8CTfOlpMNxPlCrvq_VbqmVJdBYtwgALKjrkIYZVSJekA==
+      - 0f-zJi9nZve0kjlLJKAVNc1guz6jwAlT50KkbKTDvL5yDxuzuPf8-w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -4727,7 +4711,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:11 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:16 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/62558eb26176752d36f43a77
@@ -4743,9 +4727,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIH7TjQDeSLJEOLEXlSxE4SAHTtLaPvjuIFVbk4MGzP47AiEAxG5IXbgdRIULrfMd37P97T3Bh8q3qRXa0N6zt5WJINY="
+        host date digest",signature="MEYCIQD4Fsrjl234NHuqG1HVXE22P6r+k50+pZo33D9q5UD+ggIhANfglOWg2k65NftCvLhOBjwMPLwyNUnZUVFiW2y7BvSk"
       Date:
-      - Tue, 26 Apr 2022 05:03:11 GMT
+      - Wed, 27 Apr 2022 06:19:16 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -4758,16 +4742,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:11 GMT
+      - Wed, 27 Apr 2022 06:19:17 GMT
       Set-Cookie:
-      - AWSALB=9nRMD2A7itDt/7QAhfCkH9g8uTi4xMpvMyqac4R3PxXd+3KMR1m0Dp5hutEdRMdyS+j8uh0tTHEMA+2yuHwSe1FWPxsY5ZDc2wrhuvdLjOIM1BJ1IKIZ0ni6WL5T;
-        Expires=Tue, 03 May 2022 05:03:11 GMT; Path=/
-      - AWSALBCORS=9nRMD2A7itDt/7QAhfCkH9g8uTi4xMpvMyqac4R3PxXd+3KMR1m0Dp5hutEdRMdyS+j8uh0tTHEMA+2yuHwSe1FWPxsY5ZDc2wrhuvdLjOIM1BJ1IKIZ0ni6WL5T;
-        Expires=Tue, 03 May 2022 05:03:11 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=2iSU+dbJn1Fr6w380dVGTwASJwn+gRG4E7dvJqfWwT9yIwQLWcz5P9e7dMZQIM0WrL3KKXhWrGMIiSvYFce1FTt4erMLPhaFk8Maipd4y0fsCPztmL4vMoxy/Rui;
+        Expires=Wed, 04 May 2022 06:19:17 GMT; Path=/
+      - AWSALBCORS=2iSU+dbJn1Fr6w380dVGTwASJwn+gRG4E7dvJqfWwT9yIwQLWcz5P9e7dMZQIM0WrL3KKXhWrGMIiSvYFce1FTt4erMLPhaFk8Maipd4y0fsCPztmL4vMoxy/Rui;
+        Expires=Wed, 04 May 2022 06:19:17 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb402ee693c07420d0f488d072a0e0f56
+      - NBbb459f205b2293c6e92abd3e72b449b2
       Pragma:
       - no-cache
       Cache-Control:
@@ -4797,11 +4781,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - zuYoCM4_-iqVJ1JSzw3L9Je_4iEGEZ5JnbV3Sy09kRzxVGZtRwPtvA==
+      - _Ehv0zwDf_85CXqO-E0-8zho5xfewiU02ReujYTVP2UIokRBK3K1PA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -5018,7 +5002,7 @@ http_interactions:
           "Vmedia": null
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:11 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:17 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/equipment/LocatorLeds/62558eb96176752d36f43d12
@@ -5034,9 +5018,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDsMbar7j+kkFYc5/9p+aapbiyO10zSyb58CsEGxx7UZwIhAIoNlqhrVO3p9euDdR/jUy2MexiNEL0TDHQyJpOPOvFD"
+        host date digest",signature="MEUCIDW5IkrZ61dCf2XpI8AYf6j8uSImqHA0FFrVaxnfAWBDAiEA7sDpmBnezp4WmLyf43EDB1FRlTV2ERD/8eHgk03vVOU="
       Date:
-      - Tue, 26 Apr 2022 05:03:11 GMT
+      - Wed, 27 Apr 2022 06:19:17 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -5049,16 +5033,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:11 GMT
+      - Wed, 27 Apr 2022 06:19:17 GMT
       Set-Cookie:
-      - AWSALB=BVEzVO3mnvjDoKF6McZmJAlKhED9RgHdvckHeMy5rWw9V5gi6Rz9WktlqKLTJo33QPq/mwkO+OBu48JxpCedOYrnkY8tnjx1QhfT4tERUynGk2isWM3wLgUQ7n8B;
-        Expires=Tue, 03 May 2022 05:03:11 GMT; Path=/
-      - AWSALBCORS=BVEzVO3mnvjDoKF6McZmJAlKhED9RgHdvckHeMy5rWw9V5gi6Rz9WktlqKLTJo33QPq/mwkO+OBu48JxpCedOYrnkY8tnjx1QhfT4tERUynGk2isWM3wLgUQ7n8B;
-        Expires=Tue, 03 May 2022 05:03:11 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=0Wo7m9u/KicZ6dLKkT11JXvw1MKRGjm6jAf8ADRlU+Q/wTeJpFtr7anxDiXl7/KGXlZwKY4nUaFJ9nCkoXFCD+uXg8NN2GwVIUYg8A9muYNEWXR6uY3Px6ZN4P7l;
+        Expires=Wed, 04 May 2022 06:19:17 GMT; Path=/
+      - AWSALBCORS=0Wo7m9u/KicZ6dLKkT11JXvw1MKRGjm6jAf8ADRlU+Q/wTeJpFtr7anxDiXl7/KGXlZwKY4nUaFJ9nCkoXFCD+uXg8NN2GwVIUYg8A9muYNEWXR6uY3Px6ZN4P7l;
+        Expires=Wed, 04 May 2022 06:19:17 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB8e2277dfebd7f58e3cebafdd139b59a2
+      - NB5835430b6c88fad1b14e824d606222ce
       Pragma:
       - no-cache
       Cache-Control:
@@ -5088,11 +5072,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ILy6V-QRwV_LsQOhTq3rVgLwAo9u9Dlw0NohIpNjklTNcR9daNYYrg==
+      - copkQ5MS1zAYLq2J2wKkBM9pqszU_o_PfrfaIsjc_W-DxrdKw3ypsQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -5169,7 +5153,7 @@ http_interactions:
           "Tags": []
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:11 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:17 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/62558eb26176752d36f43a77
@@ -5185,9 +5169,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCpwXT86jnSqjO22hkOA5UaLYQqXl+nE4Q5Jjha3kDN/gIhAJ4IZJhob6a3EIv7e8rMx7PbBPhMoiqlYJZ9NbAaADzQ"
+        host date digest",signature="MEUCIAjs9s/ve/ikwpSaNQuipYY9pakDjy9AcXOSM9XIhLN4AiEAxE72z1Tbk2mkIqvqaimTLvwl/j6P1S7MTFhpIiMd790="
       Date:
-      - Tue, 26 Apr 2022 05:03:11 GMT
+      - Wed, 27 Apr 2022 06:19:17 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -5200,16 +5184,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:12 GMT
+      - Wed, 27 Apr 2022 06:19:18 GMT
       Set-Cookie:
-      - AWSALB=5O91ajFb0TTA3HbWhep75m406sSxKWzvlOv+CFv+D7NtlHdSZXyIOp7+bv63WrWqCI53XyU7QR0N9Dwg8NJvPjzvJ6yanslE9oU8keIQCcmkJEDVmUwdKZdHyD51;
-        Expires=Tue, 03 May 2022 05:03:12 GMT; Path=/
-      - AWSALBCORS=5O91ajFb0TTA3HbWhep75m406sSxKWzvlOv+CFv+D7NtlHdSZXyIOp7+bv63WrWqCI53XyU7QR0N9Dwg8NJvPjzvJ6yanslE9oU8keIQCcmkJEDVmUwdKZdHyD51;
-        Expires=Tue, 03 May 2022 05:03:12 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ma2YIr4FcxRPEvyMRD6dIz0Ilqd+GA9fu/pzOzzKTyyCHbXYAGDAN8lPOvDPfZelMFyM1oFWtkiODGpTcSb0PrTW5SVMmAPy15DyAADZFejlTqAQottl1ndOz6QX;
+        Expires=Wed, 04 May 2022 06:19:18 GMT; Path=/
+      - AWSALBCORS=ma2YIr4FcxRPEvyMRD6dIz0Ilqd+GA9fu/pzOzzKTyyCHbXYAGDAN8lPOvDPfZelMFyM1oFWtkiODGpTcSb0PrTW5SVMmAPy15DyAADZFejlTqAQottl1ndOz6QX;
+        Expires=Wed, 04 May 2022 06:19:18 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc9976ba38688e11872c8461a0e41c2ca
+      - NBd81ea2c44a03af2c1744f602f81135d9
       Pragma:
       - no-cache
       Cache-Control:
@@ -5239,11 +5223,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 0pJXZWt9gme0ZONpYXVdcVj9cf1xsLPSqoR5DD6Zp2aN1QNq4tRZcg==
+      - 8BD1Bg0uZIhy0eMskC7Vsxn9cD89wbko4-FHyU2y2lJiLBjI9em0pQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -5460,7 +5444,7 @@ http_interactions:
           "Vmedia": null
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:12 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:18 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Boards/625590a56176752d36f4c0a8
@@ -5476,9 +5460,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQC6Srg5cs3nUfD6n2nzSq7YmY+Z2FD2ANybyGMvCbQC9QIgYvpFY7hdoyWFiPoeTpfb1peg1Xwg7KnGflZ/8OXC3+0="
+        host date digest",signature="MEQCIH7PeqN+rMrfTLZwLlETuW53+7aGrT7l5Qet9nUygRErAiAcH9oEKzlzGSI57hFvjuA4iOscBhpSB6iIWYj9OQ9xcw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:12 GMT
+      - Wed, 27 Apr 2022 06:19:18 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -5491,16 +5475,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:12 GMT
+      - Wed, 27 Apr 2022 06:19:18 GMT
       Set-Cookie:
-      - AWSALB=w56d+GyIKGlfA3T2lU0+WdNmHX/VWlD4QTu+u/xO5PvsWlF4y2JdHH6NR1W8UVCopTGW3wi+S/HAuKYdVKl8DdprjrU/ZBaN8pU/+CDCWAScFh182vfeGaLpTt3W;
-        Expires=Tue, 03 May 2022 05:03:12 GMT; Path=/
-      - AWSALBCORS=w56d+GyIKGlfA3T2lU0+WdNmHX/VWlD4QTu+u/xO5PvsWlF4y2JdHH6NR1W8UVCopTGW3wi+S/HAuKYdVKl8DdprjrU/ZBaN8pU/+CDCWAScFh182vfeGaLpTt3W;
-        Expires=Tue, 03 May 2022 05:03:12 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=eIIl/I7aRxK9Iy3+1+vJfjhtoqcORNRFFnbMLRsAfECXJtXGL9LGN8DomZ/IkbY02NGMyPNuERz5tP0TOeWAO6jH8oWTUre2OioI8KlGuFNcJEQYityP+TJ6V2sd;
+        Expires=Wed, 04 May 2022 06:19:18 GMT; Path=/
+      - AWSALBCORS=eIIl/I7aRxK9Iy3+1+vJfjhtoqcORNRFFnbMLRsAfECXJtXGL9LGN8DomZ/IkbY02NGMyPNuERz5tP0TOeWAO6jH8oWTUre2OioI8KlGuFNcJEQYityP+TJ6V2sd;
+        Expires=Wed, 04 May 2022 06:19:18 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB12f98aaed2a8c5d814185e799b710742
+      - NB607a1eeb0d3d6f19952a4dd168d89bfd
       Pragma:
       - no-cache
       Cache-Control:
@@ -5530,11 +5514,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - alLhsBe7epG0MRuC43-kNpcIBbtG6ukx5vVr0kowSYGzVix69GXxLA==
+      - ElSyCBuq1lxxYqNYdS8cHCGu5FyUyRdJcdR00Y7qx7aRsi4bOpt7lg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -5662,7 +5646,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:12 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:18 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/adapter/Units/625590a66176752d36f4c1ce
@@ -5678,9 +5662,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDPhFl+TnJ1ubbynoNcdRf0JVsvE+sqMyVWEpl9PlI3/wIgMvoMe8F2eAQY/7WIRxZyrTXj75G5WbfPjV9Z2SkgU1s="
+        host date digest",signature="MEUCIGKLwr0Z8rJuPS+Dolje+R/PhLPRU6aAnBeqoTxcXTKNAiEA1CQTassGsA6xGYaw0VnblU6XxAQBnbRXJD6IrUPE+aI="
       Date:
-      - Tue, 26 Apr 2022 05:03:12 GMT
+      - Wed, 27 Apr 2022 06:19:18 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -5693,16 +5677,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:13 GMT
+      - Wed, 27 Apr 2022 06:19:18 GMT
       Set-Cookie:
-      - AWSALB=lOIMjv3+C5zNEGxspwJekFjnKgq5byDK23WfwQSJGY20BGUiAkCDw69ghX/uGwJV1yrg+R04D93GFILgXJm+3V5dT3q+FErVa8GE6cFe3d9ktzMQvb8rKzI4rMkb;
-        Expires=Tue, 03 May 2022 05:03:13 GMT; Path=/
-      - AWSALBCORS=lOIMjv3+C5zNEGxspwJekFjnKgq5byDK23WfwQSJGY20BGUiAkCDw69ghX/uGwJV1yrg+R04D93GFILgXJm+3V5dT3q+FErVa8GE6cFe3d9ktzMQvb8rKzI4rMkb;
-        Expires=Tue, 03 May 2022 05:03:13 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ZCz8HzERuwgVZw2h0SKni04DWAw/5e4XEWwC5yIgA+caKJoy9gZ5w0IP9/J1DESA0SXYsjOcF/DxvZsY2GdQVYu+afrf/vLkCCaiBDK8xvknOCGa3m4bBW2fR7tX;
+        Expires=Wed, 04 May 2022 06:19:18 GMT; Path=/
+      - AWSALBCORS=ZCz8HzERuwgVZw2h0SKni04DWAw/5e4XEWwC5yIgA+caKJoy9gZ5w0IP9/J1DESA0SXYsjOcF/DxvZsY2GdQVYu+afrf/vLkCCaiBDK8xvknOCGa3m4bBW2fR7tX;
+        Expires=Wed, 04 May 2022 06:19:18 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBead00ce5c37643bfea1b98c73cc9d031
+      - NB55b305fa9766550dfe2b4770400f36e9
       Pragma:
       - no-cache
       Cache-Control:
@@ -5732,11 +5716,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - uDjNKphyaD4v8U6AA_55wvEpr3BwdEByjHnK2QNi7nH7CaIZquSUog==
+      - jlCF-Rl-wRyPLLnEIKoxp1PuwfW-FRe4UIGkEZjql53DVtZV8JyuiQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -5882,7 +5866,7 @@ http_interactions:
           "Vid": ""
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:13 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:18 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/asset/DeviceRegistrations/6266ce196f72612d33dfcc93
@@ -5898,9 +5882,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCaJfZ4V/5EcLEjM2EPefWBwmNic1DlePjD9PZ7J+t8GQIhAODnutsuimIc3HFOqy+C/B2XH1nU5hWDdGdzQzY+aO6I"
+        host date digest",signature="MEYCIQD6E/kJeOQGNiSHjRwwd9H5Z8fYU7y6niSBlrxGzyPUEgIhALux/IJ2wN+dJq7qrhhBHul0AYRFfyF0p8/IW1cHNYpf"
       Date:
-      - Tue, 26 Apr 2022 05:03:13 GMT
+      - Wed, 27 Apr 2022 06:19:18 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -5913,16 +5897,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:13 GMT
+      - Wed, 27 Apr 2022 06:19:18 GMT
       Set-Cookie:
-      - AWSALB=5blc70rWfi8mo6UdSP9ReD2JrTMGXdKp/Et2r4oiTd7/hPEOHuR32+EO6JoZKMonvwjZOJyoC2Cb4Q2Qh0coCZO6uObDQF8iC+xCEO/RhuBpo91P4O0jSif0c4Q2;
-        Expires=Tue, 03 May 2022 05:03:13 GMT; Path=/
-      - AWSALBCORS=5blc70rWfi8mo6UdSP9ReD2JrTMGXdKp/Et2r4oiTd7/hPEOHuR32+EO6JoZKMonvwjZOJyoC2Cb4Q2Qh0coCZO6uObDQF8iC+xCEO/RhuBpo91P4O0jSif0c4Q2;
-        Expires=Tue, 03 May 2022 05:03:13 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=gifOJyIUKZYZRL+4vnmqmXo1NjH9tAadjSxYgOgDf7IOEnmZD/Tc5c+qd2lbLAkovk4dekoM6DYrBGIOtRuEeOg2qG3T21NfJ+9nEUQqDA6QVPygohEuuJwuv+JA;
+        Expires=Wed, 04 May 2022 06:19:18 GMT; Path=/
+      - AWSALBCORS=gifOJyIUKZYZRL+4vnmqmXo1NjH9tAadjSxYgOgDf7IOEnmZD/Tc5c+qd2lbLAkovk4dekoM6DYrBGIOtRuEeOg2qG3T21NfJ+9nEUQqDA6QVPygohEuuJwuv+JA;
+        Expires=Wed, 04 May 2022 06:19:18 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB876af3e0f40f6e82a04b0d41cb501e2c
+      - NBd619e7d48051e485135bfc43804c3857
       Pragma:
       - no-cache
       Cache-Control:
@@ -5952,11 +5936,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - UT7iPTZfZo4WeE3g6QLJ2RIYirfEtObjD0DD3gjuwuABBZyeiQXn-w==
+      - dwmYxotcDzYi6JUHOJo6JOuexP69hv-72tsbuDko-o_Gs6LSZdKNrA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -6070,7 +6054,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:13 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:18 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/6266ce226176752d36c8fe12
@@ -6086,9 +6070,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIEMZazLTa55TnzDnagjbTkZD1qCaFTzLkY0NozxQUDCuAiA7vLiFfg4usSqPGKPAOgRr5ugEtQo56szqzDHj3j8/YQ=="
+        host date digest",signature="MEYCIQDzmJNBeVSBdfVQtG6OlUZpC1ElS5pKH62Y15gmffzTcQIhAKP9Pvjao9y9DW5A3V5pt4wlZBiqB8aNqay3ev6yQH3U"
       Date:
-      - Tue, 26 Apr 2022 05:03:13 GMT
+      - Wed, 27 Apr 2022 06:19:18 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -6101,16 +6085,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:14 GMT
+      - Wed, 27 Apr 2022 06:19:18 GMT
       Set-Cookie:
-      - AWSALB=N4L25od6I/1IUmz4RkkWSiPCZC1j7bVLNNSgYOHo3pGKm7nO1YivWOjoOf3b0JYNw8artnbU0vXBzD2lla+SqVJdgElfrwTUTbKtWttVEOc+nHd1CZp6nJLaRYrB;
-        Expires=Tue, 03 May 2022 05:03:14 GMT; Path=/
-      - AWSALBCORS=N4L25od6I/1IUmz4RkkWSiPCZC1j7bVLNNSgYOHo3pGKm7nO1YivWOjoOf3b0JYNw8artnbU0vXBzD2lla+SqVJdgElfrwTUTbKtWttVEOc+nHd1CZp6nJLaRYrB;
-        Expires=Tue, 03 May 2022 05:03:14 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=CgUXlSiEsjuqmr41tZFTwLm2ZZQ//9nMkhLnVmYBrUV73+yEfQirq3ZXdVGup/0YeQ49GIAx6XoVfKU4E2L/VvGJO0+4iS6zLWZQZDylvMVUwE6UaFcurvPwQnUU;
+        Expires=Wed, 04 May 2022 06:19:18 GMT; Path=/
+      - AWSALBCORS=CgUXlSiEsjuqmr41tZFTwLm2ZZQ//9nMkhLnVmYBrUV73+yEfQirq3ZXdVGup/0YeQ49GIAx6XoVfKU4E2L/VvGJO0+4iS6zLWZQZDylvMVUwE6UaFcurvPwQnUU;
+        Expires=Wed, 04 May 2022 06:19:18 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6bf684e734a7aa9ed55c85fc079db2f9
+      - NBebe11b45cb4191e63b0b7c84d8c08bce
       Pragma:
       - no-cache
       Cache-Control:
@@ -6140,11 +6124,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - _RXoM5G5G8rj_xSNGjbNHQBfXpcFQy5HZC1EiBrehY5NsmgCCE_VHw==
+      - _zvtXcdhX_xZWHo8sN_8yfulwpHXnFfZrXVDyo1QwG5nOlBHGmqAhQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -6239,23 +6223,7 @@ http_interactions:
           "GraphicsCards": [],
           "HardwareUuid": "D0D77522-FA5B-4B24-A183-66BF636342FE",
           "InventoryDeviceInfo": null,
-          "KvmIpAddresses": [
-            {
-              "Address": "100.66.11.151",
-              "Category": "Equipment",
-              "ClassId": "compute.IpAddress",
-              "DefaultGateway": "100.66.11.129",
-              "Dn": "",
-              "HttpPort": 80,
-              "HttpsPort": 443,
-              "KvmPort": 2068,
-              "KvmVlan": 0,
-              "Name": "Outband",
-              "ObjectType": "compute.IpAddress",
-              "Subnet": "255.255.255.192",
-              "Type": "MgmtInterface"
-            }
-          ],
+          "KvmIpAddresses": [],
           "LocatorLed": {
             "ClassId": "mo.MoRef",
             "Moid": "6266cf0e6176752d36c945d2",
@@ -6271,8 +6239,8 @@ http_interactions:
             "ObjectType": "compute.BladeIdentity",
             "link": "https://www.intersight.com/api/v1/compute/BladeIdentities/614cebe66f62692d30838637"
           },
-          "MgmtIpAddress": "100.66.11.151",
-          "ModTime": "2022-04-26T05:02:26.732Z",
+          "MgmtIpAddress": "",
+          "ModTime": "2022-04-27T05:52:51.686Z",
           "Model": "UCSX-210C-M6",
           "Moid": "6266ce226176752d36c8fe12",
           "Name": "LAB02D02F01-1-3",
@@ -6284,7 +6252,7 @@ http_interactions:
           "NumFcHostInterfaces": 0,
           "NumThreads": 112,
           "ObjectType": "compute.Blade",
-          "OperPowerState": "on",
+          "OperPowerState": "off",
           "OperReason": [],
           "OperState": "",
           "Operability": "",
@@ -6361,7 +6329,7 @@ http_interactions:
           "Vmedia": null
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:14 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:19 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/equipment/LocatorLeds/6266cf0e6176752d36c945d2
@@ -6377,9 +6345,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCDhnO8hJnQsxITEzZZgEYDqeia2IPn/EUP82uVB+Yn9gIhANPtzXjv2vI/Wu9FlT04WjsAUr8DhOVhWHj3zBqWcQvp"
+        host date digest",signature="MEYCIQCG4a6IYbhVBLRSKK+6K+4qph9MatL7FpX8celaIOEgNgIhAKO42uYg6WkWzbK/h4sL6sWIBbl7vs5lcHqju203dVV4"
       Date:
-      - Tue, 26 Apr 2022 05:03:14 GMT
+      - Wed, 27 Apr 2022 06:19:19 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -6392,16 +6360,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:14 GMT
+      - Wed, 27 Apr 2022 06:19:19 GMT
       Set-Cookie:
-      - AWSALB=4Pv2QBSCTzyzC+r3t87d0Y4ZQOp2NeV63roO4ambMB5DR0ZK7apH7lkpKWZ+qStPaL2zGwgJxn1GUAx/Go5MMd+keeS5U68xkKrc8NO/l6Z1v/7nW6nnKEYoRQ+G;
-        Expires=Tue, 03 May 2022 05:03:14 GMT; Path=/
-      - AWSALBCORS=4Pv2QBSCTzyzC+r3t87d0Y4ZQOp2NeV63roO4ambMB5DR0ZK7apH7lkpKWZ+qStPaL2zGwgJxn1GUAx/Go5MMd+keeS5U68xkKrc8NO/l6Z1v/7nW6nnKEYoRQ+G;
-        Expires=Tue, 03 May 2022 05:03:14 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=+dTa7NbpsRa6K6HzCzURPpbrO+ja6woQD/DYTOoLVJ4g1XJkNnxp/HWtXTX+QtsU8aj1clIyhsu0EwEAYAN9qPhD4UChYrbjf4KH48/25fHqEYmJAqVfFDSTQ2up;
+        Expires=Wed, 04 May 2022 06:19:19 GMT; Path=/
+      - AWSALBCORS=+dTa7NbpsRa6K6HzCzURPpbrO+ja6woQD/DYTOoLVJ4g1XJkNnxp/HWtXTX+QtsU8aj1clIyhsu0EwEAYAN9qPhD4UChYrbjf4KH48/25fHqEYmJAqVfFDSTQ2up;
+        Expires=Wed, 04 May 2022 06:19:19 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBad1185896d721231f58cad6184dc3563
+      - NB37ceca8ad7dc9e6b2ce82b66fd6832c7
       Pragma:
       - no-cache
       Cache-Control:
@@ -6431,11 +6399,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - GxoAvuDTP1eYWTIjki7D88RVQXjhPwZ9POMfrormuCIhYjPvQR-gXg==
+      - IJeTcJRRpbwHoprS_nuugVnkbiOoxiH2Jl2zbAbs0l6y5xoA0M2Llg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -6471,7 +6439,7 @@ http_interactions:
           "EquipmentChassis": null,
           "EquipmentFex": null,
           "InventoryDeviceInfo": null,
-          "ModTime": "2022-04-26T05:02:26.735Z",
+          "ModTime": "2022-04-27T05:52:51.69Z",
           "Moid": "6266cf0e6176752d36c945d2",
           "ObjectType": "equipment.LocatorLed",
           "OperState": "off",
@@ -6512,7 +6480,7 @@ http_interactions:
           "Tags": []
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:14 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:19 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/6266ce226176752d36c8fe12
@@ -6528,9 +6496,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQClKPJKkr3sJr2Fqxz2kksAReuo68AGFSlY3jKwrniIWQIgAsBHDqQuCuC5dbMqBXDz0ScrDZEgcuyqNAIXprbtz6k="
+        host date digest",signature="MEYCIQCJD+TSwwo2lq7GqluJM/rHmCbosF3Wr58swKsaxBv2wAIhAKhwoJq4QCaUnJb1BciEZH77DQnG7wTiJ1vsbcAopoGN"
       Date:
-      - Tue, 26 Apr 2022 05:03:14 GMT
+      - Wed, 27 Apr 2022 06:19:19 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -6543,16 +6511,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:14 GMT
+      - Wed, 27 Apr 2022 06:19:19 GMT
       Set-Cookie:
-      - AWSALB=rvzTa3M5dviRxRcYubBmDAaTk38XdMyPDZLlltuUtyCchwfu+M7uZMwLdOTM2GKtFArYFt3U4JpcbQOTC/Q6U95mea+qAGEXY19QCSqJGWvnF5GPnD08A3s1Gmnk;
-        Expires=Tue, 03 May 2022 05:03:14 GMT; Path=/
-      - AWSALBCORS=rvzTa3M5dviRxRcYubBmDAaTk38XdMyPDZLlltuUtyCchwfu+M7uZMwLdOTM2GKtFArYFt3U4JpcbQOTC/Q6U95mea+qAGEXY19QCSqJGWvnF5GPnD08A3s1Gmnk;
-        Expires=Tue, 03 May 2022 05:03:14 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=+lLTnNOO9JzZTx3leENnYdHtz2UvniFzULRMkazDUma3bzna1I+UlQk++BLLBiMMgsONAudigb9t9GPrOptUFERWT4ktfRKgAhaagH8EORhtgxJs1FwbeCYJHpAt;
+        Expires=Wed, 04 May 2022 06:19:19 GMT; Path=/
+      - AWSALBCORS=+lLTnNOO9JzZTx3leENnYdHtz2UvniFzULRMkazDUma3bzna1I+UlQk++BLLBiMMgsONAudigb9t9GPrOptUFERWT4ktfRKgAhaagH8EORhtgxJs1FwbeCYJHpAt;
+        Expires=Wed, 04 May 2022 06:19:19 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3fc8277ca56da3b9ae4dc6ffa1da7c68
+      - NB1a959da5d6d3e8e868527e9438917902
       Pragma:
       - no-cache
       Cache-Control:
@@ -6582,11 +6550,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - M_eqTHKuXpY7W3waSyf1oHixFOGuwW8Br0FfWdMRX872beMH6MJpmg==
+      - yC6GP9IUHVpo1NaIxeSaW2qe5soe1f6Jyc3SHaTNURYNU9gFDBPxGQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -6681,23 +6649,7 @@ http_interactions:
           "GraphicsCards": [],
           "HardwareUuid": "D0D77522-FA5B-4B24-A183-66BF636342FE",
           "InventoryDeviceInfo": null,
-          "KvmIpAddresses": [
-            {
-              "Address": "100.66.11.151",
-              "Category": "Equipment",
-              "ClassId": "compute.IpAddress",
-              "DefaultGateway": "100.66.11.129",
-              "Dn": "",
-              "HttpPort": 80,
-              "HttpsPort": 443,
-              "KvmPort": 2068,
-              "KvmVlan": 0,
-              "Name": "Outband",
-              "ObjectType": "compute.IpAddress",
-              "Subnet": "255.255.255.192",
-              "Type": "MgmtInterface"
-            }
-          ],
+          "KvmIpAddresses": [],
           "LocatorLed": {
             "ClassId": "mo.MoRef",
             "Moid": "6266cf0e6176752d36c945d2",
@@ -6713,8 +6665,8 @@ http_interactions:
             "ObjectType": "compute.BladeIdentity",
             "link": "https://www.intersight.com/api/v1/compute/BladeIdentities/614cebe66f62692d30838637"
           },
-          "MgmtIpAddress": "100.66.11.151",
-          "ModTime": "2022-04-26T05:02:26.732Z",
+          "MgmtIpAddress": "",
+          "ModTime": "2022-04-27T05:52:51.686Z",
           "Model": "UCSX-210C-M6",
           "Moid": "6266ce226176752d36c8fe12",
           "Name": "LAB02D02F01-1-3",
@@ -6726,7 +6678,7 @@ http_interactions:
           "NumFcHostInterfaces": 0,
           "NumThreads": 112,
           "ObjectType": "compute.Blade",
-          "OperPowerState": "on",
+          "OperPowerState": "off",
           "OperReason": [],
           "OperState": "",
           "Operability": "",
@@ -6803,7 +6755,7 @@ http_interactions:
           "Vmedia": null
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:14 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:19 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Boards/6266d0016176752d36c9870d
@@ -6819,9 +6771,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQC9+fT+FGgI2GatgJsYFJvvyEVgW17ugvZU54tNmC7QoQIgZeYCfCnI8hfJ3ZPQaF9ILg9zpaK1lMuQNeQxKOHkV+M="
+        host date digest",signature="MEYCIQCJhjdcAtY5S5vAi5UMBv8w5oymlaBqRQ2s9HoDoArlcwIhAM2BnwgkwebQ82RydSK+vLB35B3sF0pAyyrh5Jp1GXbm"
       Date:
-      - Tue, 26 Apr 2022 05:03:14 GMT
+      - Wed, 27 Apr 2022 06:19:19 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -6834,16 +6786,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:14 GMT
+      - Wed, 27 Apr 2022 06:19:20 GMT
       Set-Cookie:
-      - AWSALB=u/b4LzDC3rtoizEZgJOgcKlrl9fbtwa4OIaKOpAdrD+fJWFi07i/rjICMZ2kzlwg753G9LgBtO5tk515HgnvT4MNNFE1IZ0JOlV8ERx1/HdS83j2LBWQtfEdQCea;
-        Expires=Tue, 03 May 2022 05:03:14 GMT; Path=/
-      - AWSALBCORS=u/b4LzDC3rtoizEZgJOgcKlrl9fbtwa4OIaKOpAdrD+fJWFi07i/rjICMZ2kzlwg753G9LgBtO5tk515HgnvT4MNNFE1IZ0JOlV8ERx1/HdS83j2LBWQtfEdQCea;
-        Expires=Tue, 03 May 2022 05:03:14 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=v757z/H0TarDfPMlIQMSzqoVFtXYEvyHlgdOPjhUEoHw1myla0FtvTmp0C81fbRYxUz/Llo6h0BKDBCdV86488NoIgUHi0qLrJHGZsFVeajuPOHF80xDf/vOhGyi;
+        Expires=Wed, 04 May 2022 06:19:20 GMT; Path=/
+      - AWSALBCORS=v757z/H0TarDfPMlIQMSzqoVFtXYEvyHlgdOPjhUEoHw1myla0FtvTmp0C81fbRYxUz/Llo6h0BKDBCdV86488NoIgUHi0qLrJHGZsFVeajuPOHF80xDf/vOhGyi;
+        Expires=Wed, 04 May 2022 06:19:20 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4d8718b558d16cb501175cd9a40fb012
+      - NBc38cc71c069fb80eb9ba56e7c3593db2
       Pragma:
       - no-cache
       Cache-Control:
@@ -6873,11 +6825,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ddMDcHRJDtfYInCIfMvKuYl9pX8mIs7sg7IneIUq0FkgpocxOmHvvg==
+      - 59y21QBkg7jgq7Ovdvz8isSd4VcckhX6XiJ20nL5XEor1ow8Q4OAAw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -6937,7 +6889,7 @@ http_interactions:
               "link": "https://www.intersight.com/api/v1/memory/Arrays/6266d0016176752d36c98710"
             }
           ],
-          "ModTime": "2022-04-26T05:02:26.695Z",
+          "ModTime": "2022-04-27T05:52:51.645Z",
           "Model": "UCSX-210C-M6",
           "Moid": "6266d0016176752d36c9870d",
           "ObjectType": "compute.Board",
@@ -7005,7 +6957,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:14 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:20 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/adapter/Units/6266d0036176752d36c98837
@@ -7021,9 +6973,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIBHR4wdtYj40c67cZ+gZv3dDgc2FJUqz/aNqLwXumEz0AiALF/xmfeL6GJ6tmbiaY//6utA/NkzWw6Nrd8O5aBjMNg=="
+        host date digest",signature="MEQCIHHlvdPGHDFuASJNMEhPIHdUI0v6f3FnuxCmhqvgvGwaAiBfdkggFzaBh5FiWxxxdqSDcSK8TBzGThsHFTVpiG+zVw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:14 GMT
+      - Wed, 27 Apr 2022 06:19:20 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -7036,16 +6988,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:14 GMT
+      - Wed, 27 Apr 2022 06:19:20 GMT
       Set-Cookie:
-      - AWSALB=ZJRy6ggwc04AApyuplNkFdclD5ggCl1pdiHx85wo5+oj2li5b5oRT7SmUJ4aLyQLgewkp/X735PlD2VUVS7LJoxKFrCuGUCm1AGSiuqgzrULt+GY7aWqG2kTZeN/;
-        Expires=Tue, 03 May 2022 05:03:14 GMT; Path=/
-      - AWSALBCORS=ZJRy6ggwc04AApyuplNkFdclD5ggCl1pdiHx85wo5+oj2li5b5oRT7SmUJ4aLyQLgewkp/X735PlD2VUVS7LJoxKFrCuGUCm1AGSiuqgzrULt+GY7aWqG2kTZeN/;
-        Expires=Tue, 03 May 2022 05:03:14 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=hfjvW2sbMz9ERLdKGjEIxd2gU/bgOTx5Dd8QxpK5abhV7z4Ny3PoO0OGIstkkOJ9CJJvEniupC/44PhtNb6Ij5v2S1TGmwE45O7bJUFeRahPCWqxf5jJUWvwEclg;
+        Expires=Wed, 04 May 2022 06:19:20 GMT; Path=/
+      - AWSALBCORS=hfjvW2sbMz9ERLdKGjEIxd2gU/bgOTx5Dd8QxpK5abhV7z4Ny3PoO0OGIstkkOJ9CJJvEniupC/44PhtNb6Ij5v2S1TGmwE45O7bJUFeRahPCWqxf5jJUWvwEclg;
+        Expires=Wed, 04 May 2022 06:19:20 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6f0b4a5031f4f3e0ab6abb370bb9fe66
+      - NB8d1d30d7cf943f4c6c4406b2170c1f4b
       Pragma:
       - no-cache
       Cache-Control:
@@ -7075,11 +7027,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - wnD82OtEmhitN33xWf3WS8-rLZsO3sCtMgnOPnxFVkCRSfOJlGSPgA==
+      - 6MeQcKh2IPt5tokJm2EhRv42pRzgJql-VMSi3xNc0eMcXkS8f4T7oQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -7160,7 +7112,7 @@ http_interactions:
           "HostIscsiIfs": [],
           "Integrated": "",
           "InventoryDeviceInfo": null,
-          "ModTime": "2022-04-25T16:45:00.111Z",
+          "ModTime": "2022-04-26T11:34:06.615Z",
           "Model": "UCSX-V4-Q25GML",
           "Moid": "6266d0036176752d36c98837",
           "ObjectType": "adapter.Unit",
@@ -7212,7 +7164,7 @@ http_interactions:
           "Vid": ""
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:14 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:20 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/equipment/LocatorLeds/614cebe56176752d35abb3e6
@@ -7228,9 +7180,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIF9Z3Av7ndEhrEEjZ992WD8tnGHfoBwhio8MulwzyHH7AiBQWVuUBVnOkxifmaX9p7SMCAJ2W+21oFS35Em47A6aFw=="
+        host date digest",signature="MEYCIQCVHdV+/eBDRuBzjVRhqvJ0lirGr8M0m2vkeIEHuxM8xwIhAMMoBaxSOi5HcnD96ghuIbwvGI7b1pPAdaJEOYRzYLAt"
       Date:
-      - Tue, 26 Apr 2022 05:03:14 GMT
+      - Wed, 27 Apr 2022 06:19:20 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -7243,16 +7195,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:15 GMT
+      - Wed, 27 Apr 2022 06:19:20 GMT
       Set-Cookie:
-      - AWSALB=jKfjAFd9TgW1Tw03y0VKAmjG+x4XOye2/646FkFtFH/i014l4jOCcoSTD/opeCfuvgf8qh4yQGoDb8PYdQ2eMK/MSyT7y5mXNMdRkxT7+0UZetK8B8Su7MU60s1W;
-        Expires=Tue, 03 May 2022 05:03:15 GMT; Path=/
-      - AWSALBCORS=jKfjAFd9TgW1Tw03y0VKAmjG+x4XOye2/646FkFtFH/i014l4jOCcoSTD/opeCfuvgf8qh4yQGoDb8PYdQ2eMK/MSyT7y5mXNMdRkxT7+0UZetK8B8Su7MU60s1W;
-        Expires=Tue, 03 May 2022 05:03:15 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=hBC3LA5gkO5KEr1BLdsk8fm3oXDueepomYzQYxzkjIZagtcgG5+zxkhwAWW6guvz4mtnzc/K9oYrqfH9GbovUpucjhREie9POpfpNZ334qnfdrkm09qpwPaqyrwJ;
+        Expires=Wed, 04 May 2022 06:19:20 GMT; Path=/
+      - AWSALBCORS=hBC3LA5gkO5KEr1BLdsk8fm3oXDueepomYzQYxzkjIZagtcgG5+zxkhwAWW6guvz4mtnzc/K9oYrqfH9GbovUpucjhREie9POpfpNZ334qnfdrkm09qpwPaqyrwJ;
+        Expires=Wed, 04 May 2022 06:19:20 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB1a82e9367f9daf05700da16041f717e7
+      - NBe3da19865c29cc357f59db8c8193065f
       Pragma:
       - no-cache
       Cache-Control:
@@ -7282,11 +7234,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - cyRZ_8Ovkc3wl4WOLNLlWEuPvyWn45DfLAA9KNHqQpeXt0kWczBhAA==
+      - VCIUMAkR70uHnjQssvaCbgo2ZjaR7cpdMvhwkkyPWWoHullVFlM7EA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -7356,10 +7308,10 @@ http_interactions:
           "Tags": []
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:15 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:20 GMT
 - request:
     method: get
-    uri: https://intersight.com/api/v1/equipment/SwitchCards/614ce25a4630312d42bf1d1a
+    uri: https://intersight.com/api/v1/network/ElementSummaries/614ce2a16176752d35a7ec96
     body:
       encoding: US-ASCII
       string: ''
@@ -7372,9 +7324,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIAkzFifp8I6CUMIoDJxoQsbziZmPWQTDVpJl+ztdsCuTAiEA9PTlyLa+Wx4LDA8joNz7MZwk9M50UMZW7AOtUx6flTw="
+        host date digest",signature="MEQCICllCAXxY+4OJoZbKbIS7Ee5ShijWniujMF+OhF+sVcjAiA3s8dhc/2luDb7mtaO1fNR+yWU5SJyq3LosNzzDq/XQQ=="
       Date:
-      - Tue, 26 Apr 2022 05:03:15 GMT
+      - Wed, 27 Apr 2022 06:19:20 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -7387,16 +7339,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:15 GMT
+      - Wed, 27 Apr 2022 06:19:20 GMT
       Set-Cookie:
-      - AWSALB=gyLfluQDaIBC7zJ/Vt4YKVzYOid1FpOhahF67swKG6CVHQi/0WrF6d3d/SaBG1q+iegvHeiypUKZIKGGi1yBMsgUHtIRmZ03Awz6WPHoBkvbPp1JMF71N3nS7v6i;
-        Expires=Tue, 03 May 2022 05:03:15 GMT; Path=/
-      - AWSALBCORS=gyLfluQDaIBC7zJ/Vt4YKVzYOid1FpOhahF67swKG6CVHQi/0WrF6d3d/SaBG1q+iegvHeiypUKZIKGGi1yBMsgUHtIRmZ03Awz6WPHoBkvbPp1JMF71N3nS7v6i;
-        Expires=Tue, 03 May 2022 05:03:15 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=8rYh+Em3iHUMjmBm/qKR+uBPDcK/AeUKgTQ1uk6JmAtljhcoLNW/R1GIxCfATNm7CLfR2Ovy/wxG5eZhsUfDqgm85xvwRxvYFo6lOaxplL31yFXyaTLGpgQcvw9V;
+        Expires=Wed, 04 May 2022 06:19:20 GMT; Path=/
+      - AWSALBCORS=8rYh+Em3iHUMjmBm/qKR+uBPDcK/AeUKgTQ1uk6JmAtljhcoLNW/R1GIxCfATNm7CLfR2Ovy/wxG5eZhsUfDqgm85xvwRxvYFo6lOaxplL31yFXyaTLGpgQcvw9V;
+        Expires=Wed, 04 May 2022 06:19:20 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa50993ac1f9a4839830dfcc4541d3636
+      - NBc648af0c8b0d36ba2ae570128e5118d9
       Pragma:
       - no-cache
       Cache-Control:
@@ -7426,11 +7378,187 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - hUuSV83PK7_l7AstsW8DJcRRJC_WsuCK6XpdE4qpOixafbo5osL27Q==
+      - VToa67s3EVKh8xXAaqPiF7jomVFM-YstuKBJPGzaRTr69HoXc-nbOw==
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "AccountMoid": "5ed10e437564612d3352cc2d",
+          "AdminEvacState": "disabled",
+          "AdminInbandInterfaceState": "disabled",
+          "AlarmSummary": {
+            "ClassId": "compute.AlarmSummary",
+            "Critical": 0,
+            "ObjectType": "compute.AlarmSummary",
+            "Warning": 1
+          },
+          "Ancestors": [],
+          "AvailableMemory": "",
+          "Chassis": "",
+          "ClassId": "network.ElementSummary",
+          "ConfModTs": "",
+          "ConfModTsBackup": "",
+          "CreateTime": "2021-09-23T20:25:05.943Z",
+          "DeviceMoId": "614ce29f6f72612d307f5ed4",
+          "Dn": "switch-FDO244106VJ",
+          "DomainGroupMoid": "5ed10e437564612d3352cc37",
+          "EthernetMode": "",
+          "EthernetSwitchingMode": "end-host",
+          "FaultSummary": 0,
+          "FcMode": "",
+          "FcSwitchingMode": "end-host",
+          "Firmware": "",
+          "InbandIpAddress": "0.0.0.0",
+          "InbandIpGateway": "0.0.0.0",
+          "InbandIpMask": "255.255.255.0",
+          "InbandVlan": 0,
+          "Ipv4Address": "",
+          "ManagementMode": "Intersight",
+          "ModTime": "2022-04-27T06:18:30.869Z",
+          "Model": "UCS-FI-6454",
+          "Moid": "614ce2a16176752d35a7ec96",
+          "Name": "LAB02D02F01 FI-B",
+          "NumEtherPorts": 54,
+          "NumEtherPortsConfigured": 6,
+          "NumEtherPortsLinkUp": 4,
+          "NumExpansionModules": 0,
+          "NumFcPorts": 0,
+          "NumFcPortsConfigured": 0,
+          "NumFcPortsLinkUp": 0,
+          "ObjectType": "network.ElementSummary",
+          "OperEvacState": "disabled",
+          "Operability": "online",
+          "OutOfBandIpAddress": "100.66.11.142",
+          "OutOfBandIpGateway": "100.66.11.129",
+          "OutOfBandIpMask": "255.255.255.192",
+          "OutOfBandIpv4Address": "",
+          "OutOfBandIpv4Gateway": "",
+          "OutOfBandIpv4Mask": "",
+          "OutOfBandIpv6Address": "",
+          "OutOfBandIpv6Gateway": "",
+          "OutOfBandIpv6Prefix": "",
+          "OutOfBandMac": "00:3A:9C:DA:78:C0",
+          "Owners": [
+            "5ed10e437564612d3352cc2d",
+            "614ce29f6f72612d307f5ed4"
+          ],
+          "PartNumber": "",
+          "PermissionResources": [
+            {
+              "ClassId": "mo.MoRef",
+              "Moid": "5ed10e456972652d30b39b49",
+              "ObjectType": "organization.Organization",
+              "link": "https://www.intersight.com/api/v1/organization/Organizations/5ed10e456972652d30b39b49"
+            },
+            {
+              "ClassId": "mo.MoRef",
+              "Moid": "614caf8f6972652d30d65a53",
+              "ObjectType": "organization.Organization",
+              "link": "https://www.intersight.com/api/v1/organization/Organizations/614caf8f6972652d30d65a53"
+            }
+          ],
+          "Presence": "",
+          "RegisteredDevice": {
+            "ClassId": "mo.MoRef",
+            "Moid": "614ce29f6f72612d307f5ed4",
+            "ObjectType": "asset.DeviceRegistration",
+            "link": "https://www.intersight.com/api/v1/asset/DeviceRegistrations/614ce29f6f72612d307f5ed4"
+          },
+          "Revision": "0",
+          "Rn": "",
+          "Serial": "FDO244106VJ",
+          "SharedScope": "",
+          "SourceObjectType": "network.Element",
+          "Status": "",
+          "SwitchId": "B",
+          "SwitchType": "FabricInterconnect",
+          "SystemUpTime": "",
+          "Tags": [],
+          "Thermal": "ok",
+          "TotalMemory": 64265,
+          "Vendor": "Cisco Systems, Inc.",
+          "Version": "9.3(5)I42(1f)"
+        }
+    http_version:
+  recorded_at: Wed, 27 Apr 2022 06:19:21 GMT
+- request:
+    method: get
+    uri: https://intersight.com/api/v1/equipment/SwitchCards/614ce25a4630312d42bf1d1a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.1.3/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
+        host date digest",signature="MEUCIQD+QRCUEruU9PZoI8NXrUb3PXR07cruxfOSUwnH8eYwvwIgfgXzEbZYkWbsVHbKTBl7rfWOU4GetuBDaBLr783sBXU="
+      Date:
+      - Wed, 27 Apr 2022 06:19:21 GMT
+      Digest:
+      - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 27 Apr 2022 06:19:21 GMT
+      Set-Cookie:
+      - AWSALB=WUW1D+PfS6qvKdpLzen+eUU/BhdNOZP27gt21FXIFl9S7LXUBe/U9F9aoLHyD8kISRdtZ0fQMGmROyWsTIGAhWSvsiEVgtXqYxUFJznaGaksDs0IQdzp8aw/lYDp;
+        Expires=Wed, 04 May 2022 06:19:21 GMT; Path=/
+      - AWSALBCORS=WUW1D+PfS6qvKdpLzen+eUU/BhdNOZP27gt21FXIFl9S7LXUBe/U9F9aoLHyD8kISRdtZ0fQMGmROyWsTIGAhWSvsiEVgtXqYxUFJznaGaksDs0IQdzp8aw/lYDp;
+        Expires=Wed, 04 May 2022 06:19:21 GMT; Path=/; SameSite=None; Secure
+      Server:
+      - nginx
+      X-Starship-Traceid:
+      - NB8733913fa83ad668a834deae922483d0
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Security-Policy:
+      - 'base-uri ''self'' https://cdn.intersight.com/; child-src ''self'' https://www.intersight.com/
+        https://cdn.intersight.com/  https://cloudsso.cisco.com https://www.cisco.com/
+        https://id.cisco.com; default-src ''self'' https://cdn.intersight.com/; font-src
+        ''self'' data: https://cdn.intersight.com/; frame-ancestors ''self''; img-src
+        ''self'' data: https://cdn.intersight.com/; style-src ''self'' ''unsafe-inline''
+        https://cdn.intersight.com/; object-src ''none''; form-action ''self'' https://www.intersight.com/
+        https://cloudsso.cisco.com https://www.cisco.com/ https://id.cisco.com; script-src
+        ''self'' https://cdn.intersight.com/; sandbox allow-modals allow-scripts allow-same-origin
+        allow-popups allow-forms allow-downloads; connect-src ''self'' https://cdn.intersight.com/
+        https://status.intersight.com https://download.intersight.com/ wss://socket.intersight.com
+        wss://intersight.com; frame-src ''self'' blob: https://www.intersight.com/
+        https://cdn.intersight.com/  https://cloudsso.cisco.com https://www.cisco.com/
+        https://id.cisco.com;'
+      X-Xss-Protection:
+      - 1; mode=block;
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - ZAG50-C1
+      X-Amz-Cf-Id:
+      - vOz19lLwTMTUIZk_JeLfFMNdxtJTidjeNOmBGw9UVxbhQaw8OPU_HA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -7466,7 +7594,7 @@ http_interactions:
           "FcSwitchingMode": "end-host",
           "HwVersion": "",
           "InventoryDeviceInfo": null,
-          "ModTime": "2022-04-26T04:32:29.265Z",
+          "ModTime": "2022-04-27T06:18:30.57Z",
           "Model": "UCS-FI-6454",
           "Moid": "614ce25a4630312d42bf1d1a",
           "Name": "",
@@ -7576,7 +7704,7 @@ http_interactions:
           "Vendor": "Cisco Systems, Inc."
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:15 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:21 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/port/Groups/614ce2a26176752d35a7ed6f
@@ -7592,9 +7720,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCEacTUTM2B/BWteATpSoil02hLRVUm6NLhKDBJWtO2mgIgGJ1/w0IhksVjNiD25TigfbQOeTDFlE6Sb7CZkuBt4P4="
+        host date digest",signature="MEUCIQDI1EuBCQyiBSc7isLF0R78yX7UtZxdpKND1OQoJIG6TAIgEypGeIR6gnQCQ6e4RCHZq5qSQLmsWD3bSr6xeV8tVaw="
       Date:
-      - Tue, 26 Apr 2022 05:03:15 GMT
+      - Wed, 27 Apr 2022 06:19:21 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -7607,16 +7735,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:15 GMT
+      - Wed, 27 Apr 2022 06:19:21 GMT
       Set-Cookie:
-      - AWSALB=lY4Cp+ylybIxzGIvRC0aMl6vmvptMIkUBlsS27cymrwXG7fVYZq/GIFRxrQJ2wsc0WJVsudpNv3ZPQPAGpm97BlIVkslFeYnIYc/E2/7Y8VQhqNQa5Tkmfl5RIH3;
-        Expires=Tue, 03 May 2022 05:03:15 GMT; Path=/
-      - AWSALBCORS=lY4Cp+ylybIxzGIvRC0aMl6vmvptMIkUBlsS27cymrwXG7fVYZq/GIFRxrQJ2wsc0WJVsudpNv3ZPQPAGpm97BlIVkslFeYnIYc/E2/7Y8VQhqNQa5Tkmfl5RIH3;
-        Expires=Tue, 03 May 2022 05:03:15 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=JTXJ1nyuFTL4y1FnwXMcJyUWR+mq2UeopC2FYibjsWSFH7yLBrtdwfy8JSo2y0PY/v1yr1Zy+11lqGPYNxsuMetWeiTBMU8BRWuOo1igD/4LU6uvPk6hwJkVDJhZ;
+        Expires=Wed, 04 May 2022 06:19:21 GMT; Path=/
+      - AWSALBCORS=JTXJ1nyuFTL4y1FnwXMcJyUWR+mq2UeopC2FYibjsWSFH7yLBrtdwfy8JSo2y0PY/v1yr1Zy+11lqGPYNxsuMetWeiTBMU8BRWuOo1igD/4LU6uvPk6hwJkVDJhZ;
+        Expires=Wed, 04 May 2022 06:19:21 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB8b1f8518d5174b50ed07def52baf7b47
+      - NB4805b71d9f3d94f4ea2917bb8372d76b
       Pragma:
       - no-cache
       Cache-Control:
@@ -7646,11 +7774,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - wZyp1URJ0Q-hXp7OppH3KFtr6l1AYnjiI0dBXDo0PEnPQrXCXVRtdw==
+      - 7cShTRtwIFtGLf89Mz3L3-bF0PUT1YitOMJYD13OIk-XnQvqD9WF6w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -8050,7 +8178,7 @@ http_interactions:
           "Transport": "ether"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:15 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:21 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d67
@@ -8066,9 +8194,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCrkQ8m3GJsoivnV63c9qvGxndFZ0y5tOrFwa9NSgX0BgIhAIY2GxKl3ENhpUsd8Ut3s7/Ia2XLx4BPaQT/4FE3xwVn"
+        host date digest",signature="MEUCIFt/wViWcEV94vs4XzuAHeiPh0nsCWs0TRXLd66GlOuBAiEAx/QKXFDmfs46w2meYC6ayE3s7GkP0kIf4qUAkmGVbUA="
       Date:
-      - Tue, 26 Apr 2022 05:03:15 GMT
+      - Wed, 27 Apr 2022 06:19:21 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -8081,16 +8209,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:15 GMT
+      - Wed, 27 Apr 2022 06:19:21 GMT
       Set-Cookie:
-      - AWSALB=kGtesgZrcrrpXiy7BWGSMgD4lu4F9d9wHmABBmkYOnT9TxwO6I2wzYzUESmI+1Ys6lpmLi5VEhOok3nQguVNCElW7gZbGbRfNvbNzZhoE6MvJBrqz3uEUb1B66MI;
-        Expires=Tue, 03 May 2022 05:03:15 GMT; Path=/
-      - AWSALBCORS=kGtesgZrcrrpXiy7BWGSMgD4lu4F9d9wHmABBmkYOnT9TxwO6I2wzYzUESmI+1Ys6lpmLi5VEhOok3nQguVNCElW7gZbGbRfNvbNzZhoE6MvJBrqz3uEUb1B66MI;
-        Expires=Tue, 03 May 2022 05:03:15 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=bejdVcPUncEHyiUxnj6WoJrrUAG1DqdHmyrIlNFLj91YWKehygcdu+jXXKRFFnOypFRAfAwH+ISJM6RMZEi/RCvT0hoi/QEJ/elMQEArhy0e4PTCeNtLyk3EcFCO;
+        Expires=Wed, 04 May 2022 06:19:21 GMT; Path=/
+      - AWSALBCORS=bejdVcPUncEHyiUxnj6WoJrrUAG1DqdHmyrIlNFLj91YWKehygcdu+jXXKRFFnOypFRAfAwH+ISJM6RMZEi/RCvT0hoi/QEJ/elMQEArhy0e4PTCeNtLyk3EcFCO;
+        Expires=Wed, 04 May 2022 06:19:21 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa7c3dd858a0855ce14a752af4486758d
+      - NB1e3b76295b4216c3f8bc3386503cf344
       Pragma:
       - no-cache
       Cache-Control:
@@ -8120,11 +8248,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - PN-CaM2yCn2hXPNeFLUhTVVcudHp5W6D49f6_p0szZe4DMzFO6Yipw==
+      - XBNqNpNffm6kZsZ6Pbew7UC9BQez0fKlhgJeunmABtmmuZ2Y6BlzXQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -8171,7 +8299,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F1",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d67",
           "Name": "",
@@ -8230,7 +8358,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:15 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:21 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6a
@@ -8246,9 +8374,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDnRN3Keedo2Xx07Juwj/OooOdhaTJlznCmArhpbg/uJgIgVL+NVHxWKaHbOgzpqJ9mZi7ii/O8i+yHmedFnT4W7QY="
+        host date digest",signature="MEQCIFxgX92QRdhZA4ZZJNk9S6sfSVZ4gLnrwDqVFWZyRp1wAiA/mUaHZEfC0KsgBO0vjqUPI10DtJOtjkvprIRLGMGagg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:15 GMT
+      - Wed, 27 Apr 2022 06:19:21 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -8261,16 +8389,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:16 GMT
+      - Wed, 27 Apr 2022 06:19:22 GMT
       Set-Cookie:
-      - AWSALB=FKGaKx+nkt8mr1Rn4Kfxf01dTQUdSbgka962CufPYc7WmxduomeaBIeUOvUFHo+YFBKhPzsfLdJxXqGSJIMexnPENq+2UoDoMrzHrM/paNUGntGm7PYrb6Pap4z5;
-        Expires=Tue, 03 May 2022 05:03:16 GMT; Path=/
-      - AWSALBCORS=FKGaKx+nkt8mr1Rn4Kfxf01dTQUdSbgka962CufPYc7WmxduomeaBIeUOvUFHo+YFBKhPzsfLdJxXqGSJIMexnPENq+2UoDoMrzHrM/paNUGntGm7PYrb6Pap4z5;
-        Expires=Tue, 03 May 2022 05:03:16 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=BadjiEuGF5TC2mBE2K2GXTplOYnE7aRDjic+pALCAXAE87oBpRJffTLPNDOmyWUqb+pHRhRqn7ntuS+u2T3Yn3028zrKvk4HTYSRi1OzE4AZms3ByK3J2BvhZOI8;
+        Expires=Wed, 04 May 2022 06:19:22 GMT; Path=/
+      - AWSALBCORS=BadjiEuGF5TC2mBE2K2GXTplOYnE7aRDjic+pALCAXAE87oBpRJffTLPNDOmyWUqb+pHRhRqn7ntuS+u2T3Yn3028zrKvk4HTYSRi1OzE4AZms3ByK3J2BvhZOI8;
+        Expires=Wed, 04 May 2022 06:19:22 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB014eeab2c3b843ecb7dadfd32513692b
+      - NBc589315691986626a4112a393dd1ba22
       Pragma:
       - no-cache
       Cache-Control:
@@ -8300,11 +8428,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - e8_BsmDm7EU99l8vy_N_EQTGA4KZoYTGdqaWM1mBmZxPLzGJrK6LOA==
+      - eIMwqeI2CCgLwO4JXLPsZT85ws8hdpEsL7Z6rXUZr2lXzSn8qcwnLg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -8351,7 +8479,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F4",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d6a",
           "Name": "",
@@ -8410,7 +8538,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:16 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:22 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d71
@@ -8426,9 +8554,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIHrPeeyCWtjrvth6ZWAgDNlQPV5PKYidNbPb7AEaCAQuAiA+akH5oicU5hFKC3csoPbNx0BLmxr2gzzIgsx/sLm7iQ=="
+        host date digest",signature="MEYCIQCwCbBZNfo+Kn7L39RuiElBAzK54drhSK4sV3Vegf9DXwIhAIKOJx6VtiatCsuymDw/vQvEay9k+CR8H4wpH0g5IpmG"
       Date:
-      - Tue, 26 Apr 2022 05:03:16 GMT
+      - Wed, 27 Apr 2022 06:19:22 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -8441,16 +8569,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:16 GMT
+      - Wed, 27 Apr 2022 06:19:22 GMT
       Set-Cookie:
-      - AWSALB=Bd+MN0RTXObf4iyFIWtvZt5rE9lO30yrtznJylOL/7hQn3QSJuQ3294zpqWPD9DgqWa3D0h/k+8+8upGAAudPWVD6QBL5ac3eUV69P9XEq5C2t0OVdceBjfS2TKV;
-        Expires=Tue, 03 May 2022 05:03:16 GMT; Path=/
-      - AWSALBCORS=Bd+MN0RTXObf4iyFIWtvZt5rE9lO30yrtznJylOL/7hQn3QSJuQ3294zpqWPD9DgqWa3D0h/k+8+8upGAAudPWVD6QBL5ac3eUV69P9XEq5C2t0OVdceBjfS2TKV;
-        Expires=Tue, 03 May 2022 05:03:16 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=KlrSZHwMZoYggqlib1D6zz9Z8Qx+ciSAhdjyRDKe7r4Hj2/n7ARztbnGK/zkwBiP7NY6xKN8YMUKqh/svR6zK1ojfwiMc2JZPzBk2jBeWxV+vMTXRnu400yvxJfl;
+        Expires=Wed, 04 May 2022 06:19:22 GMT; Path=/
+      - AWSALBCORS=KlrSZHwMZoYggqlib1D6zz9Z8Qx+ciSAhdjyRDKe7r4Hj2/n7ARztbnGK/zkwBiP7NY6xKN8YMUKqh/svR6zK1ojfwiMc2JZPzBk2jBeWxV+vMTXRnu400yvxJfl;
+        Expires=Wed, 04 May 2022 06:19:22 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf730bd9762b1e3bec2360a9494224919
+      - NBb6ea34ddb6e1508289752d70a3bd7246
       Pragma:
       - no-cache
       Cache-Control:
@@ -8480,11 +8608,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - frzgGCUTSR1ntZoBkXT5BgpAeKbplYYI7q5Wr538QMDWjg8p7IENog==
+      - l7X_LT5I_X_NcfwNQiXXt5RILrMwZaphMzsHEfwMB5KlAnaQgCVNMA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -8531,7 +8659,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:79:04",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d71",
           "Name": "",
@@ -8590,7 +8718,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:16 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:22 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8b
@@ -8606,9 +8734,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQC4vIyCWZ04lQ+Ucub6kY8NY+Oq6HvmQcdtIf8kD4/QDAIhAOBb/edIo+QziKNY3s/MktUm0GBckoL2nJvf6uqv90Pa"
+        host date digest",signature="MEUCIQDL5zpAM+WYE3Ki5d/jTskZqiScgQL7KRww3x1606HY6QIgaELRhEv+RGEd8VzPVnRq4M6hgCaAQcbHmu9yhcEMqKU="
       Date:
-      - Tue, 26 Apr 2022 05:03:16 GMT
+      - Wed, 27 Apr 2022 06:19:22 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -8621,16 +8749,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:16 GMT
+      - Wed, 27 Apr 2022 06:19:22 GMT
       Set-Cookie:
-      - AWSALB=DiU54FnZAVDuYKCfU5Hyiej4GQPdZ5ID9fc2DwgUq79bQI30byJX4j60q2+5p95KAwNqnAv+cNZ8QcHjRuXVacu4FfDz5a16Tmv/apjtAi1nP6UDriBKkJzpZcCe;
-        Expires=Tue, 03 May 2022 05:03:16 GMT; Path=/
-      - AWSALBCORS=DiU54FnZAVDuYKCfU5Hyiej4GQPdZ5ID9fc2DwgUq79bQI30byJX4j60q2+5p95KAwNqnAv+cNZ8QcHjRuXVacu4FfDz5a16Tmv/apjtAi1nP6UDriBKkJzpZcCe;
-        Expires=Tue, 03 May 2022 05:03:16 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=f/QRjjzTwqBaCzpWx0yuTjhdvXP8Oto2h450fku4qLI1/epxhE5xRP//bRuO9iLXe/+euj0VDjCEwoF5uo1bWIrV8GH5WE4+9r/vqcXzCDIDDw+IqxAWpD7eT/f4;
+        Expires=Wed, 04 May 2022 06:19:22 GMT; Path=/
+      - AWSALBCORS=f/QRjjzTwqBaCzpWx0yuTjhdvXP8Oto2h450fku4qLI1/epxhE5xRP//bRuO9iLXe/+euj0VDjCEwoF5uo1bWIrV8GH5WE4+9r/vqcXzCDIDDw+IqxAWpD7eT/f4;
+        Expires=Wed, 04 May 2022 06:19:22 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBfd7e72153fe5a2ac356882c4e8ebc6b3
+      - NBadab86e2cfdf77bc69133b7da14d7762
       Pragma:
       - no-cache
       Cache-Control:
@@ -8660,11 +8788,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - YVMquqHGys03K3_-KTY-AmiDPg0I4FBioNTnOSJInGpxIoqxcaYj3g==
+      - t1ss3IEwHFrkrQnBXUrpLGswO6MfeuIeXVquz0xa3q0nNhr7r9wa_w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -8711,7 +8839,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DF",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8b",
           "Name": "",
@@ -8770,7 +8898,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:16 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:22 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8d
@@ -8786,9 +8914,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCvqnMdZMFyDCyj8tNFomZtdIpEVJrFZFTC5BtQDFz5vwIgV+950B0EWCclwWDsidRrXwYMpxpj7l5TAcBb3v9HIqI="
+        host date digest",signature="MEYCIQCZYiAMPYh6bGxLGVd6AAsG/hSwB15sPNkc6rvZCTt4tgIhALfrM9hwUQNR0tWncRoa6yQ7e7vhfArhZWIWFGdyiy1x"
       Date:
-      - Tue, 26 Apr 2022 05:03:16 GMT
+      - Wed, 27 Apr 2022 06:19:22 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -8801,16 +8929,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:16 GMT
+      - Wed, 27 Apr 2022 06:19:22 GMT
       Set-Cookie:
-      - AWSALB=QScj08kcYK9lAhjTy3P6SmxhFq8xOfx9fKQ1hm4bC8PRwD36cD9t/poD6Ux7Vg2Tmu1+UIueMuVNT6YKUdoEpPq1vqHEr0sbJ0m7FKOhI/yZhBb98UAbips112wn;
-        Expires=Tue, 03 May 2022 05:03:16 GMT; Path=/
-      - AWSALBCORS=QScj08kcYK9lAhjTy3P6SmxhFq8xOfx9fKQ1hm4bC8PRwD36cD9t/poD6Ux7Vg2Tmu1+UIueMuVNT6YKUdoEpPq1vqHEr0sbJ0m7FKOhI/yZhBb98UAbips112wn;
-        Expires=Tue, 03 May 2022 05:03:16 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=iX3KZThxZwxKVrVIsw64ODKqo7wQjV961vAfSulsaLSgbcntzotKBs+iUsJ41c84LPZvzGAK9emj92KIqHZr0xuCq+7SJ/TLt49KPWWtiEdVObE86MeVu++BYSpQ;
+        Expires=Wed, 04 May 2022 06:19:22 GMT; Path=/
+      - AWSALBCORS=iX3KZThxZwxKVrVIsw64ODKqo7wQjV961vAfSulsaLSgbcntzotKBs+iUsJ41c84LPZvzGAK9emj92KIqHZr0xuCq+7SJ/TLt49KPWWtiEdVObE86MeVu++BYSpQ;
+        Expires=Wed, 04 May 2022 06:19:22 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBfe7eefbed83db558df91787349e33331
+      - NB3d7f9fece2ae8242caf8f882ba3afd1b
       Pragma:
       - no-cache
       Cache-Control:
@@ -8840,11 +8968,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - vlkemnEVCzO7KSU8qV8lLfvUQ6_YlkydYfZ-IQM_J3H5LWyDaEIpNQ==
+      - yWsR5DwPxHPHO-sry9OTrL6j-rTm4cAwJ0oJaVzarsNXgEZQC7q8LQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -8891,7 +9019,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E1",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8d",
           "Name": "",
@@ -8950,7 +9078,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:16 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:22 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d91
@@ -8966,9 +9094,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIA8f1Vmh4AhSTlR0ydtZ97N94glUsoAx/TGQpuwSjeSkAiEAieiGm2tVWXCXdQ9OhNe/yS47VGnmZ28w814XCQ84+84="
+        host date digest",signature="MEYCIQD2ZRXn5EQK3eSYFsrdArQ9b3jBIn2QVFMZPALFWjjGygIhALsGcZXHxVKseI5SRKb3hNHNvFLx1EPwnIHe0/xs/IKJ"
       Date:
-      - Tue, 26 Apr 2022 05:03:16 GMT
+      - Wed, 27 Apr 2022 06:19:22 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -8981,16 +9109,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:17 GMT
+      - Wed, 27 Apr 2022 06:19:22 GMT
       Set-Cookie:
-      - AWSALB=nJrC8lpyKrNYyNmlMoV5yFUjfGtCFJnfoGYGg4tUpDYeMcYmjvBiu3oIlE4olptO1+1nrqU9Dz607QdpxNE/ktQjf5jFtJEiIRt6jOuzzAU8TOXrLebpjIL3ft00;
-        Expires=Tue, 03 May 2022 05:03:17 GMT; Path=/
-      - AWSALBCORS=nJrC8lpyKrNYyNmlMoV5yFUjfGtCFJnfoGYGg4tUpDYeMcYmjvBiu3oIlE4olptO1+1nrqU9Dz607QdpxNE/ktQjf5jFtJEiIRt6jOuzzAU8TOXrLebpjIL3ft00;
-        Expires=Tue, 03 May 2022 05:03:17 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=Oor1mynqzF5aWZ/Z/t9pV1+NLZ+LAWI92F5+RlMAXkO4Ie0P/RoEF7XVq6X+GILvkSezS+TwRAJ29gYj9CnFiCyLSyKBaRf9Ah7feCY9uFuuQnw5jfKYbP+5aGVB;
+        Expires=Wed, 04 May 2022 06:19:22 GMT; Path=/
+      - AWSALBCORS=Oor1mynqzF5aWZ/Z/t9pV1+NLZ+LAWI92F5+RlMAXkO4Ie0P/RoEF7XVq6X+GILvkSezS+TwRAJ29gYj9CnFiCyLSyKBaRf9Ah7feCY9uFuuQnw5jfKYbP+5aGVB;
+        Expires=Wed, 04 May 2022 06:19:22 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4a73bfc81f1c76bf26240d796f79f8e8
+      - NB969edafab94f7fbfcc733ca4701e2e6d
       Pragma:
       - no-cache
       Cache-Control:
@@ -9020,11 +9148,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - RX9zI_aouT7Nov2yzcME-kqzNiijb-FyUPtPKV3g6LIYT7nZtvsVbA==
+      - fphfHv1Uy2zYji3kXEPEeDyzbJtA60WI1EjUol7A9Y07iAgJwW_mYg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -9071,7 +9199,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E5",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d91",
           "Name": "",
@@ -9130,7 +9258,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:17 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:22 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d63
@@ -9146,9 +9274,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIBVngzMvyXSLyIsTqMuEsIMMkrGRNLs2ZwWJ8MueAhP7AiApg8VAgiw4ym0yJbL0rVJUOoa6e0XC6RYt1rv6Y6eM7A=="
+        host date digest",signature="MEUCICqdRO7jCJmxwUrju0tRYW2/VO5PIjy21dshOJ+fZZ58AiEAi/Nxb3c5/qvOmO6Z0giS2KBScHh2g4qW2jlyn6IR5O8="
       Date:
-      - Tue, 26 Apr 2022 05:03:17 GMT
+      - Wed, 27 Apr 2022 06:19:22 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -9161,16 +9289,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:17 GMT
+      - Wed, 27 Apr 2022 06:19:23 GMT
       Set-Cookie:
-      - AWSALB=sfKJilbLEDtmRkXDqgPPj6P7YCTVNQMofjQhuqISBUtfbwgXE+dgYE/t8VTFQYslieYp2Fo5VoUYc4AKYxXWczmZVS0bEyNOAIOmi4DgOuqZXqsodSoUBovZm9ou;
-        Expires=Tue, 03 May 2022 05:03:17 GMT; Path=/
-      - AWSALBCORS=sfKJilbLEDtmRkXDqgPPj6P7YCTVNQMofjQhuqISBUtfbwgXE+dgYE/t8VTFQYslieYp2Fo5VoUYc4AKYxXWczmZVS0bEyNOAIOmi4DgOuqZXqsodSoUBovZm9ou;
-        Expires=Tue, 03 May 2022 05:03:17 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=XtmCYVnVj0C0uED9IEA/x0eZVuLUW1aHmzX5Psr6/Ecu/PXwh6B1djrKrOuUYEAI063FL8XFxQcwOMqdlP6bGGXsQVZPI8wj4IUmKIv/quqbeOZR+fZuUoYK5SZm;
+        Expires=Wed, 04 May 2022 06:19:23 GMT; Path=/
+      - AWSALBCORS=XtmCYVnVj0C0uED9IEA/x0eZVuLUW1aHmzX5Psr6/Ecu/PXwh6B1djrKrOuUYEAI063FL8XFxQcwOMqdlP6bGGXsQVZPI8wj4IUmKIv/quqbeOZR+fZuUoYK5SZm;
+        Expires=Wed, 04 May 2022 06:19:23 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0c1bebb8f0767aca3e754706cf399530
+      - NBa1e3e53411c254a0ff0cd6f85fd979b3
       Pragma:
       - no-cache
       Cache-Control:
@@ -9200,11 +9328,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - kihOC1zpoQ1f862U1KiL6vfpBLkE5hM6Vab70AUeu1QPGyp4QxXLFw==
+      - kNd7m5syKeiZliX3wolqULTPB2OJtE2RWb-KpGIEbKV8sGZZVymS-A==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -9251,7 +9379,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:ED",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d63",
           "Name": "",
@@ -9310,7 +9438,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:17 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:23 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d64
@@ -9326,9 +9454,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQC3sv13AFhyMVcrxx+TLcBJfa1QKb20JoKWHuNhvFWdmQIgLWX2yvS6Ffp7I0UG5/bnbOJWrHjpbiJbfq2JXGO4L24="
+        host date digest",signature="MEUCIQDMo0WckfCuR2nQdHYlc+/XGx7P9lsvbbvgHb/yy1EoBAIgFa6A3R3xQWeEP2RMc48o3+0EsTQkIvo9vVQzips2xY0="
       Date:
-      - Tue, 26 Apr 2022 05:03:17 GMT
+      - Wed, 27 Apr 2022 06:19:23 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -9341,16 +9469,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:17 GMT
+      - Wed, 27 Apr 2022 06:19:23 GMT
       Set-Cookie:
-      - AWSALB=Xc9pOru6jhgcQEd01zZFb9yzSBn1JQO1XZqsKevBiUdYtn/5eRCOobbqTzgf+KCg7sZIGQNK3AbCW7EOe9JBhQW/9ZjUQqqdQ9eT0/HlhmEAjtyKFJVg31k+1fIw;
-        Expires=Tue, 03 May 2022 05:03:17 GMT; Path=/
-      - AWSALBCORS=Xc9pOru6jhgcQEd01zZFb9yzSBn1JQO1XZqsKevBiUdYtn/5eRCOobbqTzgf+KCg7sZIGQNK3AbCW7EOe9JBhQW/9ZjUQqqdQ9eT0/HlhmEAjtyKFJVg31k+1fIw;
-        Expires=Tue, 03 May 2022 05:03:17 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=4WJAM6G1evzIlMIJEsJab2wQFAMOkXCmwbCdXxnuZoF5aordPlJ4gq7M8V5OTtCVQg2oZvuTe5V/zFnBKM0JEH+NoV6MLyC1Ypq/brzQ2Jkg3l/E1dycI0jFBAPv;
+        Expires=Wed, 04 May 2022 06:19:23 GMT; Path=/
+      - AWSALBCORS=4WJAM6G1evzIlMIJEsJab2wQFAMOkXCmwbCdXxnuZoF5aordPlJ4gq7M8V5OTtCVQg2oZvuTe5V/zFnBKM0JEH+NoV6MLyC1Ypq/brzQ2Jkg3l/E1dycI0jFBAPv;
+        Expires=Wed, 04 May 2022 06:19:23 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB51104d75fee98f2f128a0060e2711553
+      - NBcf3dc3e6ebd60cafa6dacee544231c21
       Pragma:
       - no-cache
       Cache-Control:
@@ -9380,11 +9508,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Up6GFvqsBbQlvrOKOMzkjO46lfKcwW33aKlbsL-IcMLNFdkhqypX-Q==
+      - eCN0AuteTkIwehSQx3Q0lTWKRUyObd1rUzZyPNv_UKG7FbCFdP-bjQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -9431,7 +9559,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:EE",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d64",
           "Name": "",
@@ -9490,7 +9618,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:17 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:23 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d66
@@ -9506,9 +9634,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQD000++0DJSJvJE41BRMEGciwDKuaXU1k/G8Ga5gzd9PAIhAI5udbxCWxqe4wDLG+I5G57cHh0+n1rgD0EN1OGDfr9C"
+        host date digest",signature="MEUCICNyAiTlmvhv5vQARz0Nd9KGPkfEVGyDq568Djn+5I14AiEAjQ5FUdpZvtmNI0pZoUHcwltAmh6JVhk30ZDSenISbYY="
       Date:
-      - Tue, 26 Apr 2022 05:03:17 GMT
+      - Wed, 27 Apr 2022 06:19:23 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -9521,16 +9649,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:18 GMT
+      - Wed, 27 Apr 2022 06:19:23 GMT
       Set-Cookie:
-      - AWSALB=gJrPyxkMS3lUvaLK60NpwletmEhK0I1xkZOz/BA+yavp5+tTZfAPAaolFor2XtLQlhFxxA1MUgb7ANesAh8KKULu4+krlxGoJ5+7t3NeEmOL6PKD20fAo7XM7IAE;
-        Expires=Tue, 03 May 2022 05:03:17 GMT; Path=/
-      - AWSALBCORS=gJrPyxkMS3lUvaLK60NpwletmEhK0I1xkZOz/BA+yavp5+tTZfAPAaolFor2XtLQlhFxxA1MUgb7ANesAh8KKULu4+krlxGoJ5+7t3NeEmOL6PKD20fAo7XM7IAE;
-        Expires=Tue, 03 May 2022 05:03:17 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ZvSSbdg1ZG8BNsS90dZxEK3u3leajAcxj0RSF69uzb+7xcyM6nbpNSpOP04sdIYiv7eEc3VnQsBUXJtDTIUHIJghKU1fNrRjSwrZPjubKdrCnMsdYmKi02BCCk0d;
+        Expires=Wed, 04 May 2022 06:19:23 GMT; Path=/
+      - AWSALBCORS=ZvSSbdg1ZG8BNsS90dZxEK3u3leajAcxj0RSF69uzb+7xcyM6nbpNSpOP04sdIYiv7eEc3VnQsBUXJtDTIUHIJghKU1fNrRjSwrZPjubKdrCnMsdYmKi02BCCk0d;
+        Expires=Wed, 04 May 2022 06:19:23 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc72324bf2c3c056dcf63cc77d5283cca
+      - NB5e5224b9ecec17c49cf2eebdf9867177
       Pragma:
       - no-cache
       Cache-Control:
@@ -9560,11 +9688,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - vsF7-CrBwY8dT6QdhEJfheEIHkg3T5kKBvY06qEKi4taufSpMhSKcg==
+      - qOhimpAp4gTuTIBCL1d9HAKPBOmjnZuosirrVf1Cw3CxhxYfaRN9UQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -9611,7 +9739,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F0",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d66",
           "Name": "",
@@ -9670,7 +9798,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:18 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:23 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7c
@@ -9686,9 +9814,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDl3lG0fUqEhDXo0FLQqXCa0I4e4fr/zHaG3SP/6IjCvgIgUXc7w4Fj4wnRLHMBaa1EAhCU6MeA8tBEfIfFRGfIeFg="
+        host date digest",signature="MEUCIGjGNvpOHyhrpqwAiG5pP4Q8/C0SixXetdG0JfIpPPGAAiEAsXnnGHoLwrPtxlYZKF2hSoshXQ9vkpI0Bv0SPL5+nNc="
       Date:
-      - Tue, 26 Apr 2022 05:03:18 GMT
+      - Wed, 27 Apr 2022 06:19:23 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -9701,16 +9829,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:18 GMT
+      - Wed, 27 Apr 2022 06:19:23 GMT
       Set-Cookie:
-      - AWSALB=O8RVvhAYfpIi7aJrV6m5v2TtX3liy7wF4I4dvMN69LeedCKg7CZULyzZyZjz2ljthLWlOkKUWnGPfNjPUj/Y5dqP+3G72vcDyDtm42eP2wzaLt9EYypc9GD7EeqX;
-        Expires=Tue, 03 May 2022 05:03:18 GMT; Path=/
-      - AWSALBCORS=O8RVvhAYfpIi7aJrV6m5v2TtX3liy7wF4I4dvMN69LeedCKg7CZULyzZyZjz2ljthLWlOkKUWnGPfNjPUj/Y5dqP+3G72vcDyDtm42eP2wzaLt9EYypc9GD7EeqX;
-        Expires=Tue, 03 May 2022 05:03:18 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=MFoMsDyH8Np1MERyNpAKTDS7nB1lh7H4Rac+8qf5N52J0lBJaPy0njdu+528RzCxPak0CumzN12x40GvkbU8fmsImqtIDHYYaa5fNAAoTUoFM44DEUqhmki15Mee;
+        Expires=Wed, 04 May 2022 06:19:23 GMT; Path=/
+      - AWSALBCORS=MFoMsDyH8Np1MERyNpAKTDS7nB1lh7H4Rac+8qf5N52J0lBJaPy0njdu+528RzCxPak0CumzN12x40GvkbU8fmsImqtIDHYYaa5fNAAoTUoFM44DEUqhmki15Mee;
+        Expires=Wed, 04 May 2022 06:19:23 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB84a0cbb80daa8ca12f6878068292331b
+      - NB040f4770d146963518cc90565cd0e8e6
       Pragma:
       - no-cache
       Cache-Control:
@@ -9740,11 +9868,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - TcEGJUC1JjnUu2awqwWII_SaERtUUfn8zoBKG_MNESlbJePvpYFG8w==
+      - WIGdDuujUQTPeIcZQ7ZEeFIKRYV1NPrUDrz2ubZR0fje3OJXa83_3w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -9791,7 +9919,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D0",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7c",
           "Name": "",
@@ -9850,7 +9978,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:18 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:23 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d93
@@ -9866,9 +9994,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIAVY2UtiCla7Z4c81tQCuZbcL6Q0uUBjTf4pYd0PxdS7AiA88v2NMM9wQmxxFyfr19URlbeLJttcXwmRIMGx+I/DlA=="
+        host date digest",signature="MEUCIAKRot/uxYipQOuKsAyIaE09eikffGxF/gJ+OvRy2B/vAiEAwbU7cldV4jIlxU6LGlrO1x34T4nWhpBTc31VUmNGwdA="
       Date:
-      - Tue, 26 Apr 2022 05:03:18 GMT
+      - Wed, 27 Apr 2022 06:19:23 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -9881,16 +10009,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:18 GMT
+      - Wed, 27 Apr 2022 06:19:24 GMT
       Set-Cookie:
-      - AWSALB=gzUhZDQWlSbov529oTuyTrM7kdvVwMHn0+YCvhu70yecsf52fkOaAtLNqMqPKdu6wQTYoY+JY9Y4hEi4K7DIzCX+67sF5aY756y8NXfzdQJe5mItuYhMcreXkTwq;
-        Expires=Tue, 03 May 2022 05:03:18 GMT; Path=/
-      - AWSALBCORS=gzUhZDQWlSbov529oTuyTrM7kdvVwMHn0+YCvhu70yecsf52fkOaAtLNqMqPKdu6wQTYoY+JY9Y4hEi4K7DIzCX+67sF5aY756y8NXfzdQJe5mItuYhMcreXkTwq;
-        Expires=Tue, 03 May 2022 05:03:18 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=wjJnnKohHVTgBRfAKELrN9egWzLlKhEF4GBy+movrQKS+EhPuwjR3DUuW8+AhdAO+T1w3Il0aZhg/y5ZCrEEx1NSUOYRexsrKRiy7vDJKz7Qc8U668liPvOoaSEd;
+        Expires=Wed, 04 May 2022 06:19:23 GMT; Path=/
+      - AWSALBCORS=wjJnnKohHVTgBRfAKELrN9egWzLlKhEF4GBy+movrQKS+EhPuwjR3DUuW8+AhdAO+T1w3Il0aZhg/y5ZCrEEx1NSUOYRexsrKRiy7vDJKz7Qc8U668liPvOoaSEd;
+        Expires=Wed, 04 May 2022 06:19:23 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB5ff948a2e248b1653a10ccfe0130ce49
+      - NB1a91d38268a19641fcdc06b7d35d9d4a
       Pragma:
       - no-cache
       Cache-Control:
@@ -9920,11 +10048,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 554FWC6tmnOiz-fVyFGzwziTwM5XDOx_QDqslGBypS4B9G3rtZBsUA==
+      - jN4DHr5wh77eH92dBCXjNsDx8ZVOoc6xeBd2NyuRTdsPM19RLlFz5w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -9971,7 +10099,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E7",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d93",
           "Name": "",
@@ -10030,7 +10158,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:18 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:24 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d62
@@ -10046,9 +10174,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQD4+7ZaxqCv4JzvpZfN9NDpxsvodfbwZ5NRklBiWVErKAIhAPQAIe+mttYqrXzdIiLuS56hAhzAC7hO/XqBSdgVYx4g"
+        host date digest",signature="MEQCIGmEkcrvSAmeWuBulrj5No1GXiZzOOQCaB8c3BawAMArAiAqAan71/sLG479kLedu8H5rtxiRXt7L6S8Jg0w3dYtjg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:18 GMT
+      - Wed, 27 Apr 2022 06:19:24 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -10061,16 +10189,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:18 GMT
+      - Wed, 27 Apr 2022 06:19:24 GMT
       Set-Cookie:
-      - AWSALB=0qLqYouUWNhsw61xF3OqDqjPRpVNBqifvtTggl6uQwDY3R2sWyvH3meIoSpDS5jwOfCxD6iPLo/WbaxdhIcPQ/312G96O8gP7t6EzFjes3fS9Q6yYBiaQ6Xa6hle;
-        Expires=Tue, 03 May 2022 05:03:18 GMT; Path=/
-      - AWSALBCORS=0qLqYouUWNhsw61xF3OqDqjPRpVNBqifvtTggl6uQwDY3R2sWyvH3meIoSpDS5jwOfCxD6iPLo/WbaxdhIcPQ/312G96O8gP7t6EzFjes3fS9Q6yYBiaQ6Xa6hle;
-        Expires=Tue, 03 May 2022 05:03:18 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=asahxZ1Y27hGkutS07nYciQJY2bgYeRmmpJC1EXwTX2Hvd4SQSOiKow2pskPP7SvVA30Z3GRe2IqVWWajkJEPUdTmnGmjrSCuCxOUyNuVr0n3zWDsm9+058hR5aB;
+        Expires=Wed, 04 May 2022 06:19:24 GMT; Path=/
+      - AWSALBCORS=asahxZ1Y27hGkutS07nYciQJY2bgYeRmmpJC1EXwTX2Hvd4SQSOiKow2pskPP7SvVA30Z3GRe2IqVWWajkJEPUdTmnGmjrSCuCxOUyNuVr0n3zWDsm9+058hR5aB;
+        Expires=Wed, 04 May 2022 06:19:24 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd31ffea8e87df9235082c7fd1adbefd1
+      - NB0f8fd6150ad2ba6e68b5ef95d5ff8ac6
       Pragma:
       - no-cache
       Cache-Control:
@@ -10100,11 +10228,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 0hDRNU7ysSNvySV01nSvRDnMPVWPd9oR7ZGEePFki7EnUlHQVf1tgg==
+      - AzJ4QHH-wjF9-pFsRYYWpsHDm3KrYuVcGOPLqa4QWb2FIZq8lJZC9Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -10151,7 +10279,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:EC",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d62",
           "Name": "",
@@ -10210,7 +10338,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:18 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:24 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7a
@@ -10226,9 +10354,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCItrNPVA2FSTsRw/9YF2XlXScxGrD4bnVKwykCSj7JEQIgQNDe0Is0as0yXsdCk6DhIn+t03voMnkyc4Sj54/7FLY="
+        host date digest",signature="MEUCIF73uq/R+bBdm/XYuzNX0e1jjqr/884djZXhRe82hN08AiEAn+5eVYGXg+kMstg+osM4Dsk2mhDgMnuGtfqahSrEWFA="
       Date:
-      - Tue, 26 Apr 2022 05:03:18 GMT
+      - Wed, 27 Apr 2022 06:19:24 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -10241,16 +10369,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:18 GMT
+      - Wed, 27 Apr 2022 06:19:24 GMT
       Set-Cookie:
-      - AWSALB=yGSIHF5DAeXsgQ0LXR53JWtRnTgdqLMqgxI1LIH/R8j/7d8dahGJ/FTew8tNU7GGAhDTThc5rpRhqVnodPlNw5vvhO4Cpfz8fgfzf2/5DVwbPkYCA1HpsQEY4QgW;
-        Expires=Tue, 03 May 2022 05:03:18 GMT; Path=/
-      - AWSALBCORS=yGSIHF5DAeXsgQ0LXR53JWtRnTgdqLMqgxI1LIH/R8j/7d8dahGJ/FTew8tNU7GGAhDTThc5rpRhqVnodPlNw5vvhO4Cpfz8fgfzf2/5DVwbPkYCA1HpsQEY4QgW;
-        Expires=Tue, 03 May 2022 05:03:18 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=2M17FXGhhSBfd6ddUq03S1MnUjKVLuKtPjSQyrZ8EoXLss3VA34OLtAXDrkkLD9LEl+zBiygZDmFOfejvoqldXUX1rKB+4qXZPs418w42Cggdlf1Q7hOuWYH4s74;
+        Expires=Wed, 04 May 2022 06:19:24 GMT; Path=/
+      - AWSALBCORS=2M17FXGhhSBfd6ddUq03S1MnUjKVLuKtPjSQyrZ8EoXLss3VA34OLtAXDrkkLD9LEl+zBiygZDmFOfejvoqldXUX1rKB+4qXZPs418w42Cggdlf1Q7hOuWYH4s74;
+        Expires=Wed, 04 May 2022 06:19:24 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0aac063cf3f0965fb73b3f031962064e
+      - NBb439f9a99004ac01b5857ca89db195bb
       Pragma:
       - no-cache
       Cache-Control:
@@ -10280,11 +10408,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 55pVguqSYCxcny3tNqA7TYSFo2zu8D4rvzDEbOVCdc0kpHE60mWzXg==
+      - D-SErqvfPLq_K4PXhIo0jslF5ekxc1B6_nM8m6hDERnE4zlaUGhHFA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -10331,7 +10459,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CE",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7a",
           "Name": "",
@@ -10390,7 +10518,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:18 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:24 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7b
@@ -10406,9 +10534,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIAWmw7PO2CsmAiVy89kIPxMT8P5/MZArAEynZ5qMVl1rAiEAkDHRaAFmw2WXi37wKnI0MVgnNH/LqnvkigVnJu3yQLU="
+        host date digest",signature="MEUCIQCtjxsgG0uLsfehXGo8NvQSbx4eKbfLBJr2nQoCuGEjyQIgX5WxOdWWtx0+U8lkocL79lks5nbEvUgVW7mN2vE2a5c="
       Date:
-      - Tue, 26 Apr 2022 05:03:18 GMT
+      - Wed, 27 Apr 2022 06:19:24 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -10421,16 +10549,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:19 GMT
+      - Wed, 27 Apr 2022 06:19:24 GMT
       Set-Cookie:
-      - AWSALB=FAcsNxBrYc06WXkNmMcKwnpb5KeHdVRWrh7wVc9/ezBiuA6PsK7VrElqhsGjHdHBRBqiep8u42tY0q2pCKpMyJKuSMEtahoPYKi8Xl8kwqykm/WdlERwbchxjsL8;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/
-      - AWSALBCORS=FAcsNxBrYc06WXkNmMcKwnpb5KeHdVRWrh7wVc9/ezBiuA6PsK7VrElqhsGjHdHBRBqiep8u42tY0q2pCKpMyJKuSMEtahoPYKi8Xl8kwqykm/WdlERwbchxjsL8;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=AfhMWNj8BAwNtPias87TCY25bpy4CDgwFZftQ3gLehgyql4U/SozSr9F8A8JrIX8TfHaWJKMzSdMlf2p5Oz9CyFYLNYVdQReNNnYvzmMzWec0r9ixF5L7sVuO9mN;
+        Expires=Wed, 04 May 2022 06:19:24 GMT; Path=/
+      - AWSALBCORS=AfhMWNj8BAwNtPias87TCY25bpy4CDgwFZftQ3gLehgyql4U/SozSr9F8A8JrIX8TfHaWJKMzSdMlf2p5Oz9CyFYLNYVdQReNNnYvzmMzWec0r9ixF5L7sVuO9mN;
+        Expires=Wed, 04 May 2022 06:19:24 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB31d06579d78c8595fa0988423f526832
+      - NB2324245acc1c7e654a8d06d8bed42d4e
       Pragma:
       - no-cache
       Cache-Control:
@@ -10460,11 +10588,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - MRb0Rg5VPyDne4JSslC57g4MUlPz4rLBlbr8E46Tmmwc8LPag4lsYw==
+      - s5ZxAmbkeacRKMpQ32ahW7V7b9xXW4rhNXD8ITk9_keHRRmQQVFtdw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -10511,7 +10639,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CF",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7b",
           "Name": "",
@@ -10570,7 +10698,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:19 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:24 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8e
@@ -10586,9 +10714,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIFd/RtHM6Cn71wEkbduL8MSb7uTPQSVs/HZDrbnXP/IWAiEA8wJjOSt92EeY6pcNT6As5hpOIdfE4hUEx1HIhnF25JQ="
+        host date digest",signature="MEQCIFdXDbIQYA/I1aMp9v106M9m/nynK3E4aQmDcYR5w1ygAiBW0rKYoVgknQz91LwijUCdPbOLG3vPAM67ubjVoTqeWA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:19 GMT
+      - Wed, 27 Apr 2022 06:19:24 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -10601,16 +10729,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:19 GMT
+      - Wed, 27 Apr 2022 06:19:25 GMT
       Set-Cookie:
-      - AWSALB=kDz40wshuDSqGDImiKq0NGEH1eS5I2/ErJDHDp7YL4XAfWQSwyHQUfL/guwYI0ZWHTJfAFTt/S8Nor4chpsumWOkGm92YYmjXJQZqCkSapU8P+RG9WWcW4bsS1sn;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/
-      - AWSALBCORS=kDz40wshuDSqGDImiKq0NGEH1eS5I2/ErJDHDp7YL4XAfWQSwyHQUfL/guwYI0ZWHTJfAFTt/S8Nor4chpsumWOkGm92YYmjXJQZqCkSapU8P+RG9WWcW4bsS1sn;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=gFQFbjXalp15xjuuNIUS2AF7904tvO9XtyKmzjb1+1xuAFk3BnfVxTD/iCab/qiuJuXzPtr5WKnC9ZOgp94GrqyHFmVrw26w6NiKSD7m5jLSCMfXlhP7OZfhgFZC;
+        Expires=Wed, 04 May 2022 06:19:24 GMT; Path=/
+      - AWSALBCORS=gFQFbjXalp15xjuuNIUS2AF7904tvO9XtyKmzjb1+1xuAFk3BnfVxTD/iCab/qiuJuXzPtr5WKnC9ZOgp94GrqyHFmVrw26w6NiKSD7m5jLSCMfXlhP7OZfhgFZC;
+        Expires=Wed, 04 May 2022 06:19:24 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd150ddd26e9240e5f14033d1f025c41c
+      - NBa3dacf9ec615932eb173886128839e1c
       Pragma:
       - no-cache
       Cache-Control:
@@ -10640,11 +10768,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - aUgvBlIhRJpG92-yy1RltnnizPBWgkddKrSAHSBdSPO_WQfeSSVAaQ==
+      - Ad6f1nDla2ft6YMglATkvCtv0fVBp7EfgxQsXv3zV3OIYSjF_wrGGQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -10691,7 +10819,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E2",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8e",
           "Name": "",
@@ -10750,7 +10878,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:19 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:25 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d69
@@ -10766,9 +10894,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQD6do6cZInBEkEiHmfpmg6yxQHgSXYcqy80ZrThpUfLVQIhAKpIkV1V6svPjUDdFg3o7cyihQ5mi1xUUxCw3yHjYddw"
+        host date digest",signature="MEYCIQDf9dwevYlvmYgr3SsuaQcI35cUiLIjzAxdczOMGKe7UgIhALWvTaNpoIY3tFx5BJ8684EoOBLlnoaoJkKKXrEvJvQ2"
       Date:
-      - Tue, 26 Apr 2022 05:03:19 GMT
+      - Wed, 27 Apr 2022 06:19:25 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -10781,16 +10909,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:19 GMT
+      - Wed, 27 Apr 2022 06:19:25 GMT
       Set-Cookie:
-      - AWSALB=OOJJl5Ywx/krmk4nZ1ukn4bZsLWHH9yk/eEgckr8qp8/GpCovDDskL6zn6AwP2YIWznf4hyt/uAxJeaat0mduzdh6s0VtIeume2Xpb0ZAvhK0omCOljtCbvzJD8X;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/
-      - AWSALBCORS=OOJJl5Ywx/krmk4nZ1ukn4bZsLWHH9yk/eEgckr8qp8/GpCovDDskL6zn6AwP2YIWznf4hyt/uAxJeaat0mduzdh6s0VtIeume2Xpb0ZAvhK0omCOljtCbvzJD8X;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=6vHHlDJOXkB7pbIVFrHUNat90+Jp9VAkCG3jAp2cRfprA0KcgN6Y7/KNcMmZZyTrBliWyW5IY3Wk7wit7eR/OYq6iEKfjL6F7ktSDJlmd8c4m5an1/yrSnlyD8dd;
+        Expires=Wed, 04 May 2022 06:19:25 GMT; Path=/
+      - AWSALBCORS=6vHHlDJOXkB7pbIVFrHUNat90+Jp9VAkCG3jAp2cRfprA0KcgN6Y7/KNcMmZZyTrBliWyW5IY3Wk7wit7eR/OYq6iEKfjL6F7ktSDJlmd8c4m5an1/yrSnlyD8dd;
+        Expires=Wed, 04 May 2022 06:19:25 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB62b5e9d5d60d34655a58776b4ecaa9c8
+      - NB432994c2447e4cd0814873609275b69f
       Pragma:
       - no-cache
       Cache-Control:
@@ -10820,11 +10948,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - pCLBOLkRiRAU9lHMui2-bw2qbKySt-cYjBg5ntRgNuYJaBV_EocBhQ==
+      - LUjXVzP7K1-MXxVmPe8Bdbrl9uV0KN99VoDwb9XwGQ5mB-7XxZglQg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -10871,7 +10999,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F3",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d69",
           "Name": "",
@@ -10930,7 +11058,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:19 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:25 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d79
@@ -10946,9 +11074,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHhtz1UO4B+U+ftLrDeAJat93uZ0fBvGvI/7jf3LSgKZAiEAmgYfQDMrwcSkaq/LRnO+XJOcWKQqFxoPSWFU4BqqPK0="
+        host date digest",signature="MEUCIQDmtdaXAAJG1WCYjsJ+eefR3y7MN8cpalE+z1FrvLDoLAIgK+JJ2lMuqe0W9lOzlzCTBxXOMjCmN0j0KEbwz5lQKdo="
       Date:
-      - Tue, 26 Apr 2022 05:03:19 GMT
+      - Wed, 27 Apr 2022 06:19:25 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -10961,16 +11089,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:19 GMT
+      - Wed, 27 Apr 2022 06:19:25 GMT
       Set-Cookie:
-      - AWSALB=/irkUPb6epdTIXRvC93kCxgs1YyxPKfEyIPY3vRQhNiFOBg+CjcOuQq4XNShHomMRHW6Bekl7HzVkWzsTkiVe46IF+jJ7ISFIBJ8ec0PGDevf22zT0pfmwFOyZkK;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/
-      - AWSALBCORS=/irkUPb6epdTIXRvC93kCxgs1YyxPKfEyIPY3vRQhNiFOBg+CjcOuQq4XNShHomMRHW6Bekl7HzVkWzsTkiVe46IF+jJ7ISFIBJ8ec0PGDevf22zT0pfmwFOyZkK;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=3fAbQPhjKVrX4omEShiMbLDJpN7FD3acj0+qjh4gAjPANkGmxhuFOzWuvfmy60AkQEdwNNwZajAFfdLrDRExkuUL+9QzoUuBPdwbmCLrzzoW1xr8YwoMBWf3TGdE;
+        Expires=Wed, 04 May 2022 06:19:25 GMT; Path=/
+      - AWSALBCORS=3fAbQPhjKVrX4omEShiMbLDJpN7FD3acj0+qjh4gAjPANkGmxhuFOzWuvfmy60AkQEdwNNwZajAFfdLrDRExkuUL+9QzoUuBPdwbmCLrzzoW1xr8YwoMBWf3TGdE;
+        Expires=Wed, 04 May 2022 06:19:25 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB469a7f19b103fa25d572d9de5d69d98c
+      - NBe0d8edd9a2417b8a804f44b39a481524
       Pragma:
       - no-cache
       Cache-Control:
@@ -11000,11 +11128,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - FY_0htmaTa8t1eS8ICq_uKeRNFHgJ-bMT1gs_HXfv0RdXFVBB_WUTw==
+      - pO1Ab1C_qW81SdBIpEe3IoUZREgUC8UUjslXha3-eA2AbHNZkrKDHA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -11051,7 +11179,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CD",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d79",
           "Name": "",
@@ -11110,7 +11238,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:19 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:25 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7d
@@ -11126,9 +11254,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIAVkNWpAx9WR0xRwnWnmoNrhLj6OqiAPlj9KAy8Q0Ya1AiBZeZi4gAVvwa1M+R+8XgJ8xPL1HidShJDhZh1qQw3Beg=="
+        host date digest",signature="MEUCIQCl9P/HdCcrwHfEwy+DfH3hC7P8C9aumHNIZhPyR8slUAIgAayveR+vlP/YLvzecbdrQQ29wRSqDiHTJ0mEOQhZMac="
       Date:
-      - Tue, 26 Apr 2022 05:03:19 GMT
+      - Wed, 27 Apr 2022 06:19:25 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -11141,16 +11269,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:19 GMT
+      - Wed, 27 Apr 2022 06:19:25 GMT
       Set-Cookie:
-      - AWSALB=qdhBvPSE3R47KF5FS5gKzGsiDlxH2uD6KNssk36zzPRBVHWSDfTnpJCL5HZAmiH7ljVykUI/M6fBYzfC2VY0qH6/cl1gLgy0EAGsDC6zhXpvEGfLvnJBvTzEfIII;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/
-      - AWSALBCORS=qdhBvPSE3R47KF5FS5gKzGsiDlxH2uD6KNssk36zzPRBVHWSDfTnpJCL5HZAmiH7ljVykUI/M6fBYzfC2VY0qH6/cl1gLgy0EAGsDC6zhXpvEGfLvnJBvTzEfIII;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=aqgyC1AFBKxPaVlDi3SfswnIKG9+ds0+jEMR1obiDKIAiqMQk4c+ej6ZMlC5EYofJNlrnnKEw/tNxZT4LCezXAbqemHe/bjeCVqDbqsjBNeX2hinMUvUh3Sh4gqb;
+        Expires=Wed, 04 May 2022 06:19:25 GMT; Path=/
+      - AWSALBCORS=aqgyC1AFBKxPaVlDi3SfswnIKG9+ds0+jEMR1obiDKIAiqMQk4c+ej6ZMlC5EYofJNlrnnKEw/tNxZT4LCezXAbqemHe/bjeCVqDbqsjBNeX2hinMUvUh3Sh4gqb;
+        Expires=Wed, 04 May 2022 06:19:25 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB5cdba42bd02bc93f8444878a0a6d0dce
+      - NB30fbd41754e21aa0481f1b20cc09015a
       Pragma:
       - no-cache
       Cache-Control:
@@ -11180,11 +11308,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - epjx_x7gyDytRtN4AQZBbxbpdnA7pKUABqpllS-nYV6fIr3d8PfxCg==
+      - fMC1Ge6fsueF_3N6Ru0na6_cGfF8CErXRVc2GhgCYFfkQuCoSVDSqA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -11231,7 +11359,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D1",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7d",
           "Name": "",
@@ -11290,7 +11418,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:19 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:25 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8c
@@ -11306,9 +11434,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQC0nx247T2fPaJEvdY9FxS7wpL7ihNSHoG8eA7WXn9RCAIhAKYm5Ls3Uj2OAyfmIiJlNtoUzgxZmM/9J1CYFsR/vG8E"
+        host date digest",signature="MEQCIG5mfMU4mhCUn/WBqkrlzZwiDHDpTplZqsjmo1R/a6cdAiA6KsS+cfm/YUgmATUc/1cNAmv6feKgcSUg59ys/EQIAw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:19 GMT
+      - Wed, 27 Apr 2022 06:19:25 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -11321,16 +11449,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:20 GMT
+      - Wed, 27 Apr 2022 06:19:25 GMT
       Set-Cookie:
-      - AWSALB=ypXa+9dzIJ17Snw76URprR1eUijKJYod03nMrnCA9RgYHIxGmF7IX5iIUL77O9GTZ+mgtg/La/R51UZ2iWqP32SKebvXRA600wJ5Lv6IqFr8mkrOU5ARYGPtKZRn;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/
-      - AWSALBCORS=ypXa+9dzIJ17Snw76URprR1eUijKJYod03nMrnCA9RgYHIxGmF7IX5iIUL77O9GTZ+mgtg/La/R51UZ2iWqP32SKebvXRA600wJ5Lv6IqFr8mkrOU5ARYGPtKZRn;
-        Expires=Tue, 03 May 2022 05:03:19 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=hByfYLSaDTFoFNUWKP0NCcFIJDAENDgkjhI97tC++GYBFasvyjo5u+CdWgj9hOdMLisTYkBv8kOZCgWUmjq9/rzmBM9T+uqj6ka4KnHoMKp/xlC8FcrBVrOUgdoc;
+        Expires=Wed, 04 May 2022 06:19:25 GMT; Path=/
+      - AWSALBCORS=hByfYLSaDTFoFNUWKP0NCcFIJDAENDgkjhI97tC++GYBFasvyjo5u+CdWgj9hOdMLisTYkBv8kOZCgWUmjq9/rzmBM9T+uqj6ka4KnHoMKp/xlC8FcrBVrOUgdoc;
+        Expires=Wed, 04 May 2022 06:19:25 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb3583fc20583f810b91400965192cb25
+      - NB7e97d4f8d70a779bcf770a9e42297f8e
       Pragma:
       - no-cache
       Cache-Control:
@@ -11360,11 +11488,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 5Yj5gLw0c8Pgsv5J_fx4k-ZVQr-t-RkUTEyHTmLMfahh3PgvE4CC8w==
+      - c01pUOEp1BxHDC2o9pB1ZQ9yOuiwOHaccBSXluQco7IyKtsf_E7RZg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -11411,7 +11539,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E0",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8c",
           "Name": "",
@@ -11470,7 +11598,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:20 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:26 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d65
@@ -11486,9 +11614,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDwxRU3ZM17vvd9xXxwlzPa51iPPgDWh0Sg8B5cNEACmgIhAOinC3q0Rw4/Ef1i+aRMnGehBDRKwTn5FHw+3d2B5dSn"
+        host date digest",signature="MEQCIBxUj+7n8hJDM7OSzsLVgvvYSVamDvJyYNAp0bTYVklNAiBuLsR8m/80ID1fT0HHvnhg3KojtwoOc4DiVuKUZH6Osw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:20 GMT
+      - Wed, 27 Apr 2022 06:19:26 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -11501,16 +11629,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:20 GMT
+      - Wed, 27 Apr 2022 06:19:26 GMT
       Set-Cookie:
-      - AWSALB=aRT1hlEcFs6ugYxEtyDQOrcOA1nKQdVWGhJUzS2ehDQvcsTYJIrV2c8JdTxzFGavoY6F83GEmqUz2kT5xSb4b/53FSOnPvl4NZECq8OnizrnW+wLZYFzvPJ2cZPO;
-        Expires=Tue, 03 May 2022 05:03:20 GMT; Path=/
-      - AWSALBCORS=aRT1hlEcFs6ugYxEtyDQOrcOA1nKQdVWGhJUzS2ehDQvcsTYJIrV2c8JdTxzFGavoY6F83GEmqUz2kT5xSb4b/53FSOnPvl4NZECq8OnizrnW+wLZYFzvPJ2cZPO;
-        Expires=Tue, 03 May 2022 05:03:20 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=mZ7LT6mRXFR+byBu7WolGuiDq2YCB3wnEUg5I2akttP4PYWJ/+oJ6pTeQRJuGyBT/uYaG73S0DuJ8ui+0YCNGuYL8AtkCT9JbW0ZKX1VS5NmggGl305dwuAd3/vF;
+        Expires=Wed, 04 May 2022 06:19:26 GMT; Path=/
+      - AWSALBCORS=mZ7LT6mRXFR+byBu7WolGuiDq2YCB3wnEUg5I2akttP4PYWJ/+oJ6pTeQRJuGyBT/uYaG73S0DuJ8ui+0YCNGuYL8AtkCT9JbW0ZKX1VS5NmggGl305dwuAd3/vF;
+        Expires=Wed, 04 May 2022 06:19:26 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB36fa97d1e280dcc1838f12dc6c808541
+      - NB048d085f88997f0bcb9c0b7c129ec7c3
       Pragma:
       - no-cache
       Cache-Control:
@@ -11540,11 +11668,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Vu7WAOn1kRqPC3wQi3UIAzHd_F_45_hXHoc8t56jjSHgT6dpFDWrlA==
+      - SPI0t03v7WBuctiWQcLNFmbni9QgSLWMAkh-ZxBPwW5CRpiaBJC2xA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -11591,7 +11719,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:EF",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d65",
           "Name": "",
@@ -11650,7 +11778,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:20 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:26 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d92
@@ -11666,9 +11794,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCrA+/6jOUwrOy+ChBbG351Y5DPnQkv6qsxroWj76RCdQIhANa2c+xGhkT4Y3DxphcMRZmtu6H7s2C1AnF5bF2jaHU5"
+        host date digest",signature="MEYCIQDDZcn4vm8noUjO2bFFTKg/Ak/8uS7bJ0kVEu5k6C4EjwIhAPj6PhDb21dGntTd3ubXM9iCceuLx9tDTL7H2cfoK3pm"
       Date:
-      - Tue, 26 Apr 2022 05:03:20 GMT
+      - Wed, 27 Apr 2022 06:19:26 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -11681,16 +11809,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:20 GMT
+      - Wed, 27 Apr 2022 06:19:26 GMT
       Set-Cookie:
-      - AWSALB=JrXo3ARLR+iUTp4QsZ5alUX+vrxYBXZ0HU5WU1FNafHOqzcJvjdz6QjgR3mdmwXbFX9o6GacP6J/tCCA34Q21aI1mcbEGTKw/rfWhebew81i52+kg20qQaQDRDm9;
-        Expires=Tue, 03 May 2022 05:03:20 GMT; Path=/
-      - AWSALBCORS=JrXo3ARLR+iUTp4QsZ5alUX+vrxYBXZ0HU5WU1FNafHOqzcJvjdz6QjgR3mdmwXbFX9o6GacP6J/tCCA34Q21aI1mcbEGTKw/rfWhebew81i52+kg20qQaQDRDm9;
-        Expires=Tue, 03 May 2022 05:03:20 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=BtDpI0fIseXgfFCd/A9whtBIX2mRWcks09kRe7PFb2eUM5bPINDTA61Xc2m0naZpBLY6ibHp8qHpd4a79VluLxjvVd9Pa40/vgPaLgKCdLthI0ZE2lDv4s542ND6;
+        Expires=Wed, 04 May 2022 06:19:26 GMT; Path=/
+      - AWSALBCORS=BtDpI0fIseXgfFCd/A9whtBIX2mRWcks09kRe7PFb2eUM5bPINDTA61Xc2m0naZpBLY6ibHp8qHpd4a79VluLxjvVd9Pa40/vgPaLgKCdLthI0ZE2lDv4s542ND6;
+        Expires=Wed, 04 May 2022 06:19:26 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb3d0f8853ec5e87f52a8ae45c5f52747
+      - NBea44790207ff894149c9c2a4407de369
       Pragma:
       - no-cache
       Cache-Control:
@@ -11720,11 +11848,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 3zs_J80Uw1k7GXCeMyZWzwol-l6WK-EDO0acFLd80WetAc13MEGdHw==
+      - gYAf-ei6aru1Kr2dWAUnwR9bWXRmdaTgGR3pB-svnEp7qGIBEPFSfA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -11771,7 +11899,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E6",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d92",
           "Name": "",
@@ -11830,7 +11958,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:20 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:26 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d60
@@ -11846,9 +11974,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQD5wfqZr5WwyWoLHx5mhR2/2W91b9PO/fBBfJ5PIV5LpQIhALCz55NyIXsYd7NCb3k7IZMR29t3jZpuZ8BOqT9NbYdG"
+        host date digest",signature="MEUCIQCqU0rduoJfXBauEUz56A9HkGlMKWrRpQE+tsgnD5/r5wIgaF5nt56rPovjWKmYIqreh7h9+StKee6KrVnpBIlUmDU="
       Date:
-      - Tue, 26 Apr 2022 05:03:20 GMT
+      - Wed, 27 Apr 2022 06:19:26 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -11861,16 +11989,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:20 GMT
+      - Wed, 27 Apr 2022 06:19:26 GMT
       Set-Cookie:
-      - AWSALB=qz8IRy6xqbB3/25cSTuaj6Af7mdird3a2KGNf6lZ0oskCTDYzNVUA5ZzlU69gtdnvayBmkB7CaZVHxbwMb0phv46xk458v1KTvNNPWPZJ/eyqnjCqEkDEnvaVdao;
-        Expires=Tue, 03 May 2022 05:03:20 GMT; Path=/
-      - AWSALBCORS=qz8IRy6xqbB3/25cSTuaj6Af7mdird3a2KGNf6lZ0oskCTDYzNVUA5ZzlU69gtdnvayBmkB7CaZVHxbwMb0phv46xk458v1KTvNNPWPZJ/eyqnjCqEkDEnvaVdao;
-        Expires=Tue, 03 May 2022 05:03:20 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=WprL8eYycjnu7XlAVFgDry9h0sUv8Oqj/usDpktpyiMyRmje7yzLb4mZgwf9r33gE3tEck82tET0XZlepXKluNhlGNPpfyd4osChsm4xKoz+CadzxVeF46NyFu0a;
+        Expires=Wed, 04 May 2022 06:19:26 GMT; Path=/
+      - AWSALBCORS=WprL8eYycjnu7XlAVFgDry9h0sUv8Oqj/usDpktpyiMyRmje7yzLb4mZgwf9r33gE3tEck82tET0XZlepXKluNhlGNPpfyd4osChsm4xKoz+CadzxVeF46NyFu0a;
+        Expires=Wed, 04 May 2022 06:19:26 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc146081426d071f3ce774a5ef1f478aa
+      - NB0501dc9796781e73b9a2034b4598e7ba
       Pragma:
       - no-cache
       Cache-Control:
@@ -11900,11 +12028,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - er6BE5qhDHdc_37a3soiUqwbgQo2okfqKNJqTuqEhwO5I-xC5UcXaw==
+      - Dum7wK-1th_pOJJSVfl7Ux8myg7xm1LRb38A30bsVErcCS5fL-bNeg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -11951,7 +12079,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:EA",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d60",
           "Name": "",
@@ -12010,7 +12138,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:20 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:26 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6e
@@ -12026,9 +12154,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCICnJ7d/zGewj/kY8mQTLPpPbNx42z+nfeGZLedbx81p1AiEA47c6KJx0M7JrZN/9pNOBOJaxVIG9r4A5718VbqI9PqQ="
+        host date digest",signature="MEQCHy5Vv+DPuKYI0z+VXkEVlAKMgWrusnz6YbOYLz0MS6kCIQCEjulsdQaO/5Qp4mZmZvNj98n03JqQJeUZZD3YgYesBA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:20 GMT
+      - Wed, 27 Apr 2022 06:19:26 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -12041,16 +12169,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:20 GMT
+      - Wed, 27 Apr 2022 06:19:26 GMT
       Set-Cookie:
-      - AWSALB=c+FYn7LW1OkXw0TnJZXH8YKz5dQD6uTMsm7vYky/b0heIdPjqMhS+28z7/nFEnQqbaWBk4IvWwe+hPKJGSaj+G7rW8g59Cheg5y4slrledGd6e1nSfOWb9JId26B;
-        Expires=Tue, 03 May 2022 05:03:20 GMT; Path=/
-      - AWSALBCORS=c+FYn7LW1OkXw0TnJZXH8YKz5dQD6uTMsm7vYky/b0heIdPjqMhS+28z7/nFEnQqbaWBk4IvWwe+hPKJGSaj+G7rW8g59Cheg5y4slrledGd6e1nSfOWb9JId26B;
-        Expires=Tue, 03 May 2022 05:03:20 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=sC4HL3RERoK0UTqmJCN8feelK6RsPF1GimFjbP01yhp+13BtCNB2Cx9xaOL2xLvP2VzGcUaQCt9t6L2iMDqKz/CaBaSPDi+kejFe69IvUUICR0lk1n27V+W3R+hW;
+        Expires=Wed, 04 May 2022 06:19:26 GMT; Path=/
+      - AWSALBCORS=sC4HL3RERoK0UTqmJCN8feelK6RsPF1GimFjbP01yhp+13BtCNB2Cx9xaOL2xLvP2VzGcUaQCt9t6L2iMDqKz/CaBaSPDi+kejFe69IvUUICR0lk1n27V+W3R+hW;
+        Expires=Wed, 04 May 2022 06:19:26 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBeb96203b083cf83f7da018c15fd62805
+      - NB08d868d6ec21371b8de87ffa3a0ec741
       Pragma:
       - no-cache
       Cache-Control:
@@ -12080,11 +12208,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - iQ10Jit6vWjKcjs6wptAYwiFaPG37EnX0kqQlNQggkpvVXIIQq_17g==
+      - IUUkiT_fdbap3E4aVOzqhOIxLpAwcW7uGRIOoj6EfiMlwU09v-m66Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -12131,7 +12259,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F8",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "trunk",
           "Moid": "614ce25c4630312d42bf1d6e",
           "Name": "",
@@ -12190,7 +12318,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:21 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:26 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d83
@@ -12206,9 +12334,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIGnUyN51mWglde7b10S5TU+FkGWh4Hu8D2JUu6bvPWVOAiEAxQcE0zjquW5p6ry8dQ7K4yPXq0LW//OwEgYl7fag9zw="
+        host date digest",signature="MEUCIQDq9tPMqKOpco2H+ZRe9C8b1Yb1veBy8g9t7jjqXzCBKQIgYbK50CGqKZHlkfNvu8EMxFuV0AD68I4R38dV4L8imZg="
       Date:
-      - Tue, 26 Apr 2022 05:03:21 GMT
+      - Wed, 27 Apr 2022 06:19:26 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -12221,16 +12349,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:21 GMT
+      - Wed, 27 Apr 2022 06:19:27 GMT
       Set-Cookie:
-      - AWSALB=443TqE18q3aGv9C+nA8h5g2fUDn7T96wNs5tjinP3xHeB8IvF67yWVpduB6MUeVwptj4o/f4RMQTOb17Puu5l7FTc4x+9l5juevEPzdhv1u0gQ2BgBhm2El9wdZJ;
-        Expires=Tue, 03 May 2022 05:03:21 GMT; Path=/
-      - AWSALBCORS=443TqE18q3aGv9C+nA8h5g2fUDn7T96wNs5tjinP3xHeB8IvF67yWVpduB6MUeVwptj4o/f4RMQTOb17Puu5l7FTc4x+9l5juevEPzdhv1u0gQ2BgBhm2El9wdZJ;
-        Expires=Tue, 03 May 2022 05:03:21 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=2S7/PlkdTv42J73PJ5WnCPaaSnnNZKLqhD9EZFZAGT7CAaf3silXYdHJlhON53ru42JFGC7dtoTTY6kgYQyWzvuPOynPJ6XnhukVCYQt/vjwds6DPgMtdXiEwm34;
+        Expires=Wed, 04 May 2022 06:19:27 GMT; Path=/
+      - AWSALBCORS=2S7/PlkdTv42J73PJ5WnCPaaSnnNZKLqhD9EZFZAGT7CAaf3silXYdHJlhON53ru42JFGC7dtoTTY6kgYQyWzvuPOynPJ6XnhukVCYQt/vjwds6DPgMtdXiEwm34;
+        Expires=Wed, 04 May 2022 06:19:27 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe90a49d7fb93cd1938049262d212ed20
+      - NB5d889f2e896a9bcc4e118d7fd532a168
       Pragma:
       - no-cache
       Cache-Control:
@@ -12260,11 +12388,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - GQbhYikCq7A7aiNtQ83aRroSYWtVpFBao2ELy1Fb4OQ2PZqJo4XXYA==
+      - 99-tMqj9abaDV7uvXjPT5RiMtWaA1KZTUmTnAEBks4jjKWtjH8ayUw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -12311,7 +12439,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D7",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d83",
           "Name": "",
@@ -12370,7 +12498,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:21 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:27 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d87
@@ -12386,9 +12514,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDmuw2KZjMW1ADlTXT7OR37YpXwd5OP4tQzP6rczD9mKQIgKkCoyfceSfLXraNrAdpq5WmMk1JKeplTPN9pZuj9wa0="
+        host date digest",signature="MEYCIQDxF5NS8RsmtaE5JjjlhzuBPrpJCldwHqTKt4oO5iSXQgIhAPBf3oLSKRr9cRbkRAalDPCtWZ4rQrRhKRMxBbkm756x"
       Date:
-      - Tue, 26 Apr 2022 05:03:21 GMT
+      - Wed, 27 Apr 2022 06:19:27 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -12401,16 +12529,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:21 GMT
+      - Wed, 27 Apr 2022 06:19:27 GMT
       Set-Cookie:
-      - AWSALB=OA4es4ZzwH7D6GGXvuFbkn+iu0UmOZjCVwlG6qdK4bgKK7+99JiivBFMXLQtaTarLfQSDJB3xNTMRI3UMFqHYHQnbPMdWcnWzRcwyFttWpv7asAcZm7zIFPVjelK;
-        Expires=Tue, 03 May 2022 05:03:21 GMT; Path=/
-      - AWSALBCORS=OA4es4ZzwH7D6GGXvuFbkn+iu0UmOZjCVwlG6qdK4bgKK7+99JiivBFMXLQtaTarLfQSDJB3xNTMRI3UMFqHYHQnbPMdWcnWzRcwyFttWpv7asAcZm7zIFPVjelK;
-        Expires=Tue, 03 May 2022 05:03:21 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=h1c5zGD/rwV9OMMuvZmld75N5MDh+IIbpveYql0UisNpW+ePdI4cAL/p+PWdVm4AsWNohgJK0t+7JBLvIffkahFyioy3D5TTitni3O07FngK7iAk8VxXgwO6CPhY;
+        Expires=Wed, 04 May 2022 06:19:27 GMT; Path=/
+      - AWSALBCORS=h1c5zGD/rwV9OMMuvZmld75N5MDh+IIbpveYql0UisNpW+ePdI4cAL/p+PWdVm4AsWNohgJK0t+7JBLvIffkahFyioy3D5TTitni3O07FngK7iAk8VxXgwO6CPhY;
+        Expires=Wed, 04 May 2022 06:19:27 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBaf22b6de4f1029322fcd51c659d14801
+      - NBbf5d01470d949517ca62314a943c00dd
       Pragma:
       - no-cache
       Cache-Control:
@@ -12440,11 +12568,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Gjas_PI--WDXegD0LZrMtGqP44VG1hWUO67pMh7SiQq_QeNknjrYww==
+      - roziF-QAi-y6UCyHzVFZuer6-fz1EdXNewKLBLp-NDj1_PGoPmFDhA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -12491,7 +12619,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DB",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25c4630312d42bf1d87",
           "Name": "",
@@ -12550,7 +12678,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:21 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:27 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d5e
@@ -12566,9 +12694,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIEXD/+QUqsuF0u7NJkt3fm0MkcE3bOVx5f0O86PzIRdxAiAM5RFbHpqZZqpDEXt8yWFca9ICuanbsBd1sbiyyG39Dg=="
+        host date digest",signature="MEUCIBCdwcqc1JZW4PeskA8Jv/gdyDUmxLfw2ro6oVnRf2VSAiEAk3XxlpInAen67wYuAwt4C4xQee/subROGDF2Nt5b3go="
       Date:
-      - Tue, 26 Apr 2022 05:03:21 GMT
+      - Wed, 27 Apr 2022 06:19:27 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -12581,16 +12709,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:21 GMT
+      - Wed, 27 Apr 2022 06:19:27 GMT
       Set-Cookie:
-      - AWSALB=CwVHb1JvCn2eqgD1k1/lKjijQkGW+5bCu0X2rgr71lvbX4oItM/fyVPfvoULs8RnuQvUYprvrcqRxiMnUbiPSyxWu1/1776+zeAXxJCLQ/C9BHcKencOGEO8pwNM;
-        Expires=Tue, 03 May 2022 05:03:21 GMT; Path=/
-      - AWSALBCORS=CwVHb1JvCn2eqgD1k1/lKjijQkGW+5bCu0X2rgr71lvbX4oItM/fyVPfvoULs8RnuQvUYprvrcqRxiMnUbiPSyxWu1/1776+zeAXxJCLQ/C9BHcKencOGEO8pwNM;
-        Expires=Tue, 03 May 2022 05:03:21 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=vsW/vPx82KFwbF5bQ8IMO0MFn8emQzTxUBvNBxI+5l5bVzC2DW3zr7wWvuAmvzduKORCa7IfZgDEoc0KZ7d2ka07HSjuuRL7FxDJ46GfDeAttdUKE93IDLU21tvW;
+        Expires=Wed, 04 May 2022 06:19:27 GMT; Path=/
+      - AWSALBCORS=vsW/vPx82KFwbF5bQ8IMO0MFn8emQzTxUBvNBxI+5l5bVzC2DW3zr7wWvuAmvzduKORCa7IfZgDEoc0KZ7d2ka07HSjuuRL7FxDJ46GfDeAttdUKE93IDLU21tvW;
+        Expires=Wed, 04 May 2022 06:19:27 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB75c63d3a68ca972386f350937ef76f8c
+      - NB12b83aae8340a1b8e23aee7b6528c22f
       Pragma:
       - no-cache
       Cache-Control:
@@ -12620,11 +12748,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - kH38NAYCnwepb6oABtsGyMhyQLA2fUOe8sWozedcAH3Bmhx0UBBjqQ==
+      - 1JeeeMkBE5NTPtZ9ulPRqLSo61qLY4kiMxsomcsIq8fX2__uXIxKPA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -12671,7 +12799,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E8",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d5e",
           "Name": "",
@@ -12730,7 +12858,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:21 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:27 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6c
@@ -12746,9 +12874,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDskff5xwD6YFLPi3ZmnjtJGK6m1qBNPg5pgAUtYXqkfAIgP3DPVqT2eDuGo5BLCygLLk0wt1QQ5LtuNKKmXKhVnuw="
+        host date digest",signature="MEYCIQD2e7sSu10fXmmVkWkhrD8zFrPNPrMwB/aqeK5qfTqefgIhANC7EKxlzDwTY2PD1nuoT6BdgrRHC+PssycujCAOMsp7"
       Date:
-      - Tue, 26 Apr 2022 05:03:21 GMT
+      - Wed, 27 Apr 2022 06:19:27 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -12761,16 +12889,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:21 GMT
+      - Wed, 27 Apr 2022 06:19:27 GMT
       Set-Cookie:
-      - AWSALB=107tdXr/kdlO2X4nk45ma+cMIAX6nXe7NPz2hclGz3lKFMVISXqtRDnUMv1V6uT/2Hmu3uMK9VBDzWE0lUjuFvtQybIg2OIKgaZQmWPXMZ3oKR/aaHKXOa2Bjo1o;
-        Expires=Tue, 03 May 2022 05:03:21 GMT; Path=/
-      - AWSALBCORS=107tdXr/kdlO2X4nk45ma+cMIAX6nXe7NPz2hclGz3lKFMVISXqtRDnUMv1V6uT/2Hmu3uMK9VBDzWE0lUjuFvtQybIg2OIKgaZQmWPXMZ3oKR/aaHKXOa2Bjo1o;
-        Expires=Tue, 03 May 2022 05:03:21 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=bOJUfe7sPQg3zwwqAIpUJRaL1AAv3/nb1KsF3pmjDJLiARxkviLKsEOVJYKDhX4V9QEAkBxTlTNw64B+qPMXRIO/PeL49Yz67TeAA+mxvzage4Ev5e9HERCDrJ4d;
+        Expires=Wed, 04 May 2022 06:19:27 GMT; Path=/
+      - AWSALBCORS=bOJUfe7sPQg3zwwqAIpUJRaL1AAv3/nb1KsF3pmjDJLiARxkviLKsEOVJYKDhX4V9QEAkBxTlTNw64B+qPMXRIO/PeL49Yz67TeAA+mxvzage4Ev5e9HERCDrJ4d;
+        Expires=Wed, 04 May 2022 06:19:27 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd90654bc3053b06ce74f91fc37e33108
+      - NB402362e9ee0fc4cc6a628810613b6f31
       Pragma:
       - no-cache
       Cache-Control:
@@ -12800,11 +12928,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ktcYVDDgJrY6aTa5CxpzNlbneLL4_nNzAvFXuP-pBBRSTXX_hMkPVQ==
+      - y5uuqxrB2LV5nVdg566Wo9rcijrgckWtZq5QYg1UTs4O10k9WHjoUQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -12851,7 +12979,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F6",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d6c",
           "Name": "",
@@ -12910,7 +13038,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:22 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:27 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7e
@@ -12926,9 +13054,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIAl0i1YiY+1Co4u1pSFCjjYWbv1dtGS9qo+/iojT9LteAiBOl4OhnWyWi7S5XN6W5QPBlOUbgi0DFQvCgYIuYm6dWA=="
+        host date digest",signature="MEUCIEdakpS4Jl47+35ICvOQOhNq/lsVSCTRcpAPjJWX+cZFAiEAqkbWWMzTj7lkKizmkuKQ74chbjk647TBlkE+td9T9Ag="
       Date:
-      - Tue, 26 Apr 2022 05:03:22 GMT
+      - Wed, 27 Apr 2022 06:19:27 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -12941,16 +13069,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:22 GMT
+      - Wed, 27 Apr 2022 06:19:28 GMT
       Set-Cookie:
-      - AWSALB=/oDKOjQGd7ji9lPSHi9VWg+VlFqZM2MmLe5a28Za4vXnRi76sZqHZ2b5vstpwFZ+khHNEAUcEbpiI0PCYo8Ka1z98uQLi3dI0GJyzluJyQ1c545c1hfmTpbUevw4;
-        Expires=Tue, 03 May 2022 05:03:22 GMT; Path=/
-      - AWSALBCORS=/oDKOjQGd7ji9lPSHi9VWg+VlFqZM2MmLe5a28Za4vXnRi76sZqHZ2b5vstpwFZ+khHNEAUcEbpiI0PCYo8Ka1z98uQLi3dI0GJyzluJyQ1c545c1hfmTpbUevw4;
-        Expires=Tue, 03 May 2022 05:03:22 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=rk9o2OJ32e2ND6Ad+UNGshJ8SnUrx9/BCoVXOYpGFiWf7e0DNaHFwG7PkNaEaGrozSUKZwuFK8daufZVih/hA3SVufZ3S6Don+M/sRvFZhHT8APJl4RU28Xz0y+a;
+        Expires=Wed, 04 May 2022 06:19:28 GMT; Path=/
+      - AWSALBCORS=rk9o2OJ32e2ND6Ad+UNGshJ8SnUrx9/BCoVXOYpGFiWf7e0DNaHFwG7PkNaEaGrozSUKZwuFK8daufZVih/hA3SVufZ3S6Don+M/sRvFZhHT8APJl4RU28Xz0y+a;
+        Expires=Wed, 04 May 2022 06:19:28 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB53a70447048ec73b48ace1ce4b52e955
+      - NB8c08a4141321d7dcc5f474b27c32babc
       Pragma:
       - no-cache
       Cache-Control:
@@ -12980,11 +13108,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - S_ixFX9YJ3qlI-wTlySNY2a7x05knn3_NSTbfiIctY4LKHJM6I1CFw==
+      - pq5ZuygVuArd1dwY1ILFtSsEql_eQJzPMYvYTtmlLNytIi8m8cOLGw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -13031,7 +13159,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D2",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7e",
           "Name": "",
@@ -13090,7 +13218,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:22 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:28 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6d
@@ -13106,9 +13234,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIBl5ulZGu5giPmKLrV32bE7Wa0ITiozS69k7QaTIl6hWAiAiHUerL/mlEwucyUNBHN3zTH5aWHJ216KSLhGzaZU1qA=="
+        host date digest",signature="MEYCIQC1erzgwgtAKgNd7CVw2AR2zJ7LN+Y64sNO0umqa2qMAAIhAOnHd7xkrZtPeqkGmJn/KqaN8Kdb8/Poh2+6HQgmpiJm"
       Date:
-      - Tue, 26 Apr 2022 05:03:22 GMT
+      - Wed, 27 Apr 2022 06:19:28 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -13121,16 +13249,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:22 GMT
+      - Wed, 27 Apr 2022 06:19:28 GMT
       Set-Cookie:
-      - AWSALB=gn7rwGd7ifPSoPAh0l46KDttNCHtb1BzyxFcplJX/4kmlqHd6g+BpS04HmA5dHAvgMwJYoxiXo21pQkL8qUvhMN6hJE46iwreb6Ng8yrhuBbBfGX7Y69jf37v5/e;
-        Expires=Tue, 03 May 2022 05:03:22 GMT; Path=/
-      - AWSALBCORS=gn7rwGd7ifPSoPAh0l46KDttNCHtb1BzyxFcplJX/4kmlqHd6g+BpS04HmA5dHAvgMwJYoxiXo21pQkL8qUvhMN6hJE46iwreb6Ng8yrhuBbBfGX7Y69jf37v5/e;
-        Expires=Tue, 03 May 2022 05:03:22 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=jpXGdmZ95vvqYOA6gN07X+Db4Zt4c2vrVHnXiXxv8kisQigeviw3gI8pJ70anppzyogwiQ1ra8hNYVjfcUc2gnQkYSLS0d0jFIfLnOivMMNBgOm8ErzeUw8OJHRj;
+        Expires=Wed, 04 May 2022 06:19:28 GMT; Path=/
+      - AWSALBCORS=jpXGdmZ95vvqYOA6gN07X+Db4Zt4c2vrVHnXiXxv8kisQigeviw3gI8pJ70anppzyogwiQ1ra8hNYVjfcUc2gnQkYSLS0d0jFIfLnOivMMNBgOm8ErzeUw8OJHRj;
+        Expires=Wed, 04 May 2022 06:19:28 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB2f673bba94cfda8671c32b4748d5dbda
+      - NBd3764eb6e2f672578c4300c525a427ea
       Pragma:
       - no-cache
       Cache-Control:
@@ -13160,11 +13288,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - cTOHgiZx6iVycbYNsOAv9F5rCp7SV7qpiL9CLHNGf2y4BTanKyi8XA==
+      - 2_44j-V-FMcJajcuCp3aVUZwhRdyUe2WO2P1osI8388EWgCA90G52w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -13211,7 +13339,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F7",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d6d",
           "Name": "",
@@ -13270,7 +13398,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:22 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:28 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d82
@@ -13286,9 +13414,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBkuLvFnNJnXoNFl08ZRsRvKEujsgu/bwYzxSuaqG0iJAiEAhRVbiZcAZ2MNo1FiAKjejy6Czzf+uZfVvi5xrSRfDJU="
+        host date digest",signature="MEUCIAboecWG6JVYp4RNy3MkdW8wa4MAN7J2uHsJ8uc4d7y4AiEAvN30j7A37XkpTg4x7dpB+LJp9HuTb+LXkDwolzcEyUw="
       Date:
-      - Tue, 26 Apr 2022 05:03:22 GMT
+      - Wed, 27 Apr 2022 06:19:28 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -13301,16 +13429,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:22 GMT
+      - Wed, 27 Apr 2022 06:19:28 GMT
       Set-Cookie:
-      - AWSALB=mNIPypD8WBCwDMUDPzKiqdp20S8SypzvN5osoCstFFzd7OdXaXjF5/Y0liX6LK75JluoioGzDisTMhckSzEusrWbJcT6HuWJKCAyGvjG+/XsyPQBvChcqzzkmLNN;
-        Expires=Tue, 03 May 2022 05:03:22 GMT; Path=/
-      - AWSALBCORS=mNIPypD8WBCwDMUDPzKiqdp20S8SypzvN5osoCstFFzd7OdXaXjF5/Y0liX6LK75JluoioGzDisTMhckSzEusrWbJcT6HuWJKCAyGvjG+/XsyPQBvChcqzzkmLNN;
-        Expires=Tue, 03 May 2022 05:03:22 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ouuMp9pGKDNYZ4nNqQczQ40rFxzoTZ9d03x3Ja4XsPdOEv2C00LpMtrUljcX1HLJxPeqpm//PxSdx+HZF5Sl4V6zI58l8f3lzMqti5OSVS7rU5SiNm7vpsR3CEeE;
+        Expires=Wed, 04 May 2022 06:19:28 GMT; Path=/
+      - AWSALBCORS=ouuMp9pGKDNYZ4nNqQczQ40rFxzoTZ9d03x3Ja4XsPdOEv2C00LpMtrUljcX1HLJxPeqpm//PxSdx+HZF5Sl4V6zI58l8f3lzMqti5OSVS7rU5SiNm7vpsR3CEeE;
+        Expires=Wed, 04 May 2022 06:19:28 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBebcee548b13d199a11e5ac1cf461591c
+      - NB257d53a4e7206d6e25598ae181df9d69
       Pragma:
       - no-cache
       Cache-Control:
@@ -13340,11 +13468,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 0KGWdxUV_B6JTrtcYF3OBGtViAjTFwEiF_TAeGpt1ZX9adB135O9mQ==
+      - 0CG0gNUL9lBh1YZyaCLptCwucY4nmRv8JWGw8Tz9h0GPSd2qVmMwww==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -13391,7 +13519,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D6",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d82",
           "Name": "",
@@ -13450,7 +13578,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:22 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:28 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d81
@@ -13466,9 +13594,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQD3VALPUSER0MVQHNNQWEUYRyoNin1AUtdCu54KWRfNpQIgCy9O/uAvks98Lr/sdyNvyvRZXyYHD1Z1PLHEsZMqbAs="
+        host date digest",signature="MEYCIQCUxnmeIOjcoVAsucRoa5Jcoc78cuogdEDNFjC+SsxG/gIhAJaL0iawTnYKWY+n2Yd3khcXyk9l531rhTxwuhJzyCmQ"
       Date:
-      - Tue, 26 Apr 2022 05:03:22 GMT
+      - Wed, 27 Apr 2022 06:19:28 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -13481,16 +13609,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:23 GMT
+      - Wed, 27 Apr 2022 06:19:28 GMT
       Set-Cookie:
-      - AWSALB=EuuzszEE/4rHbcflCeTCm0z8i/0TVYJcRa56RPgsh+4A/bCtj3FuiSw7QsNiLK9Xp5wDJ9GKIZD3Ek63vjigttiiiIh6t00kabuhOGsVZ5moMnlDYHXDv0FuHudz;
-        Expires=Tue, 03 May 2022 05:03:23 GMT; Path=/
-      - AWSALBCORS=EuuzszEE/4rHbcflCeTCm0z8i/0TVYJcRa56RPgsh+4A/bCtj3FuiSw7QsNiLK9Xp5wDJ9GKIZD3Ek63vjigttiiiIh6t00kabuhOGsVZ5moMnlDYHXDv0FuHudz;
-        Expires=Tue, 03 May 2022 05:03:23 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=pAi8L+jICCC/cM+FNDI0swUhoC2C0fgwHKLf6WGHOhpon94EIWNohsLZpDuLXKIvqoL3N2/GR9ftAb+00e8lMxrB/YfC+soCwB4DBwfGYIBCGqylcYvFyrxYbcSs;
+        Expires=Wed, 04 May 2022 06:19:28 GMT; Path=/
+      - AWSALBCORS=pAi8L+jICCC/cM+FNDI0swUhoC2C0fgwHKLf6WGHOhpon94EIWNohsLZpDuLXKIvqoL3N2/GR9ftAb+00e8lMxrB/YfC+soCwB4DBwfGYIBCGqylcYvFyrxYbcSs;
+        Expires=Wed, 04 May 2022 06:19:28 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBdc5e3d58a8ad13d8ba6a0a1bf8ff7528
+      - NB76e945fa4f4046963b497bb6a9e134d5
       Pragma:
       - no-cache
       Cache-Control:
@@ -13520,11 +13648,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - br8AFZ3T5vFX87ho2NTr-uICT98KHwEivGT6yJPufNZPyAVCMwL0sw==
+      - JXwSOHAfRw28UDxKhH_TV74wmzFKoK3GL0zmKJEP80x6OZWeg0CA5Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -13571,7 +13699,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D5",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d81",
           "Name": "",
@@ -13630,7 +13758,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:23 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:29 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d89
@@ -13646,9 +13774,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIDjmsHHg/5GSTthH7RwLhZ8vLR+n+sZpb8g2zozKV35mAiEAl4z67bZDyLDqFTxmyvRZ0i1ElkOj2BY8GL9ZyEexnFk="
+        host date digest",signature="MEUCIQCIKTB9+6y7WDbASBVMuLqhJHKaTE8zV8/QrCZ4qJbyVAIgWBI3CfDtyAoKueCR/MzI8S1MGZljeJKedJDQvO9wXbE="
       Date:
-      - Tue, 26 Apr 2022 05:03:23 GMT
+      - Wed, 27 Apr 2022 06:19:29 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -13661,16 +13789,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:23 GMT
+      - Wed, 27 Apr 2022 06:19:29 GMT
       Set-Cookie:
-      - AWSALB=82bRXWMvftwRuk5cL42vEQAowmuAXKgXZkDyta+R+9YvNKL8T/gg/xA9NbumsPpCzHebaj70IHZs6oA3+tkOV45JZjga837C1HbQ+K1tPycrvplUP7NcO9jVn34M;
-        Expires=Tue, 03 May 2022 05:03:23 GMT; Path=/
-      - AWSALBCORS=82bRXWMvftwRuk5cL42vEQAowmuAXKgXZkDyta+R+9YvNKL8T/gg/xA9NbumsPpCzHebaj70IHZs6oA3+tkOV45JZjga837C1HbQ+K1tPycrvplUP7NcO9jVn34M;
-        Expires=Tue, 03 May 2022 05:03:23 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=RiR+IQYlXHaUbPXbFOgi1UvbzWDbEAriH3r9b5ZdRyKotP5aY/r8OB385o33oPkejcWNaUR0Og8uF4ov8Mij6W42t2ovLtV4CI24yhLfFMxzYNUwpOnzmG8nP0aF;
+        Expires=Wed, 04 May 2022 06:19:29 GMT; Path=/
+      - AWSALBCORS=RiR+IQYlXHaUbPXbFOgi1UvbzWDbEAriH3r9b5ZdRyKotP5aY/r8OB385o33oPkejcWNaUR0Og8uF4ov8Mij6W42t2ovLtV4CI24yhLfFMxzYNUwpOnzmG8nP0aF;
+        Expires=Wed, 04 May 2022 06:19:29 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB653a7d3d13af2e1de02716cf794a3b8a
+      - NBf4625156cde0455e6b6e3875e9afb01d
       Pragma:
       - no-cache
       Cache-Control:
@@ -13700,11 +13828,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - k0PtTmAXXgU8TwIsPXeR4GKt4CEIU6hsi8gtXaz6BbsoI8rQO8yw1Q==
+      - VvpxgKiyfRopZ3avJNCrISJYZgJmX83kO7dQ2EtQocQd_xE1DLdGCg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -13751,7 +13879,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DD",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d89",
           "Name": "",
@@ -13810,7 +13938,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:23 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:29 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d78
@@ -13826,9 +13954,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBjLG9jbj5qRIMGPtHtGKi02IyfOaBTIvelRdo4Ck1k2AiEA+YKofKyqjcl4CG5pvjfl7N+pye30pGf+RFwMeX/bJh4="
+        host date digest",signature="MEYCIQCq3S1DoTZG2Gl3hgrISqzafligAoMRPIrEOrSchFjheAIhAMMnCZ+H4hDYckDh5pWVis5QledLZME27UArP3O/hcg5"
       Date:
-      - Tue, 26 Apr 2022 05:03:23 GMT
+      - Wed, 27 Apr 2022 06:19:29 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -13841,16 +13969,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:23 GMT
+      - Wed, 27 Apr 2022 06:19:29 GMT
       Set-Cookie:
-      - AWSALB=JqUA71Bj7VSgxDXFQrZpLsdMKrM6icbG9Qvr2JSSGMvNIsyUAlE+YpTE7TrsHa+Sj2dhOsUTH8XmEJZPSt60itMXf7a7Gyoz/8Gzvazke+TxnEcIE1e+7bdYWiFO;
-        Expires=Tue, 03 May 2022 05:03:23 GMT; Path=/
-      - AWSALBCORS=JqUA71Bj7VSgxDXFQrZpLsdMKrM6icbG9Qvr2JSSGMvNIsyUAlE+YpTE7TrsHa+Sj2dhOsUTH8XmEJZPSt60itMXf7a7Gyoz/8Gzvazke+TxnEcIE1e+7bdYWiFO;
-        Expires=Tue, 03 May 2022 05:03:23 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=+CeVwVHrrnyg/eTrLH7Zr18Nrk+NT2iG3Z/TsGlPdV2tFHYf6GXu95XZ/d5gFcNEGr1IzveRcffEKPWTNoCk89keve3EqWvbnPsnQbPacT7HsOgFT4prZ5mxQNN5;
+        Expires=Wed, 04 May 2022 06:19:29 GMT; Path=/
+      - AWSALBCORS=+CeVwVHrrnyg/eTrLH7Zr18Nrk+NT2iG3Z/TsGlPdV2tFHYf6GXu95XZ/d5gFcNEGr1IzveRcffEKPWTNoCk89keve3EqWvbnPsnQbPacT7HsOgFT4prZ5mxQNN5;
+        Expires=Wed, 04 May 2022 06:19:29 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe333172a291fa0d79e47c39ba83fbf5d
+      - NBe31ca401c35f0ee2fc0bfd0c158b5b9c
       Pragma:
       - no-cache
       Cache-Control:
@@ -13880,11 +14008,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 7vdQQEArHTrefBLCDKSofgOHTIKUyliklOc_6JgASwtt3tRLDLFinw==
+      - YAgSuhTu332F0jjjfPYKJ9T1TZBsAX5mYHzAt87tFcowQHSVp3M0vA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -13931,7 +14059,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CC",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d78",
           "Name": "",
@@ -13990,7 +14118,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:23 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:29 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d5f
@@ -14006,9 +14134,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDSZ0zm2gk8t57n2DXc0PaYE7K9YG5vwVgmK7fqgQ3ZEQIhAO3XzGYoBn0RDe6hEl+4ZZYiASvwZ2SpTj5jkfrZ59io"
+        host date digest",signature="MEUCIGZS+dgv1U5YLvyU33R4p4eSTD3FdgcfD6ixGTFlp2WcAiEA6KaqrDMT3+8kAy9Vj9dNoq/rlPds14z4FU3OAAvxx3E="
       Date:
-      - Tue, 26 Apr 2022 05:03:23 GMT
+      - Wed, 27 Apr 2022 06:19:29 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -14021,16 +14149,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:23 GMT
+      - Wed, 27 Apr 2022 06:19:29 GMT
       Set-Cookie:
-      - AWSALB=gmCyXtsYclomTWvN02a7Nkqd7LG+ZqJynMK8LlrWu0Ez4c1cv3lGbND/cvYF8L5kvoS/SgF36sIc4IHZ8PkvtVsmINT3sJljubvBjl41UWNCikZGEyKnywwKP/o7;
-        Expires=Tue, 03 May 2022 05:03:23 GMT; Path=/
-      - AWSALBCORS=gmCyXtsYclomTWvN02a7Nkqd7LG+ZqJynMK8LlrWu0Ez4c1cv3lGbND/cvYF8L5kvoS/SgF36sIc4IHZ8PkvtVsmINT3sJljubvBjl41UWNCikZGEyKnywwKP/o7;
-        Expires=Tue, 03 May 2022 05:03:23 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=jbyU5IefMK3QYaBUtdcbIZBseKyCgkZowJTtePvoaQfgyUowMH+kb7OIFj03Fuy+aqHN3CK4D7GLZIfURDl8faicBlvSwogCSySE5JrN4ptqSLaJflE/q3+KaixY;
+        Expires=Wed, 04 May 2022 06:19:29 GMT; Path=/
+      - AWSALBCORS=jbyU5IefMK3QYaBUtdcbIZBseKyCgkZowJTtePvoaQfgyUowMH+kb7OIFj03Fuy+aqHN3CK4D7GLZIfURDl8faicBlvSwogCSySE5JrN4ptqSLaJflE/q3+KaixY;
+        Expires=Wed, 04 May 2022 06:19:29 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB984548d127f2f913928aa90da6fb92dc
+      - NB503cbb1cabe2b34ef51090c8a0527510
       Pragma:
       - no-cache
       Cache-Control:
@@ -14060,11 +14188,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - tVFQsVs7Wp1F0stlMk0ZwRYRwrX6PmlrxqmVeQe8ZnPDbYAjltO8Xg==
+      - V6whAPoEDekyTqLyeZVJFIkMKst57GyzT7uvcgoq0MADaLkG7qORGQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -14111,7 +14239,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E9",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d5f",
           "Name": "",
@@ -14170,7 +14298,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:23 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:29 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d61
@@ -14186,9 +14314,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDimI9OXr2tYHZG01rDOa7dHGiKOqipHx79/9RGLCFiAwIgIjRf44IUHo3VDOQsnmupRNYBF+nwMJ0mnZ6Isnf5eUc="
+        host date digest",signature="MEYCIQCeW1+2Olbp9a3bzR5IKYyuD4DKxNs3jJBeZXWk08C9sQIhAJWkoRM+Zk1J4KLKn6Cp026tRI00f4/e8b1efaXlbmqH"
       Date:
-      - Tue, 26 Apr 2022 05:03:23 GMT
+      - Wed, 27 Apr 2022 06:19:29 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -14201,16 +14329,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:23 GMT
+      - Wed, 27 Apr 2022 06:19:29 GMT
       Set-Cookie:
-      - AWSALB=R3i0s7IXQvtEpSV9OLTqJ+siM+KrkCITOqcAMq/8GbrsAD7SulUkFllQC8tnkv6eYYdR1fN3h1yZeTVy/f/nyg8ZIVhOqXOrTuzjAs1xw3ncMoB0Mwtg6lz5iLRl;
-        Expires=Tue, 03 May 2022 05:03:23 GMT; Path=/
-      - AWSALBCORS=R3i0s7IXQvtEpSV9OLTqJ+siM+KrkCITOqcAMq/8GbrsAD7SulUkFllQC8tnkv6eYYdR1fN3h1yZeTVy/f/nyg8ZIVhOqXOrTuzjAs1xw3ncMoB0Mwtg6lz5iLRl;
-        Expires=Tue, 03 May 2022 05:03:23 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=iR93KCWfOagvrBgm56qLEkRsGCaXDwO9E6sUvnQzRCHdiAxN2x0KRBb5NPPCt50CHmP534n5s90bKVEhZjvhNYiMt1OOC83J1Gft7dotwS+Mf+G5HS6z7S84dajq;
+        Expires=Wed, 04 May 2022 06:19:29 GMT; Path=/
+      - AWSALBCORS=iR93KCWfOagvrBgm56qLEkRsGCaXDwO9E6sUvnQzRCHdiAxN2x0KRBb5NPPCt50CHmP534n5s90bKVEhZjvhNYiMt1OOC83J1Gft7dotwS+Mf+G5HS6z7S84dajq;
+        Expires=Wed, 04 May 2022 06:19:29 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB5cac4d99e87036c2af499f61bf2b1374
+      - NB43958624a71bcca838a10ea3ee2cab6b
       Pragma:
       - no-cache
       Cache-Control:
@@ -14240,11 +14368,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - nsmJoO0Yn-l5qoXuLSN_MWii2vyNLW_3le6B9Ea2dOt4FoVByaZRyQ==
+      - kgQ1ciUm_BmhLk717RaUCD5ThFQif6UccnD6Psp2DDy7stiKvZ4WcA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -14291,7 +14419,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:EB",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d61",
           "Name": "",
@@ -14350,7 +14478,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:23 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:29 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d84
@@ -14366,9 +14494,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIGIBdrfSeBvKJA7TFOaTvONedkWpF1ypT2V+E5taHzQwAiAkAniKZFNavUqxLeGnOWLjtPcwLNMRaFoPpvUi/rrdtg=="
+        host date digest",signature="MEYCIQDeOx4I/QHah5GIm0psHZ48yBBIGVrZBlqoFyoYQx7oXAIhAO1ZMHCWEqwf7B7Tr5MtDEmsEcbOlBw3asbnKIUfVl/R"
       Date:
-      - Tue, 26 Apr 2022 05:03:23 GMT
+      - Wed, 27 Apr 2022 06:19:29 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -14381,16 +14509,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:24 GMT
+      - Wed, 27 Apr 2022 06:19:30 GMT
       Set-Cookie:
-      - AWSALB=pT57Dt80ewYUcruczqUpYl5YUrbl4hSv5eQFxME1GZ3UOCttkegl9+3PovcUHhve3ep30s2HR4osFLbnE8oRcmb2gjy6aPwSH2R6zhRpetnLjZoIWCsD07G44vdM;
-        Expires=Tue, 03 May 2022 05:03:24 GMT; Path=/
-      - AWSALBCORS=pT57Dt80ewYUcruczqUpYl5YUrbl4hSv5eQFxME1GZ3UOCttkegl9+3PovcUHhve3ep30s2HR4osFLbnE8oRcmb2gjy6aPwSH2R6zhRpetnLjZoIWCsD07G44vdM;
-        Expires=Tue, 03 May 2022 05:03:24 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=O/vxBdavm/1o+UI30gzCwZ6mdWj0TaGnRnKuWHdY/0T6V+j9DqDz6Z+4YHXlbqP5kL8l6nMPnW0xa72pbR9C/PkY+smiF16EIFLNv/PJj8O+ErqJEGO289j4r4D1;
+        Expires=Wed, 04 May 2022 06:19:30 GMT; Path=/
+      - AWSALBCORS=O/vxBdavm/1o+UI30gzCwZ6mdWj0TaGnRnKuWHdY/0T6V+j9DqDz6Z+4YHXlbqP5kL8l6nMPnW0xa72pbR9C/PkY+smiF16EIFLNv/PJj8O+ErqJEGO289j4r4D1;
+        Expires=Wed, 04 May 2022 06:19:30 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB472d11df82eb8dfb8a03d5dc67a32e75
+      - NB8943e07b18180f345ecebf7aea8cf95d
       Pragma:
       - no-cache
       Cache-Control:
@@ -14420,11 +14548,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - GmJhHbEvgxtobzv2MEQ8crZtlX5Pppv87rza6IjZxVkpI3pb_-ubfQ==
+      - 8O9yNBZvqm_IKsSN4QpEeyqMdd_GZu3G9BMQ9um_YnpSQwxyynl1NQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -14471,7 +14599,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D8",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25c4630312d42bf1d84",
           "Name": "",
@@ -14530,7 +14658,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:24 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:30 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d90
@@ -14546,9 +14674,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIFMwLD9HTtOK7aZcA/rQks163iBLODF0kPa0bI2AzowHAiAWHscXsqnCmvQv2f+upKDUadRLScBA555wLAtAEHu+KA=="
+        host date digest",signature="MEYCIQCJxK0zKcu13dhDGWMz6w8yxUzN/JaE4Hp1qzFkFJuemwIhALq6hRVe9KRp/YZNf1TSNeB01R3IWBj6Ku4Gg2/dPiBS"
       Date:
-      - Tue, 26 Apr 2022 05:03:24 GMT
+      - Wed, 27 Apr 2022 06:19:30 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -14561,16 +14689,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:24 GMT
+      - Wed, 27 Apr 2022 06:19:30 GMT
       Set-Cookie:
-      - AWSALB=SpBWCW+cj1BpJJKd/Lb63yzn6RgFpGM0XLQlmmnpkCfLw4b/iUj6mBgYBnGeVNDWn2YL4hnfAhFTR57Cx3o1RdKFPUaX5p+hds4KKqONwfbCnhSE4C6l6SVhZBWN;
-        Expires=Tue, 03 May 2022 05:03:24 GMT; Path=/
-      - AWSALBCORS=SpBWCW+cj1BpJJKd/Lb63yzn6RgFpGM0XLQlmmnpkCfLw4b/iUj6mBgYBnGeVNDWn2YL4hnfAhFTR57Cx3o1RdKFPUaX5p+hds4KKqONwfbCnhSE4C6l6SVhZBWN;
-        Expires=Tue, 03 May 2022 05:03:24 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=g41LG849qthR9nUmSZq84k+eQdvWSh382nWoGxQrPR7FnPrNRqFzOScu4Ydma2gM4zZWnb/9sro1hqNUM5PxcQqfbqGT14Z9D/1n60Dj3/c0sef4Ww4gQxoRErsj;
+        Expires=Wed, 04 May 2022 06:19:30 GMT; Path=/
+      - AWSALBCORS=g41LG849qthR9nUmSZq84k+eQdvWSh382nWoGxQrPR7FnPrNRqFzOScu4Ydma2gM4zZWnb/9sro1hqNUM5PxcQqfbqGT14Z9D/1n60Dj3/c0sef4Ww4gQxoRErsj;
+        Expires=Wed, 04 May 2022 06:19:30 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB93f60e12d42b41e72980d0d1644fd73a
+      - NBac9b2c085702eeac1670dd1ef6a08746
       Pragma:
       - no-cache
       Cache-Control:
@@ -14600,11 +14728,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - I9yHJnv2a5PrcxO8FBEeJRfoL4_-OhSAaR8fXA_uM1iVe0kGODCHFg==
+      - NMemJcxah7fhD2aKjfefUU6dNSpLwMNEQXLVR7q5Uc8Zjnt-oycD3A==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -14651,7 +14779,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E4",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d90",
           "Name": "",
@@ -14710,7 +14838,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:24 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:30 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d85
@@ -14726,9 +14854,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIBsALGjovVPT8JdpD1jgW0AvM5dlUyg3NIcGvvz02fVrAiBh7DrQ/a//cs4kxlxSueWL6yrTo73ofQBvMqRo54vrkw=="
+        host date digest",signature="MEYCIQDeZp8+Usn+C7nHw/5d5RwoVj16/3J7vFOYrpWsDGdy7AIhAJQWEXUdumYKu5cjjmasewKIpdnbJYq8IctkE+FKcPmm"
       Date:
-      - Tue, 26 Apr 2022 05:03:24 GMT
+      - Wed, 27 Apr 2022 06:19:30 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -14741,16 +14869,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:24 GMT
+      - Wed, 27 Apr 2022 06:19:30 GMT
       Set-Cookie:
-      - AWSALB=uPEd3ISpTQhMIEgjXSB8oTqpmgEVHM/L3f9yaEqCmdiyNfi9ZhkNNmtWMpsqdK3sNlRDdM4pxscvydZsPzDmq+LA4j3Uh2kaGAx0Tz8hx1Oj8D2l37qizuRjwzvi;
-        Expires=Tue, 03 May 2022 05:03:24 GMT; Path=/
-      - AWSALBCORS=uPEd3ISpTQhMIEgjXSB8oTqpmgEVHM/L3f9yaEqCmdiyNfi9ZhkNNmtWMpsqdK3sNlRDdM4pxscvydZsPzDmq+LA4j3Uh2kaGAx0Tz8hx1Oj8D2l37qizuRjwzvi;
-        Expires=Tue, 03 May 2022 05:03:24 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=AXDiMg1XhHeGEBnkuVENJiS0M99dRmLFKJL0thbIJLvQotoK3uiKnJ1U/Mig3dCR64gttVkpqXQfU6P/2KIVVEml39u1loRaVI6yFBEoM8Adsu0V5eWijgftTUEP;
+        Expires=Wed, 04 May 2022 06:19:30 GMT; Path=/
+      - AWSALBCORS=AXDiMg1XhHeGEBnkuVENJiS0M99dRmLFKJL0thbIJLvQotoK3uiKnJ1U/Mig3dCR64gttVkpqXQfU6P/2KIVVEml39u1loRaVI6yFBEoM8Adsu0V5eWijgftTUEP;
+        Expires=Wed, 04 May 2022 06:19:30 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB85f88fc1e5a3aa801b5a1f55af4d7553
+      - NBf115419d0d4eff79dd9dbba165b6064e
       Pragma:
       - no-cache
       Cache-Control:
@@ -14780,11 +14908,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - GbnpvZoz0hAr9tPVlUzTsvszX-XqhTqM8gX78agfv8pY9wU1OW5sSg==
+      - Lgl9v7afKBUMTDLOtAW5DaUfsLn8LXGFAHCUNF2dwSDaM2wAzfjoAw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -14831,7 +14959,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D9",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25c4630312d42bf1d85",
           "Name": "",
@@ -14890,7 +15018,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:24 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:30 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6b
@@ -14906,9 +15034,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDlkU4ZeYlHvws2jFxuEhW3AKMcqY9DsxzZEiYdXJ6cogIgBFjNU3VV+Apsn/bQfM7OwbNvGxegLIdaluXHD+9yWS4="
+        host date digest",signature="MEUCIQDthQV5bYXY+s5W6N9rBVmWH2XoPwekRWd2Xpu3KGSHOgIgAZsuuyzn3/U9jYHC9I/4BeX9T0jUk8Tgavs4mMRg3wE="
       Date:
-      - Tue, 26 Apr 2022 05:03:24 GMT
+      - Wed, 27 Apr 2022 06:19:30 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -14921,16 +15049,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:24 GMT
+      - Wed, 27 Apr 2022 06:19:30 GMT
       Set-Cookie:
-      - AWSALB=5JVnBu8vPa/sbLoIJV+bUuKGgQdefiuXdGaMOljgTP7LOH5fqi8DLL2Dcyl3UOwViVhMvq9tkerI3naEBCDgKBdqBABLrha10JHyX/z5qmnAMsmOv+QA6Oj9gp5I;
-        Expires=Tue, 03 May 2022 05:03:24 GMT; Path=/
-      - AWSALBCORS=5JVnBu8vPa/sbLoIJV+bUuKGgQdefiuXdGaMOljgTP7LOH5fqi8DLL2Dcyl3UOwViVhMvq9tkerI3naEBCDgKBdqBABLrha10JHyX/z5qmnAMsmOv+QA6Oj9gp5I;
-        Expires=Tue, 03 May 2022 05:03:24 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=NEArCEZpOTmV6f1sdhJwMvRG20ygGZ5zf5Akzk2xHqJCZOYGIhiFYhR7jTWNcChjDpDzZUvv9rR+vOO78VyhZRnT1KjzvnuaRIOFl34dzwgrapSGd+fjBbheXtS5;
+        Expires=Wed, 04 May 2022 06:19:30 GMT; Path=/
+      - AWSALBCORS=NEArCEZpOTmV6f1sdhJwMvRG20ygGZ5zf5Akzk2xHqJCZOYGIhiFYhR7jTWNcChjDpDzZUvv9rR+vOO78VyhZRnT1KjzvnuaRIOFl34dzwgrapSGd+fjBbheXtS5;
+        Expires=Wed, 04 May 2022 06:19:30 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBdcf2153c2a600a95829122e9951cc2cf
+      - NB588dfcf91451fe58bfab7fee83354ea9
       Pragma:
       - no-cache
       Cache-Control:
@@ -14960,11 +15088,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - bPWwXqbYil1S5D04Oc5Z3cyp_Nh6O1HTiYbYlCErMqGrvIVOro5C-A==
+      - kP-NPLiVj37vdis2Og7DhrVstDtXtAvCPiG6kCLTyA6_4E_Txn1WdA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -15011,7 +15139,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F5",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d6b",
           "Name": "",
@@ -15070,7 +15198,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:24 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:30 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d70
@@ -15086,9 +15214,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQC65AvLfnd9hhvZ+sTqtFHjjjk0zDVXhwGCsds8xxs9rAIgRg+zO6itmkqRbYrcKZo1uavcLEFmQ2+t2vIe+7hDyyw="
+        host date digest",signature="MEQCIBBZM09he9cOVPf9drfxpxsw2mka9DgjduDMLBGi2964AiBadL+p7xIf1UCTlpoLPZ6TqkqwQnx0fA+kQxTpE1r/qA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:24 GMT
+      - Wed, 27 Apr 2022 06:19:30 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -15101,16 +15229,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:30 GMT
       Set-Cookie:
-      - AWSALB=ll7vIZI+SwBYUxFhEhLqsjj1d5ZwqK8Js/lLzsXepWmJgMtr2IBMTeMUErCYFYKTwzGR8Fry0TZdk3/ypFcoPWs48Es7amyyR5iJJYldBFraNPoOnJUz5GaNfcl1;
-        Expires=Tue, 03 May 2022 05:03:24 GMT; Path=/
-      - AWSALBCORS=ll7vIZI+SwBYUxFhEhLqsjj1d5ZwqK8Js/lLzsXepWmJgMtr2IBMTeMUErCYFYKTwzGR8Fry0TZdk3/ypFcoPWs48Es7amyyR5iJJYldBFraNPoOnJUz5GaNfcl1;
-        Expires=Tue, 03 May 2022 05:03:24 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ONoeA7KSxpoKNPIyXOXu0rRWDfWNPDM3LagimvT/I39wdduST+U6l37EFnOVgyugBuf8hBCsm/fe22xkWdM0cdbhh3UwNz4Xa4GHU6wf+dUaBZDw1n5ZSu8O1ghi;
+        Expires=Wed, 04 May 2022 06:19:30 GMT; Path=/
+      - AWSALBCORS=ONoeA7KSxpoKNPIyXOXu0rRWDfWNPDM3LagimvT/I39wdduST+U6l37EFnOVgyugBuf8hBCsm/fe22xkWdM0cdbhh3UwNz4Xa4GHU6wf+dUaBZDw1n5ZSu8O1ghi;
+        Expires=Wed, 04 May 2022 06:19:30 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3fd513fad54517a0486f86d856c7bdd2
+      - NB419732304d28236fd051d1db784dcd1a
       Pragma:
       - no-cache
       Cache-Control:
@@ -15140,11 +15268,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 3mXcrya3nAkw3r8ohAchXzvic4mPTymzW-z_jRYj3agNu6WOLUTDhA==
+      - WWeLuZ03-i2mrmYB0-GGih04O8gBctrUzk67_kSvLLBy78YFE3dMCA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -15191,7 +15319,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:79:00",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d70",
           "Name": "",
@@ -15250,7 +15378,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:25 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:30 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d73
@@ -15266,9 +15394,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQD9r2MLpsuuB820i4zdueR01Kfz20rc/MPyYG+ikAvZ+QIgDf+CkfMQNifjFnBnfaiaSfXjxtaglAc47Nr7ck+I0eU="
+        host date digest",signature="MEUCIQCV7UQebu4JgW8l+TdlcGjVMec+8ztu6QFtjlb34up3ngIgdwbqTA8wMg/aL6Y9e/O7hNdx5tfM0/+A9nyRpPYCmVw="
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:30 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -15281,16 +15409,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:31 GMT
       Set-Cookie:
-      - AWSALB=mRj1WNh0nAAueNKCk44D4QEI2tF1IAKoaMkD4kjDJseaeuTRSyw3irpKtVTif2Xv6GJTpnJuxTho018Tbpj2bhJnI+V5Ni/E0hGAwtTZoaRIq9gB3fafySRjymf+;
-        Expires=Tue, 03 May 2022 05:03:25 GMT; Path=/
-      - AWSALBCORS=mRj1WNh0nAAueNKCk44D4QEI2tF1IAKoaMkD4kjDJseaeuTRSyw3irpKtVTif2Xv6GJTpnJuxTho018Tbpj2bhJnI+V5Ni/E0hGAwtTZoaRIq9gB3fafySRjymf+;
-        Expires=Tue, 03 May 2022 05:03:25 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=GLN+EbnI/U0HWEbhOHM25AcfRud0FpCkjpT67mopHbwCuVjyzKVTWgHhYov23sun/1N6MFu2cwNZV6X19rEK3MpCC+NAK5W5DejxyhR39kQqmJ3xrKNQocMH+1Rp;
+        Expires=Wed, 04 May 2022 06:19:31 GMT; Path=/
+      - AWSALBCORS=GLN+EbnI/U0HWEbhOHM25AcfRud0FpCkjpT67mopHbwCuVjyzKVTWgHhYov23sun/1N6MFu2cwNZV6X19rEK3MpCC+NAK5W5DejxyhR39kQqmJ3xrKNQocMH+1Rp;
+        Expires=Wed, 04 May 2022 06:19:31 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB321e3b1589d07d8ddf9f109a6405c46e
+      - NBd65b1afaeb5202f0ed860a5dab3dd7e6
       Pragma:
       - no-cache
       Cache-Control:
@@ -15320,11 +15448,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 6FgAsKOBbKUjy7qVwoK4HMmSQC5Pogs5PsvTN49ODWmHdzkCFdf6zA==
+      - 6Ird8GR4SazpV3q_9vn4lVixR9iW76cCWYe0kcQq_YpZM-KeRhWxuQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -15371,7 +15499,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:79:0C",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d73",
           "Name": "",
@@ -15430,7 +15558,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:25 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:31 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8f
@@ -15446,9 +15574,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBIVH358u3Py8rs+jksajNuFSZqO8s2WfEk/QJJq35XzAiEAv9WmMYtPwIR8i0zi3E56whEgkp+Ahl784ATQbWabo+8="
+        host date digest",signature="MEUCIEcRFCebo3xkfiToHfUAg49xhVgmkjfaZmsC+/3kdDq1AiEAvlLbgK5YNwxTS5fltYK7h60hhL049MkQTUnz74CjPzQ="
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:31 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -15461,16 +15589,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:31 GMT
       Set-Cookie:
-      - AWSALB=zYhKUy9oWha1VbSB6cQg4h1xQsj8NCytO59axFSfVgjoE2NzhFgrFP1NejXT59WVF32iK9/ZdP5r6exYQ/JC+aTWx8Jq/AjMhCrz3zHjlARM/H8j4i9yljXIUsOy;
-        Expires=Tue, 03 May 2022 05:03:25 GMT; Path=/
-      - AWSALBCORS=zYhKUy9oWha1VbSB6cQg4h1xQsj8NCytO59axFSfVgjoE2NzhFgrFP1NejXT59WVF32iK9/ZdP5r6exYQ/JC+aTWx8Jq/AjMhCrz3zHjlARM/H8j4i9yljXIUsOy;
-        Expires=Tue, 03 May 2022 05:03:25 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=2Jh1lxfTjAOQBo2CgIV93y3Kb6BQiJkVIEl0UI2BVZoA0C1rdP0u7ookY41V5Qky0ODiCACwgG4cJKls4I+lRjZ9Sivpoht0xiw+xW0q5iUmryBjHyu4ej9TBl+v;
+        Expires=Wed, 04 May 2022 06:19:31 GMT; Path=/
+      - AWSALBCORS=2Jh1lxfTjAOQBo2CgIV93y3Kb6BQiJkVIEl0UI2BVZoA0C1rdP0u7ookY41V5Qky0ODiCACwgG4cJKls4I+lRjZ9Sivpoht0xiw+xW0q5iUmryBjHyu4ej9TBl+v;
+        Expires=Wed, 04 May 2022 06:19:31 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB7845509789b1514befea875eda1955f5
+      - NBfc970753b8d3d2ecb12bc03d0bbce760
       Pragma:
       - no-cache
       Cache-Control:
@@ -15500,11 +15628,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - X3R18Dv_P6zHnYvkzE5O--X3DEYPLHJhfVSbV4Oxb-DuEaU9vY4TRw==
+      - q9gc8wzUnZ_N1QYLu0c5VKtUdNAt-McvrgMV_o6SBGvjQMhzO_pCRg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -15551,7 +15679,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E3",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8f",
           "Name": "",
@@ -15610,7 +15738,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:25 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:31 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d86
@@ -15626,9 +15754,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHJ09Sl+Z3TKbWvi/sqNE+T7T5GhCXoJ4rzjgCEA/QoqAiEA+7kWkNsrVshwHaH0GNNhj58wWBxN80dLYz3zjmA4sn4="
+        host date digest",signature="MEQCIBJV4Vm6eV38vh1TiA5mh2TVsEPcpAjueV2pWwh8MAEhAiAQwbquZcP1qIoNeHTjBTkQLEe3lfXu0+qSw7ECQj6YLA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:31 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -15641,16 +15769,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:31 GMT
       Set-Cookie:
-      - AWSALB=GkuFPHyxRFDy4NGAI5j4zA4Uoup5UvIg0xecvpdfpsj+eGLINt1wlYP+Sxc2XfqF4nS04ZwPiMDWOXKwMsqNTf99oz/uwT6TWki7AK6O4he/FTCqX5GyMQNXf6tK;
-        Expires=Tue, 03 May 2022 05:03:25 GMT; Path=/
-      - AWSALBCORS=GkuFPHyxRFDy4NGAI5j4zA4Uoup5UvIg0xecvpdfpsj+eGLINt1wlYP+Sxc2XfqF4nS04ZwPiMDWOXKwMsqNTf99oz/uwT6TWki7AK6O4he/FTCqX5GyMQNXf6tK;
-        Expires=Tue, 03 May 2022 05:03:25 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=+7V+eTGGoa5oPTyPD6IqSFJW4+kIptRVIifH0WtdTEHR4B56D871xwdbUXQChWUxP/2vOkW5zrexSFnAzIn4bYXeA5rQD0OtHcGXHHASq0Eiccr0IRDqEMBPFnOE;
+        Expires=Wed, 04 May 2022 06:19:31 GMT; Path=/
+      - AWSALBCORS=+7V+eTGGoa5oPTyPD6IqSFJW4+kIptRVIifH0WtdTEHR4B56D871xwdbUXQChWUxP/2vOkW5zrexSFnAzIn4bYXeA5rQD0OtHcGXHHASq0Eiccr0IRDqEMBPFnOE;
+        Expires=Wed, 04 May 2022 06:19:31 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB18f14cff6654fd5143534c50eac29c80
+      - NBf88b1311dbf0e7a1d00e3b35f6cd18be
       Pragma:
       - no-cache
       Cache-Control:
@@ -15680,11 +15808,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - s5_8M_qIk2Ek1R38RQklCXTaUuaTIj8ccc7RsECtreEGa8894JS5AA==
+      - 3aZiDTbiBvW53fcv0cxNtq5UV2KyJMfxPCK7HV79YpZcHykN8oKZ0Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -15731,7 +15859,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DA",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25c4630312d42bf1d86",
           "Name": "",
@@ -15790,7 +15918,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:25 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:31 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d88
@@ -15806,9 +15934,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIDI3pfJmlCvP0ZgMFkZuwOR5GeFZb2QOLRsXUUPXPErTAiEAyl5g7Aqf3PHkkjpN+HzQi5hdu49J8igs4h4BsIl51cY="
+        host date digest",signature="MEYCIQCa3P7QJ73M8WpRVuuD+IPMRa0SDVO1+brZckS5rpkkZQIhANx0Stp8VwAiywrt/9krrun+Li3/9C4q9nYJHpRS31lG"
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:31 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -15821,16 +15949,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:31 GMT
       Set-Cookie:
-      - AWSALB=E7c9h+cp8aYcvE66QUyaO44nnpg9VAcg7vH1x/nBbxtQ0vV0be3pN041xDqWh5hUf+iGtWn0PIKehjT0l8aDqrSJQcrasuO+yB/5ppB1b+VneAhOm7Z+h5MXcVvN;
-        Expires=Tue, 03 May 2022 05:03:25 GMT; Path=/
-      - AWSALBCORS=E7c9h+cp8aYcvE66QUyaO44nnpg9VAcg7vH1x/nBbxtQ0vV0be3pN041xDqWh5hUf+iGtWn0PIKehjT0l8aDqrSJQcrasuO+yB/5ppB1b+VneAhOm7Z+h5MXcVvN;
-        Expires=Tue, 03 May 2022 05:03:25 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=csyfS1ljrxfJ7vhK5sZvI2M7NZMQB4wXIU1rp+r+x2YZ+HjPRtFX7xrIIpMaB/M7FxStVgzM9jMNrwIGzhRP3qwR5x8BHO/569WCK6JaWdWsM532qox+/FET5N9Y;
+        Expires=Wed, 04 May 2022 06:19:31 GMT; Path=/
+      - AWSALBCORS=csyfS1ljrxfJ7vhK5sZvI2M7NZMQB4wXIU1rp+r+x2YZ+HjPRtFX7xrIIpMaB/M7FxStVgzM9jMNrwIGzhRP3qwR5x8BHO/569WCK6JaWdWsM532qox+/FET5N9Y;
+        Expires=Wed, 04 May 2022 06:19:31 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe2d28ed64d98c64d687b30e3910f2cb2
+      - NBaa60f656e251c10700669806c2e531f1
       Pragma:
       - no-cache
       Cache-Control:
@@ -15860,11 +15988,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - r7_NV9OChgB9lr2XMrFAvd9LZZpNZW_ocLsGg-JzYwQzV5MQaoQhYQ==
+      - 1Bc0xOeOBepKuWFW1csySlH9upGuXAOGEwjMROh_cNGoKoPsLAI7Og==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -15911,7 +16039,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DC",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d88",
           "Name": "",
@@ -15970,7 +16098,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:25 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:31 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6f
@@ -15986,9 +16114,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIFIoaEV3T3kK5IhBLakc5+fre7AnZyE91iiqLZc6bmCYAiARAqX0flyAWem07PqlDwWgNsz5xqgMk6w4HkNHjTiAow=="
+        host date digest",signature="MEYCIQDGUt0BkPI9R0nQfa1u1BAEsLrrV316nzYlvW/hH8ttNAIhAJAkvgILSfOagJJFt+/mEmgc5ChJht+oY380nBQp3Csm"
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:31 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -16001,16 +16129,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:31 GMT
       Set-Cookie:
-      - AWSALB=g4ioVeQpQdvZU2oKEt4opfe24FWZmIW3Ric7sXDZFUxH4Kb57l56plToNX7nPqtB07pGppLERKsoHVrZST3HwTXTYOqAO4At/ZofzbTMhX/cibNWnZhUKqZe0cxz;
-        Expires=Tue, 03 May 2022 05:03:25 GMT; Path=/
-      - AWSALBCORS=g4ioVeQpQdvZU2oKEt4opfe24FWZmIW3Ric7sXDZFUxH4Kb57l56plToNX7nPqtB07pGppLERKsoHVrZST3HwTXTYOqAO4At/ZofzbTMhX/cibNWnZhUKqZe0cxz;
-        Expires=Tue, 03 May 2022 05:03:25 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=GG4YRbz+IXg5uI6wIWZQrpuBLjm5WrEqdEYLwtkhh8Wd+VPZjOHr07G4Y4CUjt3Ub+JTsKWK5oJEGbDrWbBaOfCXspplcVbpHaAXGNNOtK7ndbM9Q7Ye0L1dMIZT;
+        Expires=Wed, 04 May 2022 06:19:31 GMT; Path=/
+      - AWSALBCORS=GG4YRbz+IXg5uI6wIWZQrpuBLjm5WrEqdEYLwtkhh8Wd+VPZjOHr07G4Y4CUjt3Ub+JTsKWK5oJEGbDrWbBaOfCXspplcVbpHaAXGNNOtK7ndbM9Q7Ye0L1dMIZT;
+        Expires=Wed, 04 May 2022 06:19:31 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB9a49196de35e2fe5d9a2f99dac18b4d9
+      - NBffd2d34ff0709b2543399e7ba26f328a
       Pragma:
       - no-cache
       Cache-Control:
@@ -16040,11 +16168,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 92YpVtqBnzLFXku7a4X0UdRL_lQphvtuXbX79_XFOOqrlm8bvEO6kw==
+      - xCwQLRLZT_CEmo73xSWmuxNFA18wuDLT96nOB1BOz86JglVgNQOJng==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -16091,7 +16219,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:FC",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "trunk",
           "Moid": "614ce25c4630312d42bf1d6f",
           "Name": "",
@@ -16150,7 +16278,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:25 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:31 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d72
@@ -16166,9 +16294,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQD9HAwh1pHAQ/Dd9c+gzyPV5qKLQUFEVseJva9i9qKXfQIhAMgJRL/yvhIWF+u8Y+KJY3D7lZKfMbLOFmXHuXhE7HeD"
+        host date digest",signature="MEUCIQDBglz0HhCllqi9HXxA8H4DCwqRsujIC1+nFtNvUNVbGAIgSKAqEMErTjnmCN/Jiy7/hsecguligV6+qM6v7IU5P18="
       Date:
-      - Tue, 26 Apr 2022 05:03:25 GMT
+      - Wed, 27 Apr 2022 06:19:31 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -16181,16 +16309,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:26 GMT
+      - Wed, 27 Apr 2022 06:19:32 GMT
       Set-Cookie:
-      - AWSALB=sHSUzc6jCyGvaWvXcQLYIJWGVBusqr/6vANyrFUog9k1emJv6EWK+gvFUw0cf69gJwNspA/WHJ+S4K4UoAqfAnBqlWfWeXi1M8pa76OUt+FjoEQlwUU+rfniusuf;
-        Expires=Tue, 03 May 2022 05:03:26 GMT; Path=/
-      - AWSALBCORS=sHSUzc6jCyGvaWvXcQLYIJWGVBusqr/6vANyrFUog9k1emJv6EWK+gvFUw0cf69gJwNspA/WHJ+S4K4UoAqfAnBqlWfWeXi1M8pa76OUt+FjoEQlwUU+rfniusuf;
-        Expires=Tue, 03 May 2022 05:03:26 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=VW98ngh37XNRo5eDrE+xDZCQdjqz19EXckR8PVHOQQs6OknDJyHB0aC2jlYsuYyM24qdFTUofxYmYka4auV5ibvr2KFDu2rxVjP4Xnq5S2d2IqIRpA7G3WtWLvEq;
+        Expires=Wed, 04 May 2022 06:19:32 GMT; Path=/
+      - AWSALBCORS=VW98ngh37XNRo5eDrE+xDZCQdjqz19EXckR8PVHOQQs6OknDJyHB0aC2jlYsuYyM24qdFTUofxYmYka4auV5ibvr2KFDu2rxVjP4Xnq5S2d2IqIRpA7G3WtWLvEq;
+        Expires=Wed, 04 May 2022 06:19:32 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb57b7663e57c19e20167e32f16601339
+      - NB12e9f0c2fe12b6ab3fbe7efc58790baf
       Pragma:
       - no-cache
       Cache-Control:
@@ -16220,11 +16348,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - IxIBOTsqz6wgcJCi-J2Zats7OMX9FUihlCvs8ZVZXIGO865AggPGHw==
+      - JjmjxBhH92Vchzy0Eebdu5538Xyb5yhHpq6sipantyL9cSfLwZ9bdQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -16271,7 +16399,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:79:08",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d72",
           "Name": "",
@@ -16330,7 +16458,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:26 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:32 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7f
@@ -16346,9 +16474,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIETlgphSnMiH/B313+SCVCJXNmM7051EOTVCnXZT1yvbAiBfWMH/3lGSCHkTIHRM5iQUt6XTVhllFp4C7d+DFGpqzQ=="
+        host date digest",signature="MEYCIQDEsZJ8ocV6RshiS2usxjIAp4BOOGGBvjR9T9n+je9bTgIhANgRUXGILtMvno7iEw41lDwRY30AJO6nNoHsRJb0Rr5P"
       Date:
-      - Tue, 26 Apr 2022 05:03:26 GMT
+      - Wed, 27 Apr 2022 06:19:32 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -16361,16 +16489,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:26 GMT
+      - Wed, 27 Apr 2022 06:19:32 GMT
       Set-Cookie:
-      - AWSALB=4xv/1kg93CsEw5B5CaXcjnvc7G4v5RdEHbo8d3cBGjXpnbJMhXb6QURD6UeBMS8iAtxqHlOmpuJGnoOtjiq6C3mM0kamGTKpgk6qw16N1h9fTuhQlC5JHkE1k7wi;
-        Expires=Tue, 03 May 2022 05:03:26 GMT; Path=/
-      - AWSALBCORS=4xv/1kg93CsEw5B5CaXcjnvc7G4v5RdEHbo8d3cBGjXpnbJMhXb6QURD6UeBMS8iAtxqHlOmpuJGnoOtjiq6C3mM0kamGTKpgk6qw16N1h9fTuhQlC5JHkE1k7wi;
-        Expires=Tue, 03 May 2022 05:03:26 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=cv24OA/rVmLylOAjgIvmRhgqUoBEzB+7Z4ykgTTQM+BNwg0gchSNEUnGEL7ezh2gF0dBZmYKYHZP1iEfX+mK5pLr2hFOS1M8vqgkfYrWXkuh5g0uCNOgmabUHs1k;
+        Expires=Wed, 04 May 2022 06:19:32 GMT; Path=/
+      - AWSALBCORS=cv24OA/rVmLylOAjgIvmRhgqUoBEzB+7Z4ykgTTQM+BNwg0gchSNEUnGEL7ezh2gF0dBZmYKYHZP1iEfX+mK5pLr2hFOS1M8vqgkfYrWXkuh5g0uCNOgmabUHs1k;
+        Expires=Wed, 04 May 2022 06:19:32 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4a7e7c1aaf9055017e4b26bf2bb39a2d
+      - NBa26d2fe52a7fd8f9895d6bca16f4cd62
       Pragma:
       - no-cache
       Cache-Control:
@@ -16400,11 +16528,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - IqBGJkvZ8F73SeWJLkghRLejoAtbjexDJkryl5mamh48pEbvhkKbrg==
+      - j7KXhomD4nIhf1QjhCf7krzg9dwkitdaY4O904qYU9R-AAzTxTPGuQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -16451,7 +16579,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D3",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7f",
           "Name": "",
@@ -16510,7 +16638,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:26 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:32 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d80
@@ -16526,9 +16654,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCICmzovg3mqy9hXtAtaTZDS4rjIbo6LM9cJwXKZseAPQEAiEA9lK+R4NWPiZSytNxa9ZT+zRAaCBxB6k2ZOFwbxhfcxY="
+        host date digest",signature="MEUCIBd+unLbs9pN2A/3CUzAdBCsziz8gEzk6QcVYzynY9DRAiEA/BOdYP2LbV8LRWrql0kXScpZcQTfl2mxHlImZqsXSRU="
       Date:
-      - Tue, 26 Apr 2022 05:03:26 GMT
+      - Wed, 27 Apr 2022 06:19:32 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -16541,16 +16669,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:26 GMT
+      - Wed, 27 Apr 2022 06:19:32 GMT
       Set-Cookie:
-      - AWSALB=TW1mpNnTyTdtoc0Qy16v93EmCQ87G7EJYhlGT8XvRzg9AqQES64IINLpJpHOam43I1vcXpiKGc4GPiVsoQLLFhk8fQmGNgGgRK5pFnuBlBmp/mPD9Hf03SnZPCI+;
-        Expires=Tue, 03 May 2022 05:03:26 GMT; Path=/
-      - AWSALBCORS=TW1mpNnTyTdtoc0Qy16v93EmCQ87G7EJYhlGT8XvRzg9AqQES64IINLpJpHOam43I1vcXpiKGc4GPiVsoQLLFhk8fQmGNgGgRK5pFnuBlBmp/mPD9Hf03SnZPCI+;
-        Expires=Tue, 03 May 2022 05:03:26 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=o1FpM+oySThGd5KIDdfcZYNJTptZL3VS1bzknGG0YRrGT9TXYCuMU3El2zPjCF6n8xboWz8kLFzMZyca3pzucKKIvypdjPsm1Jkhdc2SJF12a8wr6STuJ5DgZF6j;
+        Expires=Wed, 04 May 2022 06:19:32 GMT; Path=/
+      - AWSALBCORS=o1FpM+oySThGd5KIDdfcZYNJTptZL3VS1bzknGG0YRrGT9TXYCuMU3El2zPjCF6n8xboWz8kLFzMZyca3pzucKKIvypdjPsm1Jkhdc2SJF12a8wr6STuJ5DgZF6j;
+        Expires=Wed, 04 May 2022 06:19:32 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB45c8fc846348938cdc56fda27f7459b8
+      - NB0cf1783a200739cf4a10acfe21b9062e
       Pragma:
       - no-cache
       Cache-Control:
@@ -16580,11 +16708,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - T7eowFfv_wnbpMuEgAtrIGMnNGhMHKJDqH9gxM4ksPYxSEczPmaiag==
+      - j02krBK4GnLG7ESpus7lxrVGKvESPmgvPwknl0StxI9YZJvhCArKKA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -16631,7 +16759,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D4",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d80",
           "Name": "",
@@ -16690,7 +16818,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:26 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:32 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d68
@@ -16706,9 +16834,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDnBdH5Qn+xRW0o8wNLZ4VwfEJYQUfqzQR+i7jQUpuLEAIgBSShncHDOcDnSOZTqsbNqNyGk/n4/j1IgP/+2b+p3wM="
+        host date digest",signature="MEUCIDPxXbpwEoy7Lq4jcY0jPcV7WoJ7U7Sg/52GS2rO9jAgAiEAv13J7ts7kZNbPfcHwV+fFy5UfC05hURKrlcKzZshdd0="
       Date:
-      - Tue, 26 Apr 2022 05:03:26 GMT
+      - Wed, 27 Apr 2022 06:19:32 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -16721,16 +16849,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:26 GMT
+      - Wed, 27 Apr 2022 06:19:32 GMT
       Set-Cookie:
-      - AWSALB=AUcXovl9yhTDtBj45txAgyPFWVI802uu3dbbaJnfjEHciIhAJ/uTZ8u/e0v0ak5LestWzxn9R7bLCMRSV5VLdVRm6qpN+Iqw3qxPJVGx+clmi+TPf6zgIG7tkMf7;
-        Expires=Tue, 03 May 2022 05:03:26 GMT; Path=/
-      - AWSALBCORS=AUcXovl9yhTDtBj45txAgyPFWVI802uu3dbbaJnfjEHciIhAJ/uTZ8u/e0v0ak5LestWzxn9R7bLCMRSV5VLdVRm6qpN+Iqw3qxPJVGx+clmi+TPf6zgIG7tkMf7;
-        Expires=Tue, 03 May 2022 05:03:26 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=4w48Af7Mur4nHM7dEf54t3/qPB6JvUuSKtn4WhikMvrVw95P9hGGTDYn6y9Vn8m7bY96bBZrxM7fS6M2mmLcuWKpyI0nxx7riLYQ1IZ6bnS40YcjiD60zmfAad8C;
+        Expires=Wed, 04 May 2022 06:19:32 GMT; Path=/
+      - AWSALBCORS=4w48Af7Mur4nHM7dEf54t3/qPB6JvUuSKtn4WhikMvrVw95P9hGGTDYn6y9Vn8m7bY96bBZrxM7fS6M2mmLcuWKpyI0nxx7riLYQ1IZ6bnS40YcjiD60zmfAad8C;
+        Expires=Wed, 04 May 2022 06:19:32 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBfb2857c419304baaed2128c7f044dd57
+      - NBfe8e462950e03b6b6724ff2962bff3d5
       Pragma:
       - no-cache
       Cache-Control:
@@ -16760,11 +16888,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - H7i4chqSAXh4ubXiNUgzbuquHEEYPgthuw7NxeV5FxsfAopWdkRilQ==
+      - rpzzodEvo_0w7zmQa1XNl8iAp4sEGVmQt6k_z1S-Q4kwvPYgBlphwQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -16811,7 +16939,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F2",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d68",
           "Name": "",
@@ -16870,7 +16998,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:26 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:33 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8a
@@ -16886,9 +17014,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDFqUv5Qy8R/zBy1HB0+hT7rI/xPh6IuUyP1zZTMGfiogIgccwde9Lpwk8KZjahuBl77/xfWIiz9H1CKUmc5j6KE1s="
+        host date digest",signature="MEYCIQCOOvG2yDYEzz/FfaGoHpxmnNehmDrJ3BO5QF5VEXn8FQIhAKJCKgxkKt6ete6r4IOosYvLh8Q1ad4+/wNNRu0dXUbY"
       Date:
-      - Tue, 26 Apr 2022 05:03:26 GMT
+      - Wed, 27 Apr 2022 06:19:33 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -16901,16 +17029,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:27 GMT
+      - Wed, 27 Apr 2022 06:19:33 GMT
       Set-Cookie:
-      - AWSALB=qL/BwXs+0dkBWccZBAesNo7UbERpwDk1i/f4aXmSaVlBLvRxQgNHaVvY3pq/H8kBetjVj1LSkngHeLFi1Q79pCSKQZFaw6YqwBk8FmCvEmACTmS/JjD+pBeIGUuA;
-        Expires=Tue, 03 May 2022 05:03:27 GMT; Path=/
-      - AWSALBCORS=qL/BwXs+0dkBWccZBAesNo7UbERpwDk1i/f4aXmSaVlBLvRxQgNHaVvY3pq/H8kBetjVj1LSkngHeLFi1Q79pCSKQZFaw6YqwBk8FmCvEmACTmS/JjD+pBeIGUuA;
-        Expires=Tue, 03 May 2022 05:03:27 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ZUDa/d8UZt7uXuyJ9DH6PrgQXqo7Q1ZHbG4eU9xmu+0Hvwg4IxCX8i70+RZlHU0oH3oPl8PWzLxCaI98hwLRFBpZ63o8320I/VGrWJxqE8+zQ8UTKxru2A6GQegS;
+        Expires=Wed, 04 May 2022 06:19:33 GMT; Path=/
+      - AWSALBCORS=ZUDa/d8UZt7uXuyJ9DH6PrgQXqo7Q1ZHbG4eU9xmu+0Hvwg4IxCX8i70+RZlHU0oH3oPl8PWzLxCaI98hwLRFBpZ63o8320I/VGrWJxqE8+zQ8UTKxru2A6GQegS;
+        Expires=Wed, 04 May 2022 06:19:33 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf032addd48aca82ae18307f5f94720b9
+      - NBe87f629bfbe6cc3c8d75ae0710006037
       Pragma:
       - no-cache
       Cache-Control:
@@ -16940,11 +17068,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - FOBmtN_hAtWKXtv2iMdI9mksGVg5Fohadgp0IvoNCTSm6_HJy0D4Aw==
+      - aGO1jwdmYbSuU7kJlglxbmCVSFc7LIRn-QlJ-nA1XOso5htHK0jM5A==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -16991,7 +17119,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DE",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.7Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8a",
           "Name": "",
@@ -17050,7 +17178,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:27 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:33 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/620449094630312d425f65e6
@@ -17066,9 +17194,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQC+Dz7FYyhESo1E4AoFrT9vf+JLUS/0E4/d2XtbxM79OAIgZAtou5RdE1p7YvX8QHttp4cD64jx3DqCZZsZPxMUy0s="
+        host date digest",signature="MEUCIQDo4yNN+TLnixSLfLRdggwmlxIeHDqmqzWYlQte1SuiOQIgXWpfYa3f0ldx4wxFNYsxk65ejFwtTz0wk1xF71ee8JQ="
       Date:
-      - Tue, 26 Apr 2022 05:03:27 GMT
+      - Wed, 27 Apr 2022 06:19:33 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -17081,16 +17209,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:27 GMT
+      - Wed, 27 Apr 2022 06:19:33 GMT
       Set-Cookie:
-      - AWSALB=aZ1ok43kj+sczOjoYQi0wzBlAsItdoUa7pT+bSam5b6Z+RCW2f9ZGcTX/D/opK8uXN4qYvtubBavlMCj/R/wdvWJW1UAKDyhjqyP1ruSB4hPK3pv0k9MhGMOISFU;
-        Expires=Tue, 03 May 2022 05:03:27 GMT; Path=/
-      - AWSALBCORS=aZ1ok43kj+sczOjoYQi0wzBlAsItdoUa7pT+bSam5b6Z+RCW2f9ZGcTX/D/opK8uXN4qYvtubBavlMCj/R/wdvWJW1UAKDyhjqyP1ruSB4hPK3pv0k9MhGMOISFU;
-        Expires=Tue, 03 May 2022 05:03:27 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=xks+eTB6AciWeaKP9LbX3R4O2ZpTWivKd8YV4oE4bC+WK6JvdFInlOcizi3QdrJdIlYuUtGyVzFoE8QhqJ+n8687DSAeYLmAe1PDkFOOeszFomZ1B8FoA5yoiV4g;
+        Expires=Wed, 04 May 2022 06:19:33 GMT; Path=/
+      - AWSALBCORS=xks+eTB6AciWeaKP9LbX3R4O2ZpTWivKd8YV4oE4bC+WK6JvdFInlOcizi3QdrJdIlYuUtGyVzFoE8QhqJ+n8687DSAeYLmAe1PDkFOOeszFomZ1B8FoA5yoiV4g;
+        Expires=Wed, 04 May 2022 06:19:33 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa074bba9ca7130e7970e419dcbf46939
+      - NB6a8844fdc214ae8b0156dfd4fa665864
       Pragma:
       - no-cache
       Cache-Control:
@@ -17120,11 +17248,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 3OwlHquccGLflOue8C_gLxqksrbW5LGZRcv-lvShdBbeoE1gKAxNAQ==
+      - abDmyWcZ9QO5SthUvReDfX-eExJmOhMmu2yQ6agHZlxmokUVCqZVsA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -17171,7 +17299,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:C9",
-          "ModTime": "2022-04-26T04:32:29.506Z",
+          "ModTime": "2022-04-27T06:18:30.7Z",
           "Mode": "access",
           "Moid": "620449094630312d425f65e6",
           "Name": "",
@@ -17230,7 +17358,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:27 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:33 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/620449094630312d425f65e7
@@ -17246,9 +17374,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIF7DKuh4MTjY9gb7+0mXtssmvbmwpP/gx0C2e88uBkdmAiAshKdrLw1L6fSQWkfsQV511N9Hf11COVOJsHH0++4o6w=="
+        host date digest",signature="MEQCIF40XCTckfWzco1YQAKEwUjT6mR5JpmHXLTWXgOXQ0d7AiBFZC9XgWeGhAbRgAO+Yz8C33+F9qeUvIOKaBizvTgoGQ=="
       Date:
-      - Tue, 26 Apr 2022 05:03:27 GMT
+      - Wed, 27 Apr 2022 06:19:33 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -17261,16 +17389,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:27 GMT
+      - Wed, 27 Apr 2022 06:19:33 GMT
       Set-Cookie:
-      - AWSALB=Y65L9TpwOL9Avcs596uDrajLZiSnvMFsBWDvUeOXjOq//NLl2W+cSQHdfEVdh9+2DwKAWGOFOUP5EimOrw1ZjR9NofZjoXfKTogtNFCPb8Sy8bGFk24jBZI5CViP;
-        Expires=Tue, 03 May 2022 05:03:27 GMT; Path=/
-      - AWSALBCORS=Y65L9TpwOL9Avcs596uDrajLZiSnvMFsBWDvUeOXjOq//NLl2W+cSQHdfEVdh9+2DwKAWGOFOUP5EimOrw1ZjR9NofZjoXfKTogtNFCPb8Sy8bGFk24jBZI5CViP;
-        Expires=Tue, 03 May 2022 05:03:27 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=t2M3Ivr0J4hz90BJENPb+9U1s/BXlLZ1I86eou+q4NSyTR7cCghhT+/w5fUq/8I6Que11YBKzkpzjujdIzbbr+QUZ94o2WeuE0FpxUVHZhEnJyBgR4zCO3+Pp5N0;
+        Expires=Wed, 04 May 2022 06:19:33 GMT; Path=/
+      - AWSALBCORS=t2M3Ivr0J4hz90BJENPb+9U1s/BXlLZ1I86eou+q4NSyTR7cCghhT+/w5fUq/8I6Que11YBKzkpzjujdIzbbr+QUZ94o2WeuE0FpxUVHZhEnJyBgR4zCO3+Pp5N0;
+        Expires=Wed, 04 May 2022 06:19:33 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3749192b0e91388982b8d2eeba26bd72
+      - NB126b4a24a9144ebc346b0d2ed10d1c41
       Pragma:
       - no-cache
       Cache-Control:
@@ -17300,11 +17428,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - hkO_ZoJz2SOhY7cEBlzdXvUJ5heHR0rWwZ6wT97KnR8pKGGAfW33lw==
+      - JuPNwuu3eDqXL30uEQ4vQ5hMaI6jsVCoCyYfBkKmiy6JMHPIin1ieA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -17351,7 +17479,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CA",
-          "ModTime": "2022-04-26T04:32:29.506Z",
+          "ModTime": "2022-04-27T06:18:30.7Z",
           "Mode": "access",
           "Moid": "620449094630312d425f65e7",
           "Name": "",
@@ -17410,7 +17538,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:27 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:33 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/620449094630312d425f65e5
@@ -17426,9 +17554,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCP+KoUB4+MHYnSvkuXLJNfAhZyNqUVivUqAjfdUTCAPQIhALzpfOG0FMgB9zRQ5BR9vdPHqpEzLBYz559RZrCGAX3m"
+        host date digest",signature="MEQCIA2LibGJUPgd940YyZDrql1LT20mwNPRt4BD4wGFQeOJAiBbJ4V2WivP3uTzaKQznU1ujwIph4pOep+zDmru74MyiQ=="
       Date:
-      - Tue, 26 Apr 2022 05:03:27 GMT
+      - Wed, 27 Apr 2022 06:19:33 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -17441,16 +17569,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:27 GMT
+      - Wed, 27 Apr 2022 06:19:33 GMT
       Set-Cookie:
-      - AWSALB=6QDpzw9Gfez/vab4IDJx/TZOwKTedkP1A/9T43ndwNSoefTnHy9uK0E7CGQdL3LkY+ypGdjtjJZ+NhMniA7J55Yx1WHp7DRCOh68LyZ0/biAhTXtrdQNnetKQxpB;
-        Expires=Tue, 03 May 2022 05:03:27 GMT; Path=/
-      - AWSALBCORS=6QDpzw9Gfez/vab4IDJx/TZOwKTedkP1A/9T43ndwNSoefTnHy9uK0E7CGQdL3LkY+ypGdjtjJZ+NhMniA7J55Yx1WHp7DRCOh68LyZ0/biAhTXtrdQNnetKQxpB;
-        Expires=Tue, 03 May 2022 05:03:27 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=j+fId3ksAAow5EdQUbsFqaxMT3XLwRwq+g0eESvHCfQjMjLk8k8s5fvLI9owyRtUOK89I9T9QLGl+/PWIpCDKTEqEbyoKpRPLaBS12jLWL5uFCDoBM8CpcxavIuW;
+        Expires=Wed, 04 May 2022 06:19:33 GMT; Path=/
+      - AWSALBCORS=j+fId3ksAAow5EdQUbsFqaxMT3XLwRwq+g0eESvHCfQjMjLk8k8s5fvLI9owyRtUOK89I9T9QLGl+/PWIpCDKTEqEbyoKpRPLaBS12jLWL5uFCDoBM8CpcxavIuW;
+        Expires=Wed, 04 May 2022 06:19:33 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB583e1a997d427175ef7a2b1429e61ce2
+      - NB11b4e5acc4f73c616a635292dcce46fb
       Pragma:
       - no-cache
       Cache-Control:
@@ -17480,11 +17608,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - gaTF8Fj2MkD0Fz26Nym4Mcb1vcoLc7J3g39w--IW3Gd53G5gHPV4uA==
+      - Ve2aTuxKtyNmaY3GZvIoWx1-22TLH_VRMcSUlhYDDCs76At-TEI6iw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -17531,7 +17659,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:C8",
-          "ModTime": "2022-04-26T04:32:29.506Z",
+          "ModTime": "2022-04-27T06:18:30.7Z",
           "Mode": "access",
           "Moid": "620449094630312d425f65e5",
           "Name": "",
@@ -17590,7 +17718,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:27 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:34 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/620449094630312d425f65e8
@@ -17606,9 +17734,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQD2NwEOYU0VvF9tHb33XeGi0iTRnzv8Gu5hXaoaJZvStgIgWaMr3fANpe4M0dFxJtUACXmWh0jrUvWHJ/qD6b3Ztf0="
+        host date digest",signature="MEQCIEYdEfp8GBG22IUz5mxpFx4eyLUbwlDptTkLPbjKHX7yAiBL/+kmVs89KzWd+FCpyCBPQuxvpfXqsKlmn1kHlR/dRA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:27 GMT
+      - Wed, 27 Apr 2022 06:19:34 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -17621,16 +17749,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:28 GMT
+      - Wed, 27 Apr 2022 06:19:34 GMT
       Set-Cookie:
-      - AWSALB=ZpCJZeD4g7fk5JOdXxlkBkpiNrqbeDkTZvpNcGuA6+aEi9ocyDxvm3EqCl6WE+dCrgkiZhpsQy0ouwhUNWAsWvZBCzASN2MawlJ+UTi7fHc26BrfcS5sJsKXbkvA;
-        Expires=Tue, 03 May 2022 05:03:27 GMT; Path=/
-      - AWSALBCORS=ZpCJZeD4g7fk5JOdXxlkBkpiNrqbeDkTZvpNcGuA6+aEi9ocyDxvm3EqCl6WE+dCrgkiZhpsQy0ouwhUNWAsWvZBCzASN2MawlJ+UTi7fHc26BrfcS5sJsKXbkvA;
-        Expires=Tue, 03 May 2022 05:03:27 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=/fZ0/YElAeRsiXKrpd27UAnPFKf714i8lwRsdSBWm8pisImOmjX05jg5xYGWddG9aPobXaejyEwyvRV6IIJOGiZuYWpThAB6+kQ/84AQ8a/TR56rG7CJazOofjwg;
+        Expires=Wed, 04 May 2022 06:19:34 GMT; Path=/
+      - AWSALBCORS=/fZ0/YElAeRsiXKrpd27UAnPFKf714i8lwRsdSBWm8pisImOmjX05jg5xYGWddG9aPobXaejyEwyvRV6IIJOGiZuYWpThAB6+kQ/84AQ8a/TR56rG7CJazOofjwg;
+        Expires=Wed, 04 May 2022 06:19:34 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB091edd2f0b2a2b40241c429d4bba10eb
+      - NBb866f4e35210c42d5f7e4ffb7ba768a1
       Pragma:
       - no-cache
       Cache-Control:
@@ -17660,11 +17788,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - P7bcBvWkc5e8yyQQ0sDi5jYRUzlG74XJGvm3cBcMnIX22-0oOOEBog==
+      - t8KJD9x60SljUPGD_1Bjms6C14b1CEq1zX0Do9USP9i2loI1Vmekgw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -17711,7 +17839,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CB",
-          "ModTime": "2022-04-26T04:32:29.506Z",
+          "ModTime": "2022-04-27T06:18:30.7Z",
           "Mode": "access",
           "Moid": "620449094630312d425f65e8",
           "Name": "",
@@ -17770,7 +17898,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:28 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:34 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/port/Groups/614ce2a36176752d35a7edd5
@@ -17786,9 +17914,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDwf844+jtBbE02XuGuDkkBoCd7he3Zgm/u3duhlIQgJgIgGbtWnBOCB6AmQmNAlvoqZgp9X5jZCB37ELF1pQe6NQY="
+        host date digest",signature="MEUCIBgIm0vwn8NGrjC4pGrxxdLTQyl1thwOruRTwm/TdWzEAiEAnIdgq3C41jguy1s1+0HA/i12IY8TDHe3dqi/2MISh74="
       Date:
-      - Tue, 26 Apr 2022 05:03:28 GMT
+      - Wed, 27 Apr 2022 06:19:34 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -17801,16 +17929,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:28 GMT
+      - Wed, 27 Apr 2022 06:19:34 GMT
       Set-Cookie:
-      - AWSALB=pw0fQUuXOksuEsf9vXTWGZOY1h9W0/ja+/iQFf4PeuZm4JTaJ0ZveBAPVlEXmfuTRn4nglH87YPnXlPqiXC3HXLciDLizdDuy8m1nbcYVw7LxXqVF55hxyBpE/Ed;
-        Expires=Tue, 03 May 2022 05:03:28 GMT; Path=/
-      - AWSALBCORS=pw0fQUuXOksuEsf9vXTWGZOY1h9W0/ja+/iQFf4PeuZm4JTaJ0ZveBAPVlEXmfuTRn4nglH87YPnXlPqiXC3HXLciDLizdDuy8m1nbcYVw7LxXqVF55hxyBpE/Ed;
-        Expires=Tue, 03 May 2022 05:03:28 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=Bpr+xq4fmIJ/0/u/rCxlSAtgjKMiY05kUE4HH2Jpa6fcJwuu6+Yx1AuSvFg01pOJYWZ5Lk+BhKoR3KoavThjBAIFYxd9UMtGaG1+YQAml/63TljFmmzKNguh/RLD;
+        Expires=Wed, 04 May 2022 06:19:34 GMT; Path=/
+      - AWSALBCORS=Bpr+xq4fmIJ/0/u/rCxlSAtgjKMiY05kUE4HH2Jpa6fcJwuu6+Yx1AuSvFg01pOJYWZ5Lk+BhKoR3KoavThjBAIFYxd9UMtGaG1+YQAml/63TljFmmzKNguh/RLD;
+        Expires=Wed, 04 May 2022 06:19:34 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf0fdd53ae47336d31e562ef02ed4b926
+      - NB34e0157f20fa55297d047b6af3eec8ec
       Pragma:
       - no-cache
       Cache-Control:
@@ -17840,11 +17968,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - DePEc_blhU0hjS-hYvprNkx4kffnjeuPVFVtWBA0-gACwb45ITKRKw==
+      - yA_j4SUC1EsbXLUZtRmcL5j2N69oncGha03hBOkVDe39UKeCYmCAkQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -17919,7 +18047,7 @@ http_interactions:
           "Transport": "fc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:28 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:34 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/firmware/RunningFirmwares/614ce25c4630312d42bf1d9c
@@ -17935,9 +18063,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCICyZFCKwQfbq7poKkFO6q7WWg7OBAJooB45kShzyELbaAiB9+LOPAS4iFfAlxGT37FmnLVNOxIVtXbinL8QUuMPHfA=="
+        host date digest",signature="MEYCIQCn43Py4pkvEPvE0ITuHoB0ETtPsVjwoP1Jx4WU/5SITgIhAIUCXtoMW/BUvhE/TkscG0ROHne51i+yXG5J1xi1E2c2"
       Date:
-      - Tue, 26 Apr 2022 05:03:28 GMT
+      - Wed, 27 Apr 2022 06:19:34 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -17950,16 +18078,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:28 GMT
+      - Wed, 27 Apr 2022 06:19:34 GMT
       Set-Cookie:
-      - AWSALB=Lt2266ndhZIEEQKOnchgLEsSOZYWSGzndd7lr10mVK7aPz9NeztyIjQPBZauvD0fb79LMJ0FVf2Lj/LwX+ztNEnMsRZF+q1IqvXuoR76PBCh8RIrWAu4M4WtLed0;
-        Expires=Tue, 03 May 2022 05:03:28 GMT; Path=/
-      - AWSALBCORS=Lt2266ndhZIEEQKOnchgLEsSOZYWSGzndd7lr10mVK7aPz9NeztyIjQPBZauvD0fb79LMJ0FVf2Lj/LwX+ztNEnMsRZF+q1IqvXuoR76PBCh8RIrWAu4M4WtLed0;
-        Expires=Tue, 03 May 2022 05:03:28 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=4rN0I0MaHQyLG0I3SZT03wm7sFjfv87egy6+Q58OnvMrRUU8Aan2dAi/0RXWruT6eqypf0iYDwRSO8CtEh4YRBA9KsKx/r961JKn0fOPPR3G8L97exeua8Myhepj;
+        Expires=Wed, 04 May 2022 06:19:34 GMT; Path=/
+      - AWSALBCORS=4rN0I0MaHQyLG0I3SZT03wm7sFjfv87egy6+Q58OnvMrRUU8Aan2dAi/0RXWruT6eqypf0iYDwRSO8CtEh4YRBA9KsKx/r961JKn0fOPPR3G8L97exeua8Myhepj;
+        Expires=Wed, 04 May 2022 06:19:34 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBfdbc5f8b4634fbde17a2ef8b84cd1eb1
+      - NB68fa30ee363e51816ba94e6c2f3319b3
       Pragma:
       - no-cache
       Cache-Control:
@@ -17989,11 +18117,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 7SlnboMJHLwwowlwB4R0E7lK8IXIYX8glIqUl5ytLp5XPAht6zO7cA==
+      - WLTrEzbdaNq1MGa--QtR_cFUYmPdXD_5JjA3-qDwnWq_oVTe0PuUOg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -18028,7 +18156,7 @@ http_interactions:
             "ObjectType": "management.Controller",
             "link": "https://www.intersight.com/api/v1/management/Controllers/614ce2a36176752d35a7edc8"
           },
-          "ModTime": "2022-04-26T05:02:29.565Z",
+          "ModTime": "2022-04-27T06:14:30.363Z",
           "Moid": "614ce25c4630312d42bf1d9c",
           "NetworkElements": [
             {
@@ -18081,10 +18209,10 @@ http_interactions:
           "Version": "9.3(5)I42(1f)"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:28 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:34 GMT
 - request:
     method: get
-    uri: https://intersight.com/api/v1/equipment/SwitchCards/614ce25c4630312d416698e7
+    uri: https://intersight.com/api/v1/network/ElementSummaries/614ce2a36176752d35a7edbd
     body:
       encoding: US-ASCII
       string: ''
@@ -18097,9 +18225,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCQ1mqGX24IYn1ApG1bYCumIyTZrIWMZwmdqaYod/6RkQIgd5zQF8HJ0UDrZsNcrizMcdlV3fNgPkh59YbKi/JXdM8="
+        host date digest",signature="MEYCIQCKMzG4cmUjKiYrSVxKIOj43bFuYldNW30Q8qAu7e0wTAIhAJgRrIvX3qhajZKz2kPPYvuJJ+ZKisDwOVh5LB5cNMVz"
       Date:
-      - Tue, 26 Apr 2022 05:03:28 GMT
+      - Wed, 27 Apr 2022 06:19:34 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -18112,16 +18240,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:28 GMT
+      - Wed, 27 Apr 2022 06:19:34 GMT
       Set-Cookie:
-      - AWSALB=XZl8a9SpeAobHOQdHblKVkP1qc/TfS47vVMuo3LJptxU3Jv5lqw3vu3HST31+7wWbxUoJkS109j9OJ6PVtmciSkD2fVzAy1MqQJzwy0sAp8NQjTuf5hWGEfXC1Gq;
-        Expires=Tue, 03 May 2022 05:03:28 GMT; Path=/
-      - AWSALBCORS=XZl8a9SpeAobHOQdHblKVkP1qc/TfS47vVMuo3LJptxU3Jv5lqw3vu3HST31+7wWbxUoJkS109j9OJ6PVtmciSkD2fVzAy1MqQJzwy0sAp8NQjTuf5hWGEfXC1Gq;
-        Expires=Tue, 03 May 2022 05:03:28 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=cUYdv8V6qs5f3WKaQ4SYga3p3Mwl9HucdP3DsywYKqEGXwAx0JSl0br4fayiZgUAF4/uI7tAWgOJPKTHhwg0pv2mSsBRA3gEbeIiNl39ivG1t3nGD39q5FNPcrvH;
+        Expires=Wed, 04 May 2022 06:19:34 GMT; Path=/
+      - AWSALBCORS=cUYdv8V6qs5f3WKaQ4SYga3p3Mwl9HucdP3DsywYKqEGXwAx0JSl0br4fayiZgUAF4/uI7tAWgOJPKTHhwg0pv2mSsBRA3gEbeIiNl39ivG1t3nGD39q5FNPcrvH;
+        Expires=Wed, 04 May 2022 06:19:34 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3dfb88681d9d515107cf1ca31c5ebbf7
+      - NB7a43dad77d1f596ab777fae3f65d4996
       Pragma:
       - no-cache
       Cache-Control:
@@ -18151,11 +18279,187 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - e9c4xzGFwi2Av3T7nqZMoPzWylNi960NE9q60UuoawA9sz600C6ARg==
+      - S2Z0Xt6gVLwiKz-rptWSNj5e7s82Tgc-FgL1BO8jjBynEJ5ubuXHWA==
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "AccountMoid": "5ed10e437564612d3352cc2d",
+          "AdminEvacState": "disabled",
+          "AdminInbandInterfaceState": "disabled",
+          "AlarmSummary": {
+            "ClassId": "compute.AlarmSummary",
+            "Critical": 0,
+            "ObjectType": "compute.AlarmSummary",
+            "Warning": 1
+          },
+          "Ancestors": [],
+          "AvailableMemory": "",
+          "Chassis": "",
+          "ClassId": "network.ElementSummary",
+          "ConfModTs": "",
+          "ConfModTsBackup": "",
+          "CreateTime": "2021-09-23T20:25:07.335Z",
+          "DeviceMoId": "614ce29f6f72612d307f5ed4",
+          "Dn": "switch-FDO2441072Q",
+          "DomainGroupMoid": "5ed10e437564612d3352cc37",
+          "EthernetMode": "",
+          "EthernetSwitchingMode": "end-host",
+          "FaultSummary": 0,
+          "FcMode": "",
+          "FcSwitchingMode": "end-host",
+          "Firmware": "",
+          "InbandIpAddress": "0.0.0.0",
+          "InbandIpGateway": "0.0.0.0",
+          "InbandIpMask": "255.255.255.0",
+          "InbandVlan": 0,
+          "Ipv4Address": "",
+          "ManagementMode": "Intersight",
+          "ModTime": "2022-04-27T06:19:06.675Z",
+          "Model": "UCS-FI-6454",
+          "Moid": "614ce2a36176752d35a7edbd",
+          "Name": "LAB02D02F01 FI-A",
+          "NumEtherPorts": 54,
+          "NumEtherPortsConfigured": 6,
+          "NumEtherPortsLinkUp": 4,
+          "NumExpansionModules": 0,
+          "NumFcPorts": 0,
+          "NumFcPortsConfigured": 0,
+          "NumFcPortsLinkUp": 0,
+          "ObjectType": "network.ElementSummary",
+          "OperEvacState": "disabled",
+          "Operability": "online",
+          "OutOfBandIpAddress": "100.66.11.141",
+          "OutOfBandIpGateway": "100.66.11.129",
+          "OutOfBandIpMask": "255.255.255.192",
+          "OutOfBandIpv4Address": "",
+          "OutOfBandIpv4Gateway": "",
+          "OutOfBandIpv4Mask": "",
+          "OutOfBandIpv6Address": "",
+          "OutOfBandIpv6Gateway": "",
+          "OutOfBandIpv6Prefix": "",
+          "OutOfBandMac": "00:3A:9C:DA:93:C0",
+          "Owners": [
+            "5ed10e437564612d3352cc2d",
+            "614ce29f6f72612d307f5ed4"
+          ],
+          "PartNumber": "",
+          "PermissionResources": [
+            {
+              "ClassId": "mo.MoRef",
+              "Moid": "5ed10e456972652d30b39b49",
+              "ObjectType": "organization.Organization",
+              "link": "https://www.intersight.com/api/v1/organization/Organizations/5ed10e456972652d30b39b49"
+            },
+            {
+              "ClassId": "mo.MoRef",
+              "Moid": "614caf8f6972652d30d65a53",
+              "ObjectType": "organization.Organization",
+              "link": "https://www.intersight.com/api/v1/organization/Organizations/614caf8f6972652d30d65a53"
+            }
+          ],
+          "Presence": "",
+          "RegisteredDevice": {
+            "ClassId": "mo.MoRef",
+            "Moid": "614ce29f6f72612d307f5ed4",
+            "ObjectType": "asset.DeviceRegistration",
+            "link": "https://www.intersight.com/api/v1/asset/DeviceRegistrations/614ce29f6f72612d307f5ed4"
+          },
+          "Revision": "0",
+          "Rn": "",
+          "Serial": "FDO2441072Q",
+          "SharedScope": "",
+          "SourceObjectType": "network.Element",
+          "Status": "",
+          "SwitchId": "A",
+          "SwitchType": "FabricInterconnect",
+          "SystemUpTime": "",
+          "Tags": [],
+          "Thermal": "ok",
+          "TotalMemory": 64265,
+          "Vendor": "Cisco Systems, Inc.",
+          "Version": "9.3(5)I42(1f)"
+        }
+    http_version:
+  recorded_at: Wed, 27 Apr 2022 06:19:35 GMT
+- request:
+    method: get
+    uri: https://intersight.com/api/v1/equipment/SwitchCards/614ce25c4630312d416698e7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.1.3/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
+        host date digest",signature="MEQCIDA2SN2UqlBhUaOoWfRa4IL4FrNJoUhVxhEBy7v3cHE6AiBSQO/4SBjDcvBvoCLxeLPpCcaYhinVUgU9G8hsRKD5bw=="
+      Date:
+      - Wed, 27 Apr 2022 06:19:35 GMT
+      Digest:
+      - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 27 Apr 2022 06:19:35 GMT
+      Set-Cookie:
+      - AWSALB=6FeU0Pwo0p9LoHtzr6zOEvgcS7zMO/Kljjv60+6JQM7Un4cIACwxuEM6fS7U4R85ItmSArmuCmvfNLYEPNLtjuvyyvOeHFV8NuU/9aNPEM5mdnZSwnhnHGI1tETv;
+        Expires=Wed, 04 May 2022 06:19:35 GMT; Path=/
+      - AWSALBCORS=6FeU0Pwo0p9LoHtzr6zOEvgcS7zMO/Kljjv60+6JQM7Un4cIACwxuEM6fS7U4R85ItmSArmuCmvfNLYEPNLtjuvyyvOeHFV8NuU/9aNPEM5mdnZSwnhnHGI1tETv;
+        Expires=Wed, 04 May 2022 06:19:35 GMT; Path=/; SameSite=None; Secure
+      Server:
+      - nginx
+      X-Starship-Traceid:
+      - NBa8cdac6fade765f63c8c45cb2fdc5f63
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Security-Policy:
+      - 'base-uri ''self'' https://cdn.intersight.com/; child-src ''self'' https://www.intersight.com/
+        https://cdn.intersight.com/  https://cloudsso.cisco.com https://www.cisco.com/
+        https://id.cisco.com; default-src ''self'' https://cdn.intersight.com/; font-src
+        ''self'' data: https://cdn.intersight.com/; frame-ancestors ''self''; img-src
+        ''self'' data: https://cdn.intersight.com/; style-src ''self'' ''unsafe-inline''
+        https://cdn.intersight.com/; object-src ''none''; form-action ''self'' https://www.intersight.com/
+        https://cloudsso.cisco.com https://www.cisco.com/ https://id.cisco.com; script-src
+        ''self'' https://cdn.intersight.com/; sandbox allow-modals allow-scripts allow-same-origin
+        allow-popups allow-forms allow-downloads; connect-src ''self'' https://cdn.intersight.com/
+        https://status.intersight.com https://download.intersight.com/ wss://socket.intersight.com
+        wss://intersight.com; frame-src ''self'' blob: https://www.intersight.com/
+        https://cdn.intersight.com/  https://cloudsso.cisco.com https://www.cisco.com/
+        https://id.cisco.com;'
+      X-Xss-Protection:
+      - 1; mode=block;
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - ZAG50-C1
+      X-Amz-Cf-Id:
+      - oKxmq5ewP8N5oFrldM7S1bTRmCxtAH-HY6m636VlMbGY8JgnBQ7fFQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -18191,7 +18495,7 @@ http_interactions:
           "FcSwitchingMode": "end-host",
           "HwVersion": "",
           "InventoryDeviceInfo": null,
-          "ModTime": "2022-04-26T04:31:05.432Z",
+          "ModTime": "2022-04-27T06:19:06.133Z",
           "Model": "UCS-FI-6454",
           "Moid": "614ce25c4630312d416698e7",
           "Name": "",
@@ -18301,7 +18605,7 @@ http_interactions:
           "Vendor": "Cisco Systems, Inc."
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:28 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:35 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/port/Groups/614ce2a36176752d35a7ee2a
@@ -18317,9 +18621,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIAkgXzx7ZtP3BMAklCLqZ1u1wOf6ZEQuJv3IMvtgp+WBAiBh7tdTLj9L52ueEvjsOg5ZCuieJYXqwyFbvlPwsRstUw=="
+        host date digest",signature="MEYCIQD00o5CjkKzJGCKp+Je/yrJgOH0VqEqxp4b5crTBQ4HAQIhAPFZgQJ0EBhxllVnXwBYky1KDjmTmrcatb1j3jURT3q4"
       Date:
-      - Tue, 26 Apr 2022 05:03:28 GMT
+      - Wed, 27 Apr 2022 06:19:35 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -18332,16 +18636,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:29 GMT
+      - Wed, 27 Apr 2022 06:19:35 GMT
       Set-Cookie:
-      - AWSALB=80bnucDwREk57kYmMjCPgcbZAF0c5EXV8Rpo6w/CJunYVnOLnibPIgl6mDH5m01Xjw+EuRnIptWRERXO0AXkI9U7akid+KWPg4B8h5imhUwWeaRR/G4ya5Znf1ey;
-        Expires=Tue, 03 May 2022 05:03:29 GMT; Path=/
-      - AWSALBCORS=80bnucDwREk57kYmMjCPgcbZAF0c5EXV8Rpo6w/CJunYVnOLnibPIgl6mDH5m01Xjw+EuRnIptWRERXO0AXkI9U7akid+KWPg4B8h5imhUwWeaRR/G4ya5Znf1ey;
-        Expires=Tue, 03 May 2022 05:03:29 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=1/QcY3+esTFO3NbzCOVtOR/bWMcnb2Y5o2ekK+Pj1vvGEGKaSQEUrrXGjek4K3dbwGEzY0TL+h/nwuYU6KSZQpwyYv0x1YAqMsu5luAMDOCbOQ4bT1ifZRToYpwS;
+        Expires=Wed, 04 May 2022 06:19:35 GMT; Path=/
+      - AWSALBCORS=1/QcY3+esTFO3NbzCOVtOR/bWMcnb2Y5o2ekK+Pj1vvGEGKaSQEUrrXGjek4K3dbwGEzY0TL+h/nwuYU6KSZQpwyYv0x1YAqMsu5luAMDOCbOQ4bT1ifZRToYpwS;
+        Expires=Wed, 04 May 2022 06:19:35 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB9ea83059edc1b8e6e7e3dfdbdb57c891
+      - NB0414312c36216b6410168b4e7a83bd13
       Pragma:
       - no-cache
       Cache-Control:
@@ -18371,11 +18675,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Wk4GZoStWACdCpmwh1BAD-o8EHh1C4I0h-8XXBabA_w2RIbo4m6LmQ==
+      - kOO2jNrkFrdfZ2ms6_kpFEpiM4WVleOJywSiqyYjkFv5YsrUlbqRFw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -18775,7 +19079,7 @@ http_interactions:
           "Transport": "ether"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:29 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:35 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991d
@@ -18791,9 +19095,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIAQ/y9U2euqyfHg1TbWni0GP0Vnzp2ggw3gBMzEoNgzIAiEAyZlDWkt2EBJz6u8i65FAKvfIGsfmGCNyU/OjQ9YPiTs="
+        host date digest",signature="MEYCIQCTh7g5DzqNgru2MehaIYoKzIlYnaq67Y4YQX1cWanbKgIhANMBNbn2oohG44Gffw9Tf4WSoZ5IrdWUPFCHuDfGyzm/"
       Date:
-      - Tue, 26 Apr 2022 05:03:29 GMT
+      - Wed, 27 Apr 2022 06:19:35 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -18806,16 +19110,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:29 GMT
+      - Wed, 27 Apr 2022 06:19:35 GMT
       Set-Cookie:
-      - AWSALB=o8/9sPR/YIKM/Q4C3a72NYho91BA8sJF7jv0N88qWLupfgvkmbj6fv4VdZayV0DaBW+C28VkEIYgkxnRcpNZ3d7BZws+GOVYmYLUkAy3T3ZHNjUd7ylfQvd1JVG/;
-        Expires=Tue, 03 May 2022 05:03:29 GMT; Path=/
-      - AWSALBCORS=o8/9sPR/YIKM/Q4C3a72NYho91BA8sJF7jv0N88qWLupfgvkmbj6fv4VdZayV0DaBW+C28VkEIYgkxnRcpNZ3d7BZws+GOVYmYLUkAy3T3ZHNjUd7ylfQvd1JVG/;
-        Expires=Tue, 03 May 2022 05:03:29 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=OnQw8MuE7cPV5W+siBaVNyn9kHkmbNVN08xsC1aYBRSM+4xHJI1U5Dmm34VCnv210dGRQ6VKmJ9bqaZcr6MyHnnruAeFKKaQncCQu+FpQqf0HNPjOMmlFHx29Hqr;
+        Expires=Wed, 04 May 2022 06:19:35 GMT; Path=/
+      - AWSALBCORS=OnQw8MuE7cPV5W+siBaVNyn9kHkmbNVN08xsC1aYBRSM+4xHJI1U5Dmm34VCnv210dGRQ6VKmJ9bqaZcr6MyHnnruAeFKKaQncCQu+FpQqf0HNPjOMmlFHx29Hqr;
+        Expires=Wed, 04 May 2022 06:19:35 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6a1173afb9b961250d3eb3deba4ced48
+      - NB1811d14f5dcea533928c2dc153f5705f
       Pragma:
       - no-cache
       Cache-Control:
@@ -18845,11 +19149,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - S1jMkeSz3ts8-EtHvll5aJqR7-CFVdwE5capsHgmGDaKrpem4brVYg==
+      - ttIlhELRegHTy2Tm06C0G6f7QvEULnOspMw4kq6R35IAa8c8vOfCBw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -18896,7 +19200,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E5",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991d",
           "Name": "",
@@ -18955,7 +19259,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:29 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:36 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669906
@@ -18971,9 +19275,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCHJuS8VZKs7DDSWqiw6YjxiwfqDr96m73TxgWYamG1BQIhANpCvT/ZMF5Qia/UeEvci+KuVaJBjbT3bNahK44IEswY"
+        host date digest",signature="MEUCIQCrk6htxU11VjfGHS8LvVy8lX4FaLLtmK+j3XdPVqmN1gIgXnEnwb+2zd1ypFs3RBwb1A1cHkRMikWRg9Dt36PPO34="
       Date:
-      - Tue, 26 Apr 2022 05:03:29 GMT
+      - Wed, 27 Apr 2022 06:19:36 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -18986,16 +19290,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:29 GMT
+      - Wed, 27 Apr 2022 06:19:36 GMT
       Set-Cookie:
-      - AWSALB=UdZFq56D6W0AiwyQP3Xx5wqeAbnV3qWeQynAwSp6s3/CTMotZbD4B+rxpOyPaUxALK94Mwc6rBqqidAOA9apC75kOaglO7fh1+rmFRfZbPgfzpe06lL0bALoiUSi;
-        Expires=Tue, 03 May 2022 05:03:29 GMT; Path=/
-      - AWSALBCORS=UdZFq56D6W0AiwyQP3Xx5wqeAbnV3qWeQynAwSp6s3/CTMotZbD4B+rxpOyPaUxALK94Mwc6rBqqidAOA9apC75kOaglO7fh1+rmFRfZbPgfzpe06lL0bALoiUSi;
-        Expires=Tue, 03 May 2022 05:03:29 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=zMzSymENygx+5ZvIBWiuyywOHuiFc+SgdYSdJNrwadXlK0SyzaMACI0B4I9uF0JwWFELLj1iibZanyWySQfznIkTIAqOJRhA17P/xf8jNSxaBnYAEQqGNgghcqlf;
+        Expires=Wed, 04 May 2022 06:19:36 GMT; Path=/
+      - AWSALBCORS=zMzSymENygx+5ZvIBWiuyywOHuiFc+SgdYSdJNrwadXlK0SyzaMACI0B4I9uF0JwWFELLj1iibZanyWySQfznIkTIAqOJRhA17P/xf8jNSxaBnYAEQqGNgghcqlf;
+        Expires=Wed, 04 May 2022 06:19:36 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB572d7ec794794646807b650e0b835a9f
+      - NB96bb708c1d1a71016752e7339a6468d0
       Pragma:
       - no-cache
       Cache-Control:
@@ -19025,11 +19329,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - dd3B-dGrDiDQiGZDduVOIxc7NM3c5iKjYtD34YHn03GTLbuTBgBLww==
+      - 4UQ8MgE2rd7PSYy98DOJ0KY41_sVk2Km8eMhJZaEQM6eurymiT2eKw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -19076,7 +19380,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CE",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669906",
           "Name": "",
@@ -19135,7 +19439,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:29 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:36 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669916
@@ -19151,9 +19455,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIEdg8ze44FDdkDjljBM22HFsn04poNIiQ91SemxhvEW/AiEArmQ722/ygPGg2SGUPvu6BvobOhWpgxHXjiEozu/9W1I="
+        host date digest",signature="MEUCIQDAciDya4js328R6gClVngOIM6Lj5EPB5Xz7jncc+aGiwIgKk/TBQhT21CnTvcTC3LkIcnsD738wUQVP2ZBQrpzx4E="
       Date:
-      - Tue, 26 Apr 2022 05:03:29 GMT
+      - Wed, 27 Apr 2022 06:19:36 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -19166,16 +19470,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:29 GMT
+      - Wed, 27 Apr 2022 06:19:36 GMT
       Set-Cookie:
-      - AWSALB=1j4OEcJU7T1EH6L6030BK7v1f5Bqczvrkmc3dVloNcpzHGmwrnXoxjjm/+JkqzpyskybkkaaZnkr1JxzjSJLyYGdqvFfeJXRnFvwpg6tW+L0jRFf3TOr6hsEYMe0;
-        Expires=Tue, 03 May 2022 05:03:29 GMT; Path=/
-      - AWSALBCORS=1j4OEcJU7T1EH6L6030BK7v1f5Bqczvrkmc3dVloNcpzHGmwrnXoxjjm/+JkqzpyskybkkaaZnkr1JxzjSJLyYGdqvFfeJXRnFvwpg6tW+L0jRFf3TOr6hsEYMe0;
-        Expires=Tue, 03 May 2022 05:03:29 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=/Aqzr4VsNLi3WNwxtb/sxsHOcn6P0CmAs9c8lRar2ynMJ9gIoeVrvDnVSMXkKR8A6TGLLzVN3uCVbn228IV8jnF1cs6bCmy6QjhU9z1LPJ+AX2ZqGu39zOkglhUV;
+        Expires=Wed, 04 May 2022 06:19:36 GMT; Path=/
+      - AWSALBCORS=/Aqzr4VsNLi3WNwxtb/sxsHOcn6P0CmAs9c8lRar2ynMJ9gIoeVrvDnVSMXkKR8A6TGLLzVN3uCVbn228IV8jnF1cs6bCmy6QjhU9z1LPJ+AX2ZqGu39zOkglhUV;
+        Expires=Wed, 04 May 2022 06:19:36 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB629f07d0c3c8e62e4ef92b371674c6c9
+      - NBdd2bf00f401a53803b08058c2c173fc9
       Pragma:
       - no-cache
       Cache-Control:
@@ -19205,11 +19509,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - il0d-BoCVjkd1EeJ7bE-aJZR6GE-Fso5BRshM8QHh79ChghPSo4agw==
+      - hZ3WTmE6BSyDnCeyBFu9f7JzkwPvdsO2-keIy6J77Esd4p8dfUsluw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -19256,7 +19560,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DE",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669916",
           "Name": "",
@@ -19315,7 +19619,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:29 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:36 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669904
@@ -19331,9 +19635,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIB15YfaPP5yLlPpgSTmS6asdXWxebY2grHcjUGYKOxq4AiEA5VNqgV7Vd4Ry7vbb3/ketyDW6q1kkjlcK0Pj5KsDfPY="
+        host date digest",signature="MEUCICGOv3c3t5iPF0s+OyNxs9IDKR6H2waaoKJbbShmHhI3AiEAgLPi0PqQ/QIp/Jblkj3bVo/QrN95B6y6m3PreVDeRwU="
       Date:
-      - Tue, 26 Apr 2022 05:03:29 GMT
+      - Wed, 27 Apr 2022 06:19:36 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -19346,16 +19650,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:30 GMT
+      - Wed, 27 Apr 2022 06:19:36 GMT
       Set-Cookie:
-      - AWSALB=H/uU5mZOMEemhCg1NsgUKSOdKyCiWMo/ZObhlel4iY5Co/rX0+80skNYCHL2WaZ254JzUAwsWv75uW6L44fSosBLkpsFMQJZ38ul+CbcTzuIzQuiveqz4OB9o3kq;
-        Expires=Tue, 03 May 2022 05:03:30 GMT; Path=/
-      - AWSALBCORS=H/uU5mZOMEemhCg1NsgUKSOdKyCiWMo/ZObhlel4iY5Co/rX0+80skNYCHL2WaZ254JzUAwsWv75uW6L44fSosBLkpsFMQJZ38ul+CbcTzuIzQuiveqz4OB9o3kq;
-        Expires=Tue, 03 May 2022 05:03:30 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=W1Qc5hAZ8P32/djWmK5ZT/RcXiGBbo8MZkVNSNSTNyRoDL3Yk4zPqDp+l75ewqSf8ZxEFSJTYShIL40IYuhNJTTirPE1AU44JBirtI4fvdPksiyDFbDzGr+O0CFA;
+        Expires=Wed, 04 May 2022 06:19:36 GMT; Path=/
+      - AWSALBCORS=W1Qc5hAZ8P32/djWmK5ZT/RcXiGBbo8MZkVNSNSTNyRoDL3Yk4zPqDp+l75ewqSf8ZxEFSJTYShIL40IYuhNJTTirPE1AU44JBirtI4fvdPksiyDFbDzGr+O0CFA;
+        Expires=Wed, 04 May 2022 06:19:36 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd7ed9b9caf7832250379101e4760114b
+      - NB2f35e97f7e6708a66ea52bcd8682fed0
       Pragma:
       - no-cache
       Cache-Control:
@@ -19385,11 +19689,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Us38vwaJzXS-cPJ9YUZbZgvWXMxGYbcVGvKFzYlgEy-lLqOVHFzhFw==
+      - jGus5pG7YagbxDqmXhoRy5KMhDU40_yp9sLAUKokHEEEv8k4D-lJsg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -19436,7 +19740,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CC",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669904",
           "Name": "",
@@ -19495,7 +19799,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:30 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:36 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ea
@@ -19511,9 +19815,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDf++e+BIv56k9IZnVW/dBDNF2GXFame+LEXkMqgdM56AIhAKBtCMdxfu6QgBZ+eCjI4OslKCyWq2prQjqHAdgQXkqN"
+        host date digest",signature="MEYCIQClQ4yJ/CHVqhuKGKa6oH2bsIzZt3ZfEE2KdWJxQILfIgIhAOqjRdIv8FkCGTEDm7Vi37xUa7TIAi8EZizk792aFfFY"
       Date:
-      - Tue, 26 Apr 2022 05:03:30 GMT
+      - Wed, 27 Apr 2022 06:19:36 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -19526,16 +19830,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:30 GMT
+      - Wed, 27 Apr 2022 06:19:36 GMT
       Set-Cookie:
-      - AWSALB=SsLHqWTzfvOqxMelmEwAzXDW9J0wCl0LKkqmtYLgWDjpgbsNAWFWlWZf8TDWd8KMjCR54AAASw8hwFRDJHOYewFRCLc8shNijkuRyRXBJmD8dhM29cAZ7djPi6FY;
-        Expires=Tue, 03 May 2022 05:03:30 GMT; Path=/
-      - AWSALBCORS=SsLHqWTzfvOqxMelmEwAzXDW9J0wCl0LKkqmtYLgWDjpgbsNAWFWlWZf8TDWd8KMjCR54AAASw8hwFRDJHOYewFRCLc8shNijkuRyRXBJmD8dhM29cAZ7djPi6FY;
-        Expires=Tue, 03 May 2022 05:03:30 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=SEGyCfQzC+0MbEsnjlvvItii01Ux/GMZBvtCXe3qY+3PxaOdOovBiglvCjiMTM9JlddpCj4vAPIjcHn3rPZ93TtelS24NCbGiK1g4PL9biewkjN165746bd8Xqqs;
+        Expires=Wed, 04 May 2022 06:19:36 GMT; Path=/
+      - AWSALBCORS=SEGyCfQzC+0MbEsnjlvvItii01Ux/GMZBvtCXe3qY+3PxaOdOovBiglvCjiMTM9JlddpCj4vAPIjcHn3rPZ93TtelS24NCbGiK1g4PL9biewkjN165746bd8Xqqs;
+        Expires=Wed, 04 May 2022 06:19:36 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBff8fc2c6c6128439d381cf5c82a097cf
+      - NB629a758767329ded2e741f521832f5f3
       Pragma:
       - no-cache
       Cache-Control:
@@ -19565,11 +19869,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Te_e1d4RnnBhR_mfvdGfGYoIxzhxKcw3rUA2ho_IxivO2lZV4q906A==
+      - W2VkJWNEDiUBVfTqSgzIWJlYPv6r5BHHcqZl7JqtVhxqahdE601NqA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -19616,7 +19920,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E8",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ea",
           "Name": "",
@@ -19675,7 +19979,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:30 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:36 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698fa
@@ -19691,9 +19995,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIDsa6oZ85H0BWi58ri6Lud0C2/3aJBigJVufrMxdWOh+AiAnj7y6ow3bJnOytsAVu12srN1Nu5r6tMR3XvnC2Xwf4Q=="
+        host date digest",signature="MEQCIDPj8IqsYA3NP1zn3lvbAc9EDT2jtcQmBUSxXOHGWM03AiBg/ELvjHUwqaA9dBgacuBKxo9j6q9j61GEHm9HlGf0AA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:30 GMT
+      - Wed, 27 Apr 2022 06:19:36 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -19706,16 +20010,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:30 GMT
+      - Wed, 27 Apr 2022 06:19:37 GMT
       Set-Cookie:
-      - AWSALB=kYYEEoArB5kwOoQ9l5z/cYzq4I97H5OyHIDi4VG0EYF1ZiLHe4ewehwHcgNqSV+lefhx4KIsHptlxaqVZekZVFAWwz9TaJf/MsH4FiBwxbCnGxH3kMGEnC6TVxGT;
-        Expires=Tue, 03 May 2022 05:03:30 GMT; Path=/
-      - AWSALBCORS=kYYEEoArB5kwOoQ9l5z/cYzq4I97H5OyHIDi4VG0EYF1ZiLHe4ewehwHcgNqSV+lefhx4KIsHptlxaqVZekZVFAWwz9TaJf/MsH4FiBwxbCnGxH3kMGEnC6TVxGT;
-        Expires=Tue, 03 May 2022 05:03:30 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=fTFInXXfJVYblR78ijZIunKYmicrmquLCzfU6af2EAw9HeYtG9N5gI8gC9C+QHgrKhHEcEiAc61w04rfSV06s+fLt1u+wn0DmZosgzhgNliaw9Vsi5cyWJAgkZA5;
+        Expires=Wed, 04 May 2022 06:19:36 GMT; Path=/
+      - AWSALBCORS=fTFInXXfJVYblR78ijZIunKYmicrmquLCzfU6af2EAw9HeYtG9N5gI8gC9C+QHgrKhHEcEiAc61w04rfSV06s+fLt1u+wn0DmZosgzhgNliaw9Vsi5cyWJAgkZA5;
+        Expires=Wed, 04 May 2022 06:19:36 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBcf68b9d8da318ddc45ec4944f429d3a6
+      - NB51ccb928d3ef3abe382220a5c736c83e
       Pragma:
       - no-cache
       Cache-Control:
@@ -19745,11 +20049,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - M3pmf_oijCrtcLpOAfBUzRiYGTESeq8ZCPfiGZFygAWTao4rh5kl9A==
+      - _yQcaSMWJracLTDsCk8krxEvGAzE7vOToiBj_ZhkFboAq-n-NxvkPA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -19796,7 +20100,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F8",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "trunk",
           "Moid": "614ce25d4630312d416698fa",
           "Name": "",
@@ -19855,7 +20159,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:30 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:37 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669914
@@ -19871,9 +20175,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIFAyISh/NbRTDN0o2kH6C00M5sKCTcBP8HedHD8aeQkWAiAdzZ5Rz3iYDJj6/evarFLxVx0zGJiunOJmO7EfYTFThQ=="
+        host date digest",signature="MEQCIGl4CkRpnfw/ZKsZIiPV2HHJDInDiAGf9WhSdQkVkDYYAiB+C6UQqpyzcIMYFYhIzj9mb82xxuqBaoEDd6IkXTml/w=="
       Date:
-      - Tue, 26 Apr 2022 05:03:30 GMT
+      - Wed, 27 Apr 2022 06:19:37 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -19886,16 +20190,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:30 GMT
+      - Wed, 27 Apr 2022 06:19:37 GMT
       Set-Cookie:
-      - AWSALB=aSHOnNQpKbh8y9w2qlBm/2yWH0ELZnhfOjlW8TMWtBeR2Ru1OAaBMtP97GGZL8lAzCujEKlY5qiHGyG2aLaqPsfTahX7vQjW8o7gbM24/VFmI+PuTxduVMHdjmh/;
-        Expires=Tue, 03 May 2022 05:03:30 GMT; Path=/
-      - AWSALBCORS=aSHOnNQpKbh8y9w2qlBm/2yWH0ELZnhfOjlW8TMWtBeR2Ru1OAaBMtP97GGZL8lAzCujEKlY5qiHGyG2aLaqPsfTahX7vQjW8o7gbM24/VFmI+PuTxduVMHdjmh/;
-        Expires=Tue, 03 May 2022 05:03:30 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=Svm5YpzxXJlA65UWz6WctZHVYdMmrU/UsolSlwQgJnSfeOV3Dli8kgalSahTJpxxd7XQ8g9GIqsFuVv3RwJZ67ArNvi2llXVez6tnRwPMSTqTKXo/OVAPeymynjy;
+        Expires=Wed, 04 May 2022 06:19:37 GMT; Path=/
+      - AWSALBCORS=Svm5YpzxXJlA65UWz6WctZHVYdMmrU/UsolSlwQgJnSfeOV3Dli8kgalSahTJpxxd7XQ8g9GIqsFuVv3RwJZ67ArNvi2llXVez6tnRwPMSTqTKXo/OVAPeymynjy;
+        Expires=Wed, 04 May 2022 06:19:37 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB930075a888ba34b69927c14a350a4a58
+      - NB7854eaa67e6239bb82b8f72c71fa8629
       Pragma:
       - no-cache
       Cache-Control:
@@ -19925,11 +20229,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - S9zYDlTQap4c1kSVfElY572N0p6D4fBpvXm31JXH02mu5Np18jCUYQ==
+      - Sr83G-8fa_pnTS5mlEm3E49XrOaZ0vTNAHcHTRz3tqPDV6P7fhX1XA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -19976,7 +20280,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DC",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669914",
           "Name": "",
@@ -20035,7 +20339,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:30 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:37 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698fd
@@ -20051,9 +20355,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCPvCY2xvwk3yiv/dVnmoEIw3JtPLLwlA/+ed99+8gMYAIgBFOWIo2PCcg7bWK/FS1s9AWHCSBZU+jtRIVqWxjOMs0="
+        host date digest",signature="MEYCIQCOHEGWOXCAaR7qPHyFxbLTnKe6VlJm3C14noNIaYIB5wIhAOUgaMIaTM7trOvFoIqZTyLzRf5RMGFGQTzXW6OKjWiO"
       Date:
-      - Tue, 26 Apr 2022 05:03:30 GMT
+      - Wed, 27 Apr 2022 06:19:37 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -20066,16 +20370,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:31 GMT
+      - Wed, 27 Apr 2022 06:19:37 GMT
       Set-Cookie:
-      - AWSALB=QEBNrJoZ40dVka3icMpKNeEEqPjtUjlsivE6IJWnuv2EKOMftNrirZFZMkub+4PaNJr5TV8wXP/P2S/aPIZ0CtBM6do+A0xGGPYrn4YejV3ls1hT0Z9Lz4SbOUPI;
-        Expires=Tue, 03 May 2022 05:03:30 GMT; Path=/
-      - AWSALBCORS=QEBNrJoZ40dVka3icMpKNeEEqPjtUjlsivE6IJWnuv2EKOMftNrirZFZMkub+4PaNJr5TV8wXP/P2S/aPIZ0CtBM6do+A0xGGPYrn4YejV3ls1hT0Z9Lz4SbOUPI;
-        Expires=Tue, 03 May 2022 05:03:30 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=eoomx0UBPESCsT+/cqx+XRlDvcAAuScV3wPjvL/y5g+mXXMHySXe1PgDM1YUHHFXn+CYbDSrHveLC+CZQ/C3WiIdO03Z4xoM1eBhUDiVxZHM6UiFweSri0i6cI9V;
+        Expires=Wed, 04 May 2022 06:19:37 GMT; Path=/
+      - AWSALBCORS=eoomx0UBPESCsT+/cqx+XRlDvcAAuScV3wPjvL/y5g+mXXMHySXe1PgDM1YUHHFXn+CYbDSrHveLC+CZQ/C3WiIdO03Z4xoM1eBhUDiVxZHM6UiFweSri0i6cI9V;
+        Expires=Wed, 04 May 2022 06:19:37 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBed85a8c2e10aaff272bcc3763d8fdc2f
+      - NB55c48aa73a8a0393a35abf659890ebf1
       Pragma:
       - no-cache
       Cache-Control:
@@ -20105,11 +20409,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - xtbUsTlvY-1nG5pxkFBycCQQc3Thhcyktvmub-CiOY9Liwk1uaLWEg==
+      - W8mvunjoCCt-hvwrzK-IiCRlNB4lKKI8xXosYyfXIZsK224zgwtv6g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -20156,7 +20460,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:94:04",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698fd",
           "Name": "",
@@ -20215,7 +20519,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:31 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:37 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669905
@@ -20231,9 +20535,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIFj7X59pS6OHDvNqu+QZP7TsxoQKadNQaYyLE9bFTrKEAiEAn1q/ES1OduxGIEAiKAZ05NuYbTOcDZKY7P+GUnCYSAM="
+        host date digest",signature="MEQCIFtd8axCHvvd1P5BnUfYdvJgpxZaSp5+vlol0QHTAxmiAiAZTOfl5OExyBrpwvV4wWjC/Uo5v5rzGsVrhzKBXmC0hQ=="
       Date:
-      - Tue, 26 Apr 2022 05:03:31 GMT
+      - Wed, 27 Apr 2022 06:19:37 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -20246,16 +20550,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:31 GMT
+      - Wed, 27 Apr 2022 06:19:37 GMT
       Set-Cookie:
-      - AWSALB=Sw62wZTpZz1y4X5SSJq4nRQokJj3oysfdAktonMFJ+IKm5k7Oex0tCeZ0bvjaytrOJLum7jECZXaEjU3YhVE2nrTPIHHVOnckk6PxVxjeK4B+uApDsi7no5ver3r;
-        Expires=Tue, 03 May 2022 05:03:31 GMT; Path=/
-      - AWSALBCORS=Sw62wZTpZz1y4X5SSJq4nRQokJj3oysfdAktonMFJ+IKm5k7Oex0tCeZ0bvjaytrOJLum7jECZXaEjU3YhVE2nrTPIHHVOnckk6PxVxjeK4B+uApDsi7no5ver3r;
-        Expires=Tue, 03 May 2022 05:03:31 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=X6ugasBXvGcII02o4iCXZKYxzPPZhniqt++VxXEgaznoUzI5S36ZAahdx9e1NPlFk8pXXimB5UBYKAr5z7UHzeR2XCjA5Yc+Sci0TjRJP3DVfAB68eL5QUMyo3V7;
+        Expires=Wed, 04 May 2022 06:19:37 GMT; Path=/
+      - AWSALBCORS=X6ugasBXvGcII02o4iCXZKYxzPPZhniqt++VxXEgaznoUzI5S36ZAahdx9e1NPlFk8pXXimB5UBYKAr5z7UHzeR2XCjA5Yc+Sci0TjRJP3DVfAB68eL5QUMyo3V7;
+        Expires=Wed, 04 May 2022 06:19:37 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB19af81837037882718e1b9b02161a2c3
+      - NBb3fedea4cbf418209798c3b2710bad4a
       Pragma:
       - no-cache
       Cache-Control:
@@ -20285,11 +20589,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - mPUEhGyiVW7gc4JQkIayTWRi4Y_zP0WdHqD10P2ge9VZmzLEtCK38w==
+      - HGKI1sTz5NDIQk-gjk6V7mEFw7j3T5y28rgsdVfuKpPLbyGS-1zEvA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -20336,7 +20640,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CD",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669905",
           "Name": "",
@@ -20395,7 +20699,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:31 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:37 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669911
@@ -20411,9 +20715,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBmE8L1fkslS4G+Mo91YPNBSFWqgfAdDKR2exC+IvCaDAiEApBV4gZskQs67OlDx7LJrF8MhzA+1pflX76SUiegy8iw="
+        host date digest",signature="MEUCIBQMl5u7Wrkt5lBFJQcvOV8+xnFHeo8/+b59rIzzFq3eAiEA1uP6DT7l/POMxYwqonBDGYEAJjl7kMG5Y7UVwWImLOU="
       Date:
-      - Tue, 26 Apr 2022 05:03:31 GMT
+      - Wed, 27 Apr 2022 06:19:37 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -20426,16 +20730,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:31 GMT
+      - Wed, 27 Apr 2022 06:19:37 GMT
       Set-Cookie:
-      - AWSALB=s1BIiP5+y7q2CvE2KoWa1VaiHx7SE/oRLf2f4z/5gtOBAApsG5LeioK3eOgUi/HHT/925OsUmjAu3/HU2Hrl5uinnlC2qI/Pck3MZfQPbj/bsNoAMZVue9n5l4a0;
-        Expires=Tue, 03 May 2022 05:03:31 GMT; Path=/
-      - AWSALBCORS=s1BIiP5+y7q2CvE2KoWa1VaiHx7SE/oRLf2f4z/5gtOBAApsG5LeioK3eOgUi/HHT/925OsUmjAu3/HU2Hrl5uinnlC2qI/Pck3MZfQPbj/bsNoAMZVue9n5l4a0;
-        Expires=Tue, 03 May 2022 05:03:31 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=so8eWd/0iLTtAjaOmEdx7SnlwSnV4QbpnpUixUMRJT/EVHbPbqMbYvD9am4LMqA3WdFzdTm6GR9lS4tkDgKLA40Ec1vVX3lqDbGfIFAv8raY0xtRUCrNAtnuKyGg;
+        Expires=Wed, 04 May 2022 06:19:37 GMT; Path=/
+      - AWSALBCORS=so8eWd/0iLTtAjaOmEdx7SnlwSnV4QbpnpUixUMRJT/EVHbPbqMbYvD9am4LMqA3WdFzdTm6GR9lS4tkDgKLA40Ec1vVX3lqDbGfIFAv8raY0xtRUCrNAtnuKyGg;
+        Expires=Wed, 04 May 2022 06:19:37 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBcd0a279e366beb6e5b77eaaf4928b60b
+      - NB5c6833a3fad5dc197d7a8ac14f5d5c9c
       Pragma:
       - no-cache
       Cache-Control:
@@ -20465,11 +20769,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - kGP9SR4M1ENfRZOEXZieU3ysBuIryXFRe6cwhAYqjF4tV5I73wOK-w==
+      - MC9F_OxLw4-jmWYQgVCFAXwbyuwA9yc2J2B9V9hHSqzKONvgPGquBw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -20516,7 +20820,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D9",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.585Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25d4630312d41669911",
           "Name": "",
@@ -20575,7 +20879,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:31 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:38 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991a
@@ -20591,9 +20895,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCTOHkV4c/FNDsHmw7ohMl4zTBU6a9ccWvx6JsOIFuXKwIgPXmBYGH1JC10HzW/j8RL+JN84nPLOH27zKqthywgQDs="
+        host date digest",signature="MEUCIQDOa5/bfYRoACYJtKHabvqU1HRw2+7m+E0RnmmFmGfUeQIgE6uC9D33OkPs7RZKXCbrw0wmeArDohABniT5OFuHKFg="
       Date:
-      - Tue, 26 Apr 2022 05:03:31 GMT
+      - Wed, 27 Apr 2022 06:19:38 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -20606,16 +20910,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:31 GMT
+      - Wed, 27 Apr 2022 06:19:38 GMT
       Set-Cookie:
-      - AWSALB=nBY0JmaatBJWu5LpEBZ4vStH1tIF6bHxfVZBO4ejhPdgzCdrBZDpR26i5472yJ5lppiaqR3lE6r/XhtGIQahBD2Uj2Aasm7ShIaHYcz8OOHjnuWvEu0PisrlU8+O;
-        Expires=Tue, 03 May 2022 05:03:31 GMT; Path=/
-      - AWSALBCORS=nBY0JmaatBJWu5LpEBZ4vStH1tIF6bHxfVZBO4ejhPdgzCdrBZDpR26i5472yJ5lppiaqR3lE6r/XhtGIQahBD2Uj2Aasm7ShIaHYcz8OOHjnuWvEu0PisrlU8+O;
-        Expires=Tue, 03 May 2022 05:03:31 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=QgtfLrqxM1iafln+jxggFAOuAff7VNekEcQon47W0d8xYdckLLBUVcVxzuGnLkszdsk/Rj6K8+pWOdUYlyiv/2EGuBctT2kpKSCjnqoaBvvpgef88weNe3RpIUeO;
+        Expires=Wed, 04 May 2022 06:19:38 GMT; Path=/
+      - AWSALBCORS=QgtfLrqxM1iafln+jxggFAOuAff7VNekEcQon47W0d8xYdckLLBUVcVxzuGnLkszdsk/Rj6K8+pWOdUYlyiv/2EGuBctT2kpKSCjnqoaBvvpgef88weNe3RpIUeO;
+        Expires=Wed, 04 May 2022 06:19:38 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB575dfed7383caa329a39d7fa94c9b7c8
+      - NB84cee7014010fc3b253fc012f99456b7
       Pragma:
       - no-cache
       Cache-Control:
@@ -20645,11 +20949,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - rN7wxrIoCetJ0KC3pmjAEJsLqLq8zhmy5bwHQF0eF7MAAVAiTF9_ZA==
+      - TeG7FAC0llQX5wb7i5I3ww2J6lgwa5CsOIY79ge2oabua9Ijl7xZ2w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -20696,7 +21000,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E2",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991a",
           "Name": "",
@@ -20755,7 +21059,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:31 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:38 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ec
@@ -20771,9 +21075,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIAU6F5+c8CjQ+bGkTy8KF8W+BanAT7WhwUPuNoo25TuXAiEA4e4vSIaF2fT1Lh1Lp8zhWggma58HqIaOCS87PtwD1vA="
+        host date digest",signature="MEQCIFrKiA5Lmg+YJ2Y5tRYfyBGuOIx21Qxz3+K4IYjO8kIXAiAo0FoRZELaPAHSpdtiZGLPKMo/jtF/XWL8RF2jPslxFg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:31 GMT
+      - Wed, 27 Apr 2022 06:19:38 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -20786,16 +21090,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:31 GMT
+      - Wed, 27 Apr 2022 06:19:38 GMT
       Set-Cookie:
-      - AWSALB=WsAbRGi7/NhyQ39uJhXFo+4PrlX5tnBczdaI1qIsZT7Lt+xLDgmshK1kiFvpkO/SaUtFIlCQXubkKaJI1yQBiuvqlpf6+SVy1mrgT7q8emuN55Dl14lE1Xgay37O;
-        Expires=Tue, 03 May 2022 05:03:31 GMT; Path=/
-      - AWSALBCORS=WsAbRGi7/NhyQ39uJhXFo+4PrlX5tnBczdaI1qIsZT7Lt+xLDgmshK1kiFvpkO/SaUtFIlCQXubkKaJI1yQBiuvqlpf6+SVy1mrgT7q8emuN55Dl14lE1Xgay37O;
-        Expires=Tue, 03 May 2022 05:03:31 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=0FfRPVSkNBYuhPG10jhj4ALrpDOKTqyu4JykZcyKsTzLNH49K9KwOEU2H8fT3chZn6rmcERP3DUG1V1s2FLm1Jotbk0EchC+q1fNESy1WX4XCwlid/TTmwlOCviO;
+        Expires=Wed, 04 May 2022 06:19:38 GMT; Path=/
+      - AWSALBCORS=0FfRPVSkNBYuhPG10jhj4ALrpDOKTqyu4JykZcyKsTzLNH49K9KwOEU2H8fT3chZn6rmcERP3DUG1V1s2FLm1Jotbk0EchC+q1fNESy1WX4XCwlid/TTmwlOCviO;
+        Expires=Wed, 04 May 2022 06:19:38 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBbc2358cb97ed4a0b34dc767429a1c11c
+      - NBb1cf27a2ab6ce389de2504442f0b16a4
       Pragma:
       - no-cache
       Cache-Control:
@@ -20825,11 +21129,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 3r6bF_bfa2y8hTd22TF27Q6CAPcr1MSXIVrcY_VHDd1Wt8Sm0gCKlw==
+      - xR5P9GJBzgP5GdKpG9Yl7-zLRFlji8k98cYEClNrWWfNKaxS-J70uw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -20876,7 +21180,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:EA",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ec",
           "Name": "",
@@ -20935,7 +21239,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:31 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:38 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f6
@@ -20951,9 +21255,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCvC4JO0mav2qVRQCK4cujoJlZ1RMcLvTa5a+MaKFTOngIgIvFOlSqfd5xhSDJDI7Ti2O1veGRAWqzcAzvg0lEzBzU="
+        host date digest",signature="MEQCIGEhyqTYcHZYQQv/MsLQbwI44WDYzqCh0htAkJP4waPyAiAc4AWfl1lLz+fJ0iHXwocq7eZ/q95a4q+aTQTMN0N1LA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:31 GMT
+      - Wed, 27 Apr 2022 06:19:38 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -20966,16 +21270,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:32 GMT
+      - Wed, 27 Apr 2022 06:19:38 GMT
       Set-Cookie:
-      - AWSALB=9pXEXGRk2POb90WI8mbsXKKHapRuKPRxcBCJ8+5jsXmExAMZYnX4m2Vxvl9xjpKYJaBe5LE996zYum/MAp9xhvd/u3uM2WIFomdRH4mTwBJH2HIijeWy4AC3aoi7;
-        Expires=Tue, 03 May 2022 05:03:32 GMT; Path=/
-      - AWSALBCORS=9pXEXGRk2POb90WI8mbsXKKHapRuKPRxcBCJ8+5jsXmExAMZYnX4m2Vxvl9xjpKYJaBe5LE996zYum/MAp9xhvd/u3uM2WIFomdRH4mTwBJH2HIijeWy4AC3aoi7;
-        Expires=Tue, 03 May 2022 05:03:32 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=XH5rZNPMBTZyZQs7QZ/BLmfrJ+teP/C7dGgkvPoIoWe9hYaDSBQSsIQOR66T1pdgZpdDNU1R9rhfEwTwljMwbR1z8AbHvix73Tc+IBW/Z+okP7ZZGyGy/H+YMwPk;
+        Expires=Wed, 04 May 2022 06:19:38 GMT; Path=/
+      - AWSALBCORS=XH5rZNPMBTZyZQs7QZ/BLmfrJ+teP/C7dGgkvPoIoWe9hYaDSBQSsIQOR66T1pdgZpdDNU1R9rhfEwTwljMwbR1z8AbHvix73Tc+IBW/Z+okP7ZZGyGy/H+YMwPk;
+        Expires=Wed, 04 May 2022 06:19:38 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6104d6390438031c892af9553d89378c
+      - NB75ceec47a37262e6726e5dcd755f33a4
       Pragma:
       - no-cache
       Cache-Control:
@@ -21005,11 +21309,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - AwwedFnFxjBcVTfCQbdosT6hQCoRdodv7jqgOCb1lKn8UUOrvAL5sQ==
+      - 9fIprDLKdgPv-XbRsPZqYZTSTIGrR8c6qTdth7laWZ_eOgIdkg-oeA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -21056,7 +21360,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F4",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f6",
           "Name": "",
@@ -21115,7 +21419,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:32 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:38 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f8
@@ -21131,9 +21435,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIEqyFibaSuV87FcKVhKHEdNg3BYvhwQx9IW7DK/0mDM2AiBi30/nQJCgaqCARXyqkl2gYS3pQvbfEFwghPFZysOfOA=="
+        host date digest",signature="MEQCIEUQZSHKqa/cpghtpwKFw70LsxThUtAHh16GA8AKPXfgAiBLZT9Bgi4XwXrJ6KkrFl0ywYczwNdiMtO0+VPNjU0TIQ=="
       Date:
-      - Tue, 26 Apr 2022 05:03:32 GMT
+      - Wed, 27 Apr 2022 06:19:38 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -21146,16 +21450,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:32 GMT
+      - Wed, 27 Apr 2022 06:19:38 GMT
       Set-Cookie:
-      - AWSALB=9JBwYSaWOFZrnnLrRCpGh/vwJINFhT8VIm7DvIOXqNo8QCb1vT51nmQ5NjlWtWMFz5FHqxoIeuIRD5BW8UyzWoN4/0oItt6ZNRZC17MO39o3VukxuCT2aDHoh1xJ;
-        Expires=Tue, 03 May 2022 05:03:32 GMT; Path=/
-      - AWSALBCORS=9JBwYSaWOFZrnnLrRCpGh/vwJINFhT8VIm7DvIOXqNo8QCb1vT51nmQ5NjlWtWMFz5FHqxoIeuIRD5BW8UyzWoN4/0oItt6ZNRZC17MO39o3VukxuCT2aDHoh1xJ;
-        Expires=Tue, 03 May 2022 05:03:32 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=RX1uq4d83BKsjNHAKEBk3n/zNn08qpYPA1BL9XmsPq7yKDDHlcIW/oHGOGu2QqHDJBwAgR8PbjIQCj3bcc0SbWajeJn7iC08VmaplC3Cb8MxAAyOAFApX+/L9jEe;
+        Expires=Wed, 04 May 2022 06:19:38 GMT; Path=/
+      - AWSALBCORS=RX1uq4d83BKsjNHAKEBk3n/zNn08qpYPA1BL9XmsPq7yKDDHlcIW/oHGOGu2QqHDJBwAgR8PbjIQCj3bcc0SbWajeJn7iC08VmaplC3Cb8MxAAyOAFApX+/L9jEe;
+        Expires=Wed, 04 May 2022 06:19:38 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc95c1ae02c1f0469c2f24422feb73351
+      - NBdc3ab853d9c245bbd8108191e9d2056e
       Pragma:
       - no-cache
       Cache-Control:
@@ -21185,11 +21489,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 0R2jXXtXndV2wynePnsKLMcvtN6O4-Nm0JddC5LzKvBaLpbN5i5Riw==
+      - e-7cAYWE4a8RIL94qBZJDzcgObNtCf1CBYwfoA-UsYMRJv1wi5Yu7w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -21236,7 +21540,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F6",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f8",
           "Name": "",
@@ -21295,7 +21599,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:32 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:38 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991f
@@ -21311,9 +21615,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDgyTMAUMGBYhSt35d3Y7t1fq+OX0+5vfzHsDU23lAZzAIgTyADl41tDom/RgOaByyaTeA2zg6uz3B4GJ7wPiraDbg="
+        host date digest",signature="MEUCIBKiiIH/XMESVh16ZaHj+5s6VRhYEqIb1QDmJL80CE6DAiEAy7tKCFNFnkkIf4N6bYcnqgGIgHDwFmiU4OvS+mBCfmE="
       Date:
-      - Tue, 26 Apr 2022 05:03:32 GMT
+      - Wed, 27 Apr 2022 06:19:38 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -21326,16 +21630,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:32 GMT
+      - Wed, 27 Apr 2022 06:19:39 GMT
       Set-Cookie:
-      - AWSALB=RD0Ek3Q/V86IQliB8Q6/7Z76DErXFy3X9DSRvBN5AHM2d1Rm9qtMe84D0ckFrEGwdnzGT72gISLfZtXot81sgzg/kmpAZc4AZVLanCI0CTibKpkEvcot1jj/WYqC;
-        Expires=Tue, 03 May 2022 05:03:32 GMT; Path=/
-      - AWSALBCORS=RD0Ek3Q/V86IQliB8Q6/7Z76DErXFy3X9DSRvBN5AHM2d1Rm9qtMe84D0ckFrEGwdnzGT72gISLfZtXot81sgzg/kmpAZc4AZVLanCI0CTibKpkEvcot1jj/WYqC;
-        Expires=Tue, 03 May 2022 05:03:32 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=tcsRP4eVNkl2m8G2Y+vgDCRE9HIAVyaCSAGbaSWOnGqo+986AnWd5k/0C/miPdwIQpWlcUR2lWoaqAkpnI/JPSKCR2e12Zj+o/JlZcFygLN7QTto/a2Yqjsn+J3e;
+        Expires=Wed, 04 May 2022 06:19:39 GMT; Path=/
+      - AWSALBCORS=tcsRP4eVNkl2m8G2Y+vgDCRE9HIAVyaCSAGbaSWOnGqo+986AnWd5k/0C/miPdwIQpWlcUR2lWoaqAkpnI/JPSKCR2e12Zj+o/JlZcFygLN7QTto/a2Yqjsn+J3e;
+        Expires=Wed, 04 May 2022 06:19:39 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0bf3b45bd9980289cc08720ddcc34bb7
+      - NBf0b17e604a8931f4076b476d37a9111b
       Pragma:
       - no-cache
       Cache-Control:
@@ -21365,11 +21669,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - tf15MuB38ZxUYccwu3SAa-1YMTBX_a4bViEsZsO6-dGBcVfIUl3Ing==
+      - Ea8u2l8k2QRG39NLW2mB9tyTAIKrygaNnxAeVzQzL78xiNTT2d0ojg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -21416,7 +21720,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E7",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991f",
           "Name": "",
@@ -21475,7 +21779,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:32 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:39 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f1
@@ -21491,9 +21795,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDa2WED/V1t8PEt4p9Ezmk+V2LHVDHvgjL+F9c2joMvaQIge4qwN9De4GLryJijd/jRy46fe89Dscs0RhkFm/x4lPI="
+        host date digest",signature="MEUCIAU35+J+zNNC69b0/iCf0289GevE1uLslNWBoT4RKw3yAiEA13tA0vXXNNc9Ly2KlpbZ85rb08d2is/4QmthxQFOA3g="
       Date:
-      - Tue, 26 Apr 2022 05:03:32 GMT
+      - Wed, 27 Apr 2022 06:19:39 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -21506,16 +21810,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:32 GMT
+      - Wed, 27 Apr 2022 06:19:39 GMT
       Set-Cookie:
-      - AWSALB=//P0/Gc9Knqv2UbSi4hwbj/iRblVQnq0A8QS+WNnVbdWnWfgdbkDJQ+1zq7TW6l6PZXZ5kW66iSbk1f+1qp9KWAdG2D5FbWdS5znGrquhfj2ZP43g1D7XFpYXOCS;
-        Expires=Tue, 03 May 2022 05:03:32 GMT; Path=/
-      - AWSALBCORS=//P0/Gc9Knqv2UbSi4hwbj/iRblVQnq0A8QS+WNnVbdWnWfgdbkDJQ+1zq7TW6l6PZXZ5kW66iSbk1f+1qp9KWAdG2D5FbWdS5znGrquhfj2ZP43g1D7XFpYXOCS;
-        Expires=Tue, 03 May 2022 05:03:32 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=bNbZw/4uhwvCmXoqaBvbuoN+ibs8gjECSdIV5Bm1l8v+bJpwVc5YxhxGCeKB64S3CyFYBqkBNbI0PP6Kd5k99T6IHFCaxckwYz+X67pK9Qkg/RBRbYJw9vYC4DO+;
+        Expires=Wed, 04 May 2022 06:19:39 GMT; Path=/
+      - AWSALBCORS=bNbZw/4uhwvCmXoqaBvbuoN+ibs8gjECSdIV5Bm1l8v+bJpwVc5YxhxGCeKB64S3CyFYBqkBNbI0PP6Kd5k99T6IHFCaxckwYz+X67pK9Qkg/RBRbYJw9vYC4DO+;
+        Expires=Wed, 04 May 2022 06:19:39 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb5f67d5a2cef4b9e12437e8f10b8a44a
+      - NB0d9726368ed80b6c5bffa57f0583c478
       Pragma:
       - no-cache
       Cache-Control:
@@ -21545,11 +21849,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - LZv7YAjzBtboc_u8kkeJDwmFU-1ou-PbR-A4SA9q2oGBP7ByXj00ow==
+      - n9VdSoj55OsqGymTmZaMOoVEh39EdMGBKvswZjYP2biPa145G0jBRw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -21596,7 +21900,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:EF",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f1",
           "Name": "",
@@ -21655,7 +21959,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:32 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:39 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ff
@@ -21671,9 +21975,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIDWJInX56O6UGk6oXtnP0HWjb89y67PiiY7UB2wT+1HGAiEAsdF+5yk+G0XWQTCUFuc3Re5zbIiXRZAldK5mveLTXGw="
+        host date digest",signature="MEYCIQCsf18NIDQkU554nnzuOluzei1QK5NAL+60QgqQVmw9tAIhAIhI0mcl9QwMvU5Fw2MNW+b/o+PdJ9Bei3+3vXL3YI24"
       Date:
-      - Tue, 26 Apr 2022 05:03:32 GMT
+      - Wed, 27 Apr 2022 06:19:39 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -21686,16 +21990,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:32 GMT
+      - Wed, 27 Apr 2022 06:19:39 GMT
       Set-Cookie:
-      - AWSALB=JcdcywlJ+RTg06hIUt+oqkPv14eMFnnjEBvXJHGfLu9nrbmlwPg2GjcGVdKng/fU/Y0es0Xmcz12Wx/zgthLPHLZJwRPeYEeUJG9eRE3xItMwMqHoj847M0NMRfD;
-        Expires=Tue, 03 May 2022 05:03:32 GMT; Path=/
-      - AWSALBCORS=JcdcywlJ+RTg06hIUt+oqkPv14eMFnnjEBvXJHGfLu9nrbmlwPg2GjcGVdKng/fU/Y0es0Xmcz12Wx/zgthLPHLZJwRPeYEeUJG9eRE3xItMwMqHoj847M0NMRfD;
-        Expires=Tue, 03 May 2022 05:03:32 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=9ZUqI4w0o/bUg8QpCtTXhVx6gmMPDGYF5TJu44S9a2M1Y9uE55lb74kKUfptciqJOc0MxLhvLxpppI1169krvfz7IpPJycibo79d6h2lqIOWjmXN3gLDUwzHFSjS;
+        Expires=Wed, 04 May 2022 06:19:39 GMT; Path=/
+      - AWSALBCORS=9ZUqI4w0o/bUg8QpCtTXhVx6gmMPDGYF5TJu44S9a2M1Y9uE55lb74kKUfptciqJOc0MxLhvLxpppI1169krvfz7IpPJycibo79d6h2lqIOWjmXN3gLDUwzHFSjS;
+        Expires=Wed, 04 May 2022 06:19:39 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc38621d839a000c652ba9343e175440c
+      - NB73de47c672ce77bf91a7cb68cfd1c2a7
       Pragma:
       - no-cache
       Cache-Control:
@@ -21725,11 +22029,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - yik8OkLwQx65y4kUU_dTddInreOcQjdgTEjzbFVx-Ljr-9ED2NZ1rw==
+      - "-1p9XbPB2hpUZzTg0a8IgrmPiQxeB4uz7nPQxh1nkjEOGilN4JtCng=="
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -21776,7 +22080,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:94:0C",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ff",
           "Name": "",
@@ -21835,7 +22139,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:32 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:39 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991c
@@ -21851,9 +22155,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIH55cYpNkEcOXTBlXZubwB5gFNdbMvXzfPv0A+jxBrGNAiEApRqk2pjoFRO9UtqG0Gpco1729k8YXJQaUAwnuT1rdAM="
+        host date digest",signature="MEQCICcAuS4t7l/fO84IIs8vb0vn8YxmRDtY38QcNwvAYZWVAiBnZt95k6XX/okWEpwq0ou2N6fU6HI5JEX8FMszO9Z/oQ=="
       Date:
-      - Tue, 26 Apr 2022 05:03:32 GMT
+      - Wed, 27 Apr 2022 06:19:39 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -21866,16 +22170,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:33 GMT
+      - Wed, 27 Apr 2022 06:19:39 GMT
       Set-Cookie:
-      - AWSALB=e7Wl/FRZBLytjxGVV9FWcE4l1fJj9uDLxKPpNcvFSgwWSoVgdMIXJ5vYXRMEdh1/cNACW1oLe1ufqe4RZGigVhQNI6SdCAbzZTMgwcFS9k5NSQq3aM5JJkdjWz5F;
-        Expires=Tue, 03 May 2022 05:03:33 GMT; Path=/
-      - AWSALBCORS=e7Wl/FRZBLytjxGVV9FWcE4l1fJj9uDLxKPpNcvFSgwWSoVgdMIXJ5vYXRMEdh1/cNACW1oLe1ufqe4RZGigVhQNI6SdCAbzZTMgwcFS9k5NSQq3aM5JJkdjWz5F;
-        Expires=Tue, 03 May 2022 05:03:33 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=fvPQRdX9r9Hh+sZBLw6lSAeI+f3ygQhE6CcjMtRIyztV1IS7jkY9a+Q/xttGYe4nPy7awFaRASj8KCzNHqXuahZzypIQBuzv/xEZncQb1It0Gk1rKLi3okel4Agl;
+        Expires=Wed, 04 May 2022 06:19:39 GMT; Path=/
+      - AWSALBCORS=fvPQRdX9r9Hh+sZBLw6lSAeI+f3ygQhE6CcjMtRIyztV1IS7jkY9a+Q/xttGYe4nPy7awFaRASj8KCzNHqXuahZzypIQBuzv/xEZncQb1It0Gk1rKLi3okel4Agl;
+        Expires=Wed, 04 May 2022 06:19:39 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB5cda6afb559f4d3320c9509b230c157a
+      - NBc8a8b308e7e742aa197233dd3d0ef3ee
       Pragma:
       - no-cache
       Cache-Control:
@@ -21905,11 +22209,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - T1e3sZZSNF3PfzhyYN9Hxc5wtZsS8OM-weEQkQMQAkdHJTGeKJYUpA==
+      - _yX9sl7Qsncic6fPeNKJhlwCdeEL7I8D2Q0tPyD0Q0LEE5SYhA6PHw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -21956,7 +22260,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E4",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991c",
           "Name": "",
@@ -22015,7 +22319,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:33 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:39 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669909
@@ -22031,9 +22335,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQC6sCyVaoky4oq1g16Kt0IbV11yn2QnhBUyEWvz8oX+aAIhAKzZjV/KRAQp3/dM/prM/LrG9hx/NRAEMvwNslEu0SjX"
+        host date digest",signature="MEYCIQD8RJyY0J8VdTM9qQjZA+Wq6rKSLyRJcPYdpuatwSAsQwIhALkcRLmgxDc4mmXLzEAUDKeo3qmCMJlzLBu4fj72r3YO"
       Date:
-      - Tue, 26 Apr 2022 05:03:33 GMT
+      - Wed, 27 Apr 2022 06:19:39 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -22046,16 +22350,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:33 GMT
+      - Wed, 27 Apr 2022 06:19:40 GMT
       Set-Cookie:
-      - AWSALB=Z8dMtzhtCPNV7H0FxZ4yJOcBpHaiOx6hzF4L7+lhUxbt7jLW9ksUm8nCL6ebxAH8TQI/wjHANitmzHv/QHE0U0oLCBSgf+GfAx7fUvuqk/grbsAT3cuzWByjKp8A;
-        Expires=Tue, 03 May 2022 05:03:33 GMT; Path=/
-      - AWSALBCORS=Z8dMtzhtCPNV7H0FxZ4yJOcBpHaiOx6hzF4L7+lhUxbt7jLW9ksUm8nCL6ebxAH8TQI/wjHANitmzHv/QHE0U0oLCBSgf+GfAx7fUvuqk/grbsAT3cuzWByjKp8A;
-        Expires=Tue, 03 May 2022 05:03:33 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=5VGB5NeDjedffVj9MAYBysmaTabaEJkuNk0UnGqhnB9riW1Av+U3Kq6E4Y8GiVZ0ZOlGi1jQ/qMXktcw5xecDT5rDFFqPTYX0J/Sosn1DQFYugFf3SED1bv44YU4;
+        Expires=Wed, 04 May 2022 06:19:40 GMT; Path=/
+      - AWSALBCORS=5VGB5NeDjedffVj9MAYBysmaTabaEJkuNk0UnGqhnB9riW1Av+U3Kq6E4Y8GiVZ0ZOlGi1jQ/qMXktcw5xecDT5rDFFqPTYX0J/Sosn1DQFYugFf3SED1bv44YU4;
+        Expires=Wed, 04 May 2022 06:19:40 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBbbf240eedb538d97d264ab21f7898ef3
+      - NB9db554d7ed5948f7d372b9607e590e73
       Pragma:
       - no-cache
       Cache-Control:
@@ -22085,11 +22389,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - E-K2EQZMCIkP7J1TJ6cbM4Vpjvgm6b-WWxuLBQlQ7ywYQmvgv-A7xg==
+      - NymidKlxHtZ4z09oKNgNX68JAF1mZB5YZGx1338S6UOsaKxcd_ZQSQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -22136,7 +22440,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D1",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669909",
           "Name": "",
@@ -22195,7 +22499,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:33 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:40 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990e
@@ -22211,9 +22515,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBsksjYcxNOjSe+UvjXe0tlHBxKbttRkCXh+M0YNkpUiAiEAoe2Ld0QnJ+zeEvd3W2i8hXGwPfPXAIOwaCO/VaIlTfY="
+        host date digest",signature="MEUCIQDUK6zGRjYFxg+aDrqW1F0s7BP8No/oautHKUz+66Cq2AIgDT2hv5L9Xd3WYTPZ16Va1ICoKQMhk/dixCsbncGxKHo="
       Date:
-      - Tue, 26 Apr 2022 05:03:33 GMT
+      - Wed, 27 Apr 2022 06:19:40 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -22226,16 +22530,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:33 GMT
+      - Wed, 27 Apr 2022 06:19:40 GMT
       Set-Cookie:
-      - AWSALB=issaMYpSZXRK98y/0tDSs2LZB8IVvAiXGLgjwQNQmHywT8RUGAuIRfMMANRvqho6x7KK/M2Ko0FGsMHD2+8hlqg5fUbKSryXHLeDWrBnCDkYVssMVYuPCBRCacVO;
-        Expires=Tue, 03 May 2022 05:03:33 GMT; Path=/
-      - AWSALBCORS=issaMYpSZXRK98y/0tDSs2LZB8IVvAiXGLgjwQNQmHywT8RUGAuIRfMMANRvqho6x7KK/M2Ko0FGsMHD2+8hlqg5fUbKSryXHLeDWrBnCDkYVssMVYuPCBRCacVO;
-        Expires=Tue, 03 May 2022 05:03:33 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=M+63GHywjJAhrow6CFSNLu2/Z9SPDzKWeSymCl1vMqHGcz8NxSFkq1skgy9sGsggiVK34OxXN8AVRY7a0X1sPsIuf55aTrw872fEe+KeMGbgd3YubemlTFZPPJWC;
+        Expires=Wed, 04 May 2022 06:19:40 GMT; Path=/
+      - AWSALBCORS=M+63GHywjJAhrow6CFSNLu2/Z9SPDzKWeSymCl1vMqHGcz8NxSFkq1skgy9sGsggiVK34OxXN8AVRY7a0X1sPsIuf55aTrw872fEe+KeMGbgd3YubemlTFZPPJWC;
+        Expires=Wed, 04 May 2022 06:19:40 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB63c13711f96d94d212794bde2589ea0b
+      - NBcdd7874b84b8767d1550bc7b448a8bf3
       Pragma:
       - no-cache
       Cache-Control:
@@ -22265,11 +22569,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ut-qZbJ8fsDtr_Y-fsuNRdtidtTv4t1LylF07_vaCkMzMc16Epd0iQ==
+      - jMUW1bo6MQKspFVoR1uQRsaNoqIKLd9ob_ZxecKvBkbFofKOUW-6fQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -22316,7 +22620,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D6",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990e",
           "Name": "",
@@ -22375,7 +22679,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:33 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:40 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f4
@@ -22391,9 +22695,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDwpxh+jBMGYCCTiIk+JdYwo+L6tDd2rNIH+bS9MrXzzAIhAO9f3APTP01WquiFdVhjmJg6mUuThoGZa0ILpAMSlejq"
+        host date digest",signature="MEYCIQCZGrCRfdC0v4wSFGWLyTSY0bQzjo/RnNyQpJUTILVO7gIhAJyi+WSOqlEv4EfaspPTyR4PxVGRpnWt8rjjTdP6Me+j"
       Date:
-      - Tue, 26 Apr 2022 05:03:33 GMT
+      - Wed, 27 Apr 2022 06:19:40 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -22406,16 +22710,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:33 GMT
+      - Wed, 27 Apr 2022 06:19:40 GMT
       Set-Cookie:
-      - AWSALB=BOzL6H/Fr20iwc4L+m820tUd84J3rfebZYQQ9umjPYPxG49DE0MntvdzHMSaORA6uz/a3Go9i9+cf3nan2tMl31tHz3Nvk87mm5AWvhLH97MI4Wnx0sjdcCylRaE;
-        Expires=Tue, 03 May 2022 05:03:33 GMT; Path=/
-      - AWSALBCORS=BOzL6H/Fr20iwc4L+m820tUd84J3rfebZYQQ9umjPYPxG49DE0MntvdzHMSaORA6uz/a3Go9i9+cf3nan2tMl31tHz3Nvk87mm5AWvhLH97MI4Wnx0sjdcCylRaE;
-        Expires=Tue, 03 May 2022 05:03:33 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=2ZSTTKK9xLY0t/fhPmmVvYJkGopHHfrOtKJa3m4UwYwIIQEwVLzt1gC5Et7V5pkJL7Gq+EkNS8KiMOsCXAw0YQaL0ThuLe5gL9w+qUY2hCLBJ+KgpWm5mk7bg1D3;
+        Expires=Wed, 04 May 2022 06:19:40 GMT; Path=/
+      - AWSALBCORS=2ZSTTKK9xLY0t/fhPmmVvYJkGopHHfrOtKJa3m4UwYwIIQEwVLzt1gC5Et7V5pkJL7Gq+EkNS8KiMOsCXAw0YQaL0ThuLe5gL9w+qUY2hCLBJ+KgpWm5mk7bg1D3;
+        Expires=Wed, 04 May 2022 06:19:40 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB2a9890d78e83c49e3d72d43408419422
+      - NB15cbc4093842ad9cb6f85ff0022fc790
       Pragma:
       - no-cache
       Cache-Control:
@@ -22445,11 +22749,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - nyndn5BTyOSytRCQ5T4TEx_eJJcio16F6hKzFPyo4C5xa7DhW9yK-Q==
+      - zxln2_0ujTE_j9rfIejJ7O2OIvJWaH4VPIRmmnxquAy5b8xK9-Musg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -22496,7 +22800,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F2",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f4",
           "Name": "",
@@ -22555,7 +22859,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:33 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:40 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669917
@@ -22571,9 +22875,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIDMuWIlSCBrCnN2ChiXZ408cZXdslEczmhDHIyDFnGxWAiAZH4BmHOKPz05r1651dDZe449ZDzIW+EDW169MfyTZWg=="
+        host date digest",signature="MEUCIQCfAtc47tHJT17S/+C9WjnYuZ9wL+cgm98Lx26jKHGbiQIgKI/WJJbYppCIrcrw+OtEt2LyF7GK7pqk+n8hwcKabgg="
       Date:
-      - Tue, 26 Apr 2022 05:03:33 GMT
+      - Wed, 27 Apr 2022 06:19:40 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -22586,16 +22890,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:33 GMT
+      - Wed, 27 Apr 2022 06:19:40 GMT
       Set-Cookie:
-      - AWSALB=4cTTGsdYVbyhmLTsXSyVAImcCSARmr3WvyncdQBx8GzHgTqK/DDdu3K588FSUKwnqUJqhfavS+YtOoYO3NgJD6zNjdSPR2WAG8Iss2yWSTJzcFsuPx9i+ljzAIv5;
-        Expires=Tue, 03 May 2022 05:03:33 GMT; Path=/
-      - AWSALBCORS=4cTTGsdYVbyhmLTsXSyVAImcCSARmr3WvyncdQBx8GzHgTqK/DDdu3K588FSUKwnqUJqhfavS+YtOoYO3NgJD6zNjdSPR2WAG8Iss2yWSTJzcFsuPx9i+ljzAIv5;
-        Expires=Tue, 03 May 2022 05:03:33 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ON8YW4OQzMV9foHweCImyOP/oBgmD8VqNFkyeZ+q7MqAYYL8b+lBfDpeN4If9VsQ2W9eqEAJFMFKiU5h7eHpxxP9vYZ3++8M2irOYnn4yIJ57AzT+hqOL8VBPeuc;
+        Expires=Wed, 04 May 2022 06:19:40 GMT; Path=/
+      - AWSALBCORS=ON8YW4OQzMV9foHweCImyOP/oBgmD8VqNFkyeZ+q7MqAYYL8b+lBfDpeN4If9VsQ2W9eqEAJFMFKiU5h7eHpxxP9vYZ3++8M2irOYnn4yIJ57AzT+hqOL8VBPeuc;
+        Expires=Wed, 04 May 2022 06:19:40 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB868afc3dc1d12545ce6fcd7cdafb139d
+      - NBeb33217fbd7bbb060630a1aaf8cec0e4
       Pragma:
       - no-cache
       Cache-Control:
@@ -22625,11 +22929,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Fe155egq2ntbajyHfHpkM_X9Wm83B73-OUzeABW5ByTK81ga15izyA==
+      - HwvWjrf-ILFWIe8ci6P4iNHHkIdNdGfYK_OC6SPrNmp5LxeCA02c3w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -22676,7 +22980,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DF",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669917",
           "Name": "",
@@ -22735,7 +23039,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:33 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:40 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990a
@@ -22751,9 +23055,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBaWjpa392HYilGQ9LKzJEr5XoWf/m0TLqwR8KKQqNN5AiEAivfUoPQeClv01x1lEt90meCBzFfLH1m5wA1m74SftbM="
+        host date digest",signature="MEYCIQC50UvA1B/7caRd4bWgotK3vjct0HV52ofvkxQZPcVYTQIhAJri1SJBb2tjRhm5goKgC/5bWwObkuJNrviHumxizqU/"
       Date:
-      - Tue, 26 Apr 2022 05:03:33 GMT
+      - Wed, 27 Apr 2022 06:19:40 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -22766,16 +23070,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:34 GMT
+      - Wed, 27 Apr 2022 06:19:40 GMT
       Set-Cookie:
-      - AWSALB=+lQ1NoDm04I6zacqG14Pe377pCrY4qyG0wGfun6C3eSbyaji+mafski5RiizYUF733Q4ScknoEpLUMdUN5rpb+02aVnY8BfIe7f7Fev0J+v4I4hM7eLghv3AZys6;
-        Expires=Tue, 03 May 2022 05:03:34 GMT; Path=/
-      - AWSALBCORS=+lQ1NoDm04I6zacqG14Pe377pCrY4qyG0wGfun6C3eSbyaji+mafski5RiizYUF733Q4ScknoEpLUMdUN5rpb+02aVnY8BfIe7f7Fev0J+v4I4hM7eLghv3AZys6;
-        Expires=Tue, 03 May 2022 05:03:34 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=6GhU+Y5FbpyRunbi1ghMrZeVxMdDRJkqLyxuAFidimYNVY1ZZzrvp37mPMoDKOcQPlUEHxkd2RhsgMGsbF8FBszWj5ZVpJGfNn+9q08r+J+mqzs39t+4oHZc5ORR;
+        Expires=Wed, 04 May 2022 06:19:40 GMT; Path=/
+      - AWSALBCORS=6GhU+Y5FbpyRunbi1ghMrZeVxMdDRJkqLyxuAFidimYNVY1ZZzrvp37mPMoDKOcQPlUEHxkd2RhsgMGsbF8FBszWj5ZVpJGfNn+9q08r+J+mqzs39t+4oHZc5ORR;
+        Expires=Wed, 04 May 2022 06:19:40 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBbb8586c015a6315709134116dd020133
+      - NB80ac3fed92bb355c49d6d1a162ad9b0e
       Pragma:
       - no-cache
       Cache-Control:
@@ -22805,11 +23109,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 9I5Woe9lsqU_H2s5QwYVtoYLqLkrHeQbkto8UadJDMWJrSyusBorFg==
+      - L6l8ndRjxpamEDb-WP7mremp5YCJCGafblSZcDYFREvrUf61fXEFFg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -22856,7 +23160,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D2",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990a",
           "Name": "",
@@ -22915,7 +23219,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:34 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:40 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669918
@@ -22931,9 +23235,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIGluWX5dzpGI6+EWzZnBCtHGpocbekdhqnXdMmR5vLSFAiEAsCZqwTsDwGwR2FIya4br5hwLKGEKgEGCzP0ncwcd5rY="
+        host date digest",signature="MEYCIQD3U0bKdXq3pBMru9/AhgNKGrhwbsHJuVtpcSyvEgMiYQIhAJsekSc85ifvIjplKtjlG5V3Cca9YngthV+6UVWgtqTM"
       Date:
-      - Tue, 26 Apr 2022 05:03:34 GMT
+      - Wed, 27 Apr 2022 06:19:40 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -22946,16 +23250,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:34 GMT
+      - Wed, 27 Apr 2022 06:19:41 GMT
       Set-Cookie:
-      - AWSALB=eK8LfZdOaV/xhJBPLp+Ok/UfeY29I7flgEaooflZYQ40PDXBiecnc9Ih/X4CCuhFefnWDMfHE4Dx9AH3yNzvUvHjRgQtmAjlj7wuTRge2bH21lULXWHuiTwgV+xZ;
-        Expires=Tue, 03 May 2022 05:03:34 GMT; Path=/
-      - AWSALBCORS=eK8LfZdOaV/xhJBPLp+Ok/UfeY29I7flgEaooflZYQ40PDXBiecnc9Ih/X4CCuhFefnWDMfHE4Dx9AH3yNzvUvHjRgQtmAjlj7wuTRge2bH21lULXWHuiTwgV+xZ;
-        Expires=Tue, 03 May 2022 05:03:34 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=RoFhIKU7QTRROYa2BvTiSToTS1jfgwdRYl7prYErhlIU99Fao8L7PzM618hd6d5hjPGeWGwKAgXXVzAX8xAkWC/mppuH1Wzdrf0L87pHPvf/D1kd5yin2KULTehR;
+        Expires=Wed, 04 May 2022 06:19:41 GMT; Path=/
+      - AWSALBCORS=RoFhIKU7QTRROYa2BvTiSToTS1jfgwdRYl7prYErhlIU99Fao8L7PzM618hd6d5hjPGeWGwKAgXXVzAX8xAkWC/mppuH1Wzdrf0L87pHPvf/D1kd5yin2KULTehR;
+        Expires=Wed, 04 May 2022 06:19:41 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBae9fa5660a2c1dfffbdafe5ea62de2b1
+      - NB3d45dfaeda2f76b2c16c1bee2e2373c5
       Pragma:
       - no-cache
       Cache-Control:
@@ -22985,11 +23289,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 0yLDrcl8k35dYP-p1YinJhItR4OkA3i3VNASR8pwn8ku2odgY1x1bg==
+      - LGqg0AlQoQLx1OiXS888zdFQEI9Gus4sUxbo3renNvMvJXVOt3RiQA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -23036,7 +23340,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E0",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669918",
           "Name": "",
@@ -23095,7 +23399,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:34 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:41 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991b
@@ -23111,9 +23415,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIAq6OkYBQroUgKzIB/DRd7z3A1JpgGX0yGZXeu6O/G0dAiAcKVyN/ln8M33mqiglIBqVxn5EL6WKF3EvUIkJskQgfw=="
+        host date digest",signature="MEUCIQD5DVSHEvv2M8hg6f9yb+IEWsw36kbC9nEY9KBVX6R5TQIgOZ9dxURpU++aZCwzx1m8vFDvyTI5uv+Sv3ZykenNCrg="
       Date:
-      - Tue, 26 Apr 2022 05:03:34 GMT
+      - Wed, 27 Apr 2022 06:19:41 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -23126,16 +23430,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:41 GMT
       Set-Cookie:
-      - AWSALB=VXklQs0RcjEX5nnPTtHecbGU6GN0MxNY+7w3PlPwJaSG8DVM2TaCuFyPhxiiXI6F8UVrWvHu++IGBLAV/s/SbBHTjzRkkaAFlcCIIoFWD1bi2zqOayySCqvQOiaS;
-        Expires=Tue, 03 May 2022 05:03:34 GMT; Path=/
-      - AWSALBCORS=VXklQs0RcjEX5nnPTtHecbGU6GN0MxNY+7w3PlPwJaSG8DVM2TaCuFyPhxiiXI6F8UVrWvHu++IGBLAV/s/SbBHTjzRkkaAFlcCIIoFWD1bi2zqOayySCqvQOiaS;
-        Expires=Tue, 03 May 2022 05:03:34 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=OOerrbaYSoH533+nDtUG2/p6x228cAfiw6tzbQMQ2DOBE0bIIraofKsQR1xoyEghbt3ESyVbK5je/ZucLGYLrcjdI4UsoQ9nPVBJ6H2x8p6tNf5KYimeJyn0A4L/;
+        Expires=Wed, 04 May 2022 06:19:41 GMT; Path=/
+      - AWSALBCORS=OOerrbaYSoH533+nDtUG2/p6x228cAfiw6tzbQMQ2DOBE0bIIraofKsQR1xoyEghbt3ESyVbK5je/ZucLGYLrcjdI4UsoQ9nPVBJ6H2x8p6tNf5KYimeJyn0A4L/;
+        Expires=Wed, 04 May 2022 06:19:41 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBbe2c99634fd2df85408fcf2f41aaeb35
+      - NB734f3b0664b74df25070017c08e52a93
       Pragma:
       - no-cache
       Cache-Control:
@@ -23165,11 +23469,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - qZjshlozIGr-t2eFTaIE-yqI7Au53wEA3F5WfHSZUrj9Uu9e0xJFiQ==
+      - _vy5JTjlj_HL-8r_3wNoKmwc8bKPuLThugW6MVDOE_mI8OS-yYFiIg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -23216,7 +23520,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E3",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991b",
           "Name": "",
@@ -23275,7 +23579,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:35 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:41 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f0
@@ -23291,9 +23595,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCID7D3zJIGlDWh2kfaRQYsZbqY168v/ra+0phKkq+p8uzAiBHPqW9nkXJduk01BtL5JQ2aevFSFyifGF8j+kYE+oLFg=="
+        host date digest",signature="MEUCIDuOzTD++qx6c9gI8w32C3Yoxd3yI2ENKMQuNLUs4OHLAiEA2HA072GwS7PHB4oEFEdxDBRH3iDF4mXkwDLZ1OWXLYw="
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:41 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -23306,16 +23610,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:41 GMT
       Set-Cookie:
-      - AWSALB=PMmgE8F+uuTru2oW0naLPd/LjwT2ojyCbwTiYh+IdlistWLWJar+JvM8E1iF3uZqVkpvL80eaa4gAi7X443gX+xiya3Bw2+XBPG2DAqSVFdScwP9P+Aqvw00XFpg;
-        Expires=Tue, 03 May 2022 05:03:35 GMT; Path=/
-      - AWSALBCORS=PMmgE8F+uuTru2oW0naLPd/LjwT2ojyCbwTiYh+IdlistWLWJar+JvM8E1iF3uZqVkpvL80eaa4gAi7X443gX+xiya3Bw2+XBPG2DAqSVFdScwP9P+Aqvw00XFpg;
-        Expires=Tue, 03 May 2022 05:03:35 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ZeFD4B39qKEJUeJtvR65pPPRxt9EqEl1pV8ooUph15SJdhho6hG+g2CA0H6SnmMLyHxTRRlFYqhZUvIW9ODpg2gx01+8Y1NcclugeMpKZ0rIbxRpNJyJ1BFWlrs4;
+        Expires=Wed, 04 May 2022 06:19:41 GMT; Path=/
+      - AWSALBCORS=ZeFD4B39qKEJUeJtvR65pPPRxt9EqEl1pV8ooUph15SJdhho6hG+g2CA0H6SnmMLyHxTRRlFYqhZUvIW9ODpg2gx01+8Y1NcclugeMpKZ0rIbxRpNJyJ1BFWlrs4;
+        Expires=Wed, 04 May 2022 06:19:41 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB538599a00e63875e3775142b112d5585
+      - NBc459a9b689e48b79e3163811227c43d2
       Pragma:
       - no-cache
       Cache-Control:
@@ -23345,11 +23649,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ZACZVhaCjRtw36t5EHShSB50jAFNEAPxNq6_TDCWyhKw1a54aDSkUg==
+      - UBiIbPwb50HP31Y5P2ImyeGYqd4DdklEH8kRqxeW44FhgcUS1_TK0w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -23396,7 +23700,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:EE",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f0",
           "Name": "",
@@ -23455,7 +23759,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:35 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:41 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f2
@@ -23471,9 +23775,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCwGWrATyq3lAeap9SAvji1ug9eAWJuOvjSl49fdGRtOwIhAOSYDX0BLLMGW2mvQ9bmTVqeYw7CDITypWysnTI5ik8A"
+        host date digest",signature="MEUCIC9TuBbf8Ojk34ElilNA00S/LBKVMZ5xH3Z78PWuJPRiAiEAvl6UgeeBJH/8D6Qfrdtki6XvQ//tmKFhnFYV2eSQjLc="
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:41 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -23486,16 +23790,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:41 GMT
       Set-Cookie:
-      - AWSALB=pZ2QgEOvrvl9F5BtYLDVDoETC0J+kUqmEXHEC841xd6GRO9BycLIVBw2Wt0wmj+63t9Fu/rNmxHxOSvHE5qbXh87ON6wFOBLeS54JuNlhWWUANnEN74PKsi7WHGl;
-        Expires=Tue, 03 May 2022 05:03:35 GMT; Path=/
-      - AWSALBCORS=pZ2QgEOvrvl9F5BtYLDVDoETC0J+kUqmEXHEC841xd6GRO9BycLIVBw2Wt0wmj+63t9Fu/rNmxHxOSvHE5qbXh87ON6wFOBLeS54JuNlhWWUANnEN74PKsi7WHGl;
-        Expires=Tue, 03 May 2022 05:03:35 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=XSL03ClbQNgvH5kmCRj4lazjp87JRs4THfwqpCq9WL+flW/+8GCackr11fZgBB2lTKpr+0kk8qiSx0WLtOcXbnPWQZiMtANA+ksLBAZBbl8i5khIlBgcGHxTVJQR;
+        Expires=Wed, 04 May 2022 06:19:41 GMT; Path=/
+      - AWSALBCORS=XSL03ClbQNgvH5kmCRj4lazjp87JRs4THfwqpCq9WL+flW/+8GCackr11fZgBB2lTKpr+0kk8qiSx0WLtOcXbnPWQZiMtANA+ksLBAZBbl8i5khIlBgcGHxTVJQR;
+        Expires=Wed, 04 May 2022 06:19:41 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb6008fba1f886e0af7c3308fddb97373
+      - NB0da0b0dde6db8ab379dece3a71240f5a
       Pragma:
       - no-cache
       Cache-Control:
@@ -23525,11 +23829,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - miqkT-AOcgfieX5UpzqRBT2VHa_DNDvza2GdIg5h3X28XsH5gj7CMA==
+      - r9PDFji4V4luBYPLTtcrauFvitoAcCl7t5Yg_qE4WPe5_SbPeI4Scg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -23576,7 +23880,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F0",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f2",
           "Name": "",
@@ -23635,7 +23939,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:35 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:41 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698fc
@@ -23651,9 +23955,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHDm7IofHXLQ5HLkbvymrniGunHRbDMsa2Hm/9Cb2jfEAiEAtmyef8pTOJ8jTUm6fYcrVoeh9OSSxNbo+TpGGtReYvo="
+        host date digest",signature="MEUCID9K+I+KpHnBA9oYWBaZrCzFyjBAAB00WDBcgHKN2WYpAiEAwdjha89rHzrLdDkC/lE6WVK2DAeUjd0N56Uym3/PnOM="
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:41 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -23666,16 +23970,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:42 GMT
       Set-Cookie:
-      - AWSALB=vun2leVAQxrTdXqMTwp++Za3DbF1uMvq7OKn2SXaCwnusZMDiqoxAcZ4x1xg/WLZMiapw6cjglNMxXO/bHisYL476cw7PYSzmnfVMu+NP8qt/nSGex16OUl8VaAJ;
-        Expires=Tue, 03 May 2022 05:03:35 GMT; Path=/
-      - AWSALBCORS=vun2leVAQxrTdXqMTwp++Za3DbF1uMvq7OKn2SXaCwnusZMDiqoxAcZ4x1xg/WLZMiapw6cjglNMxXO/bHisYL476cw7PYSzmnfVMu+NP8qt/nSGex16OUl8VaAJ;
-        Expires=Tue, 03 May 2022 05:03:35 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=RguYq/JZipVDiEw1bkkm4t+Ar+rHWA0D+DxV93ks/cVTkD1ZK3fAJrn8w12vosTySbfZtHs0Cy8sdEAnyoMj9KuBWbK0I/uxH8zEazXU3aX58v83oO0xn7dreXkB;
+        Expires=Wed, 04 May 2022 06:19:42 GMT; Path=/
+      - AWSALBCORS=RguYq/JZipVDiEw1bkkm4t+Ar+rHWA0D+DxV93ks/cVTkD1ZK3fAJrn8w12vosTySbfZtHs0Cy8sdEAnyoMj9KuBWbK0I/uxH8zEazXU3aX58v83oO0xn7dreXkB;
+        Expires=Wed, 04 May 2022 06:19:42 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc604bc18e97f5ac2601fdc42dd891a96
+      - NBe1721a9704e7e7fafd5df80c3702ef88
       Pragma:
       - no-cache
       Cache-Control:
@@ -23705,11 +24009,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 9CpyJHDMDOviZKjJC3t_riapoIki2ejZAdRjLer3KzBDuZaaqmsSeg==
+      - caE1RKFLSKONDBSMZJ1p0RpQOtfutRiGI50MsALXcEsb_TC4pUvIqw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -23756,7 +24060,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:94:00",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698fc",
           "Name": "",
@@ -23815,7 +24119,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:35 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:42 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990b
@@ -23831,9 +24135,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCICGHCZscd/LOFOCHqPqBCBWj0eeMkn1I8ueepCTO+Hu5AiAh7bFXX6UKoS0ApPvCDqmL9Y5sclEA4bf/LOTqHusMQQ=="
+        host date digest",signature="MEUCIE1Fqgl+Kvyvidy7oHTYqJxxk3oyXT0zxOSf5r98QbhQAiEAtWWSNMsdcDSl4jAfJo6Rb6+sIMGEwnVtYNl891theC4="
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:42 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -23846,16 +24150,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:42 GMT
       Set-Cookie:
-      - AWSALB=xUSyNGAXrPWc3Vm46B75kgpi+tT3yQk2XhNhPjcwYG8EuimGV4fL3Pg3U5zQgSQymknxftYH55QkjsqwH8RMMZJhChKvSBQJNMQtgh6A+2Itbl/8Y/g6/gw1K05D;
-        Expires=Tue, 03 May 2022 05:03:35 GMT; Path=/
-      - AWSALBCORS=xUSyNGAXrPWc3Vm46B75kgpi+tT3yQk2XhNhPjcwYG8EuimGV4fL3Pg3U5zQgSQymknxftYH55QkjsqwH8RMMZJhChKvSBQJNMQtgh6A+2Itbl/8Y/g6/gw1K05D;
-        Expires=Tue, 03 May 2022 05:03:35 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=lzpiqVtMymiD4pcJxNfdWNl4EuW9u6qXJeTUaUl5ovDqhR30m0zcehZ1567T5b/m3QUJBuHGP7O0cJ9p5PhmXFhvZp+Smi8TNIRBf+Pmt5/2c924ARZSXEIJoKAy;
+        Expires=Wed, 04 May 2022 06:19:42 GMT; Path=/
+      - AWSALBCORS=lzpiqVtMymiD4pcJxNfdWNl4EuW9u6qXJeTUaUl5ovDqhR30m0zcehZ1567T5b/m3QUJBuHGP7O0cJ9p5PhmXFhvZp+Smi8TNIRBf+Pmt5/2c924ARZSXEIJoKAy;
+        Expires=Wed, 04 May 2022 06:19:42 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB13f410afda9437e32875c56ab76ffda5
+      - NB70c6c313890ef26f1f3c6702c7e7f826
       Pragma:
       - no-cache
       Cache-Control:
@@ -23885,11 +24189,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - EKRz9aMJSpRko2HzOPvTLoJXOL-DiwS9fTEP_XXvKOOznwN_OfKkHA==
+      - tIfQ5-rki65HvK8ZTFK0NFbZV3p2KMoCOntTv4Lk_O6T2F1b0dKsjw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -23936,7 +24240,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D3",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990b",
           "Name": "",
@@ -23995,7 +24299,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:35 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:42 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990f
@@ -24011,9 +24315,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDy9YzAPTXtIIN3MN1zG9nX8h8O819Bsy4h6Kvm8VhAQgIgI6fLnwbvpGludT9Z5O9TMQXWmJVa/G5nQPX5w7hnkNY="
+        host date digest",signature="MEQCIG0xQSxYK+YtrnODOoatWURP9IHefXAzagpVUYBmp4UTAiBxubUzQTXgwMH3yNeGSewGa9osGz/R4YFWdnlCzTk/gw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:42 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -24026,16 +24330,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:42 GMT
       Set-Cookie:
-      - AWSALB=ad/VaEgRzxcLY2bCKDD6isFEW0Q+iFS/DJG7hPSFGqaUy/GXB59pOESFVdSPxQarm/Ldr6GkQ/Z6cHk8Cq6s9Wu8yorrwQZhBIs3pKBEkktv+pZ9O6jK8wVql1x/;
-        Expires=Tue, 03 May 2022 05:03:35 GMT; Path=/
-      - AWSALBCORS=ad/VaEgRzxcLY2bCKDD6isFEW0Q+iFS/DJG7hPSFGqaUy/GXB59pOESFVdSPxQarm/Ldr6GkQ/Z6cHk8Cq6s9Wu8yorrwQZhBIs3pKBEkktv+pZ9O6jK8wVql1x/;
-        Expires=Tue, 03 May 2022 05:03:35 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=GIXZLWY8jaSLI0PNhYNRg3CvhAm6q16iitKmHqRJZ7/XjkdV33zK/8PlRCBX56YVz3lq+rVmAxWlqwR30H4f6PP3TQIwyjiGBclW5lIfud2KjKh9IHKvW5GXh07H;
+        Expires=Wed, 04 May 2022 06:19:42 GMT; Path=/
+      - AWSALBCORS=GIXZLWY8jaSLI0PNhYNRg3CvhAm6q16iitKmHqRJZ7/XjkdV33zK/8PlRCBX56YVz3lq+rVmAxWlqwR30H4f6PP3TQIwyjiGBclW5lIfud2KjKh9IHKvW5GXh07H;
+        Expires=Wed, 04 May 2022 06:19:42 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb4bd890fe09bd9b98ef4433ae6a6997a
+      - NB11dcd23b2346a771ac58056cebc9ed84
       Pragma:
       - no-cache
       Cache-Control:
@@ -24065,11 +24369,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - JatdqQ5TeSc3ZC0nl95KNnTjkMO4TaAU3QnYJyD960v10kChQUqIYg==
+      - gNSgoUTJTzxqLet83qF8srQ8hkRD62biAa3F2I4xDbIiJvaPyt99aQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -24116,7 +24420,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D7",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990f",
           "Name": "",
@@ -24175,7 +24479,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:35 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:42 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669915
@@ -24191,9 +24495,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHEwxmEVz6uv2NJjHZAg7TNSLjUKKxM/rOZY7S+M2jyyAiEA7h1MAa76lqG0uAY1JYO3asIJE23lNbnDbFSHAK9m98w="
+        host date digest",signature="MEQCIFSLzKnU9xwovElJd9K2LS/O/VbJydOR+AHkl7KM10PkAiAScaFYMZb/z1IjZj5HSstsN3NVonOR7Cr/dmfE9dxN3Q=="
       Date:
-      - Tue, 26 Apr 2022 05:03:35 GMT
+      - Wed, 27 Apr 2022 06:19:42 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -24206,16 +24510,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:36 GMT
+      - Wed, 27 Apr 2022 06:19:42 GMT
       Set-Cookie:
-      - AWSALB=9Pw77ag+IDLqoOVJy83wbwkKTZ6SGBAdy/0SofjylUoMw47MtWfoHGfzrfLK/KXV26vEg4WwTxZsYmnvbwOGFPES85Qu0ySnpH58Ywo3fU6ZuAIEWfgpLGtfzMxR;
-        Expires=Tue, 03 May 2022 05:03:36 GMT; Path=/
-      - AWSALBCORS=9Pw77ag+IDLqoOVJy83wbwkKTZ6SGBAdy/0SofjylUoMw47MtWfoHGfzrfLK/KXV26vEg4WwTxZsYmnvbwOGFPES85Qu0ySnpH58Ywo3fU6ZuAIEWfgpLGtfzMxR;
-        Expires=Tue, 03 May 2022 05:03:36 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=4JOtU3PN1enrRDG26nzx5UZHD2y4hf6KvsX6hQCbVI+42lC1BETGFNwRWrwvxqunrmtU97w0x8x4uYYnX6SQFKZElMNG0vJEp4d6jscGaCnizjkDB3B5w8Hv+CC8;
+        Expires=Wed, 04 May 2022 06:19:42 GMT; Path=/
+      - AWSALBCORS=4JOtU3PN1enrRDG26nzx5UZHD2y4hf6KvsX6hQCbVI+42lC1BETGFNwRWrwvxqunrmtU97w0x8x4uYYnX6SQFKZElMNG0vJEp4d6jscGaCnizjkDB3B5w8Hv+CC8;
+        Expires=Wed, 04 May 2022 06:19:42 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB422b4fd1886ca558c209d7cc762ba5e9
+      - NBa163934473a5e86e9c63d73808342ff7
       Pragma:
       - no-cache
       Cache-Control:
@@ -24245,11 +24549,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - pQ45nUJQ5xEDYTtg8cexyID77LibjnctBKRjhFCMSBbt7zowH94Ckg==
+      - skIIEMB4zUl36a_DdFOtbeEBmHW-dEI7btYZ-dKcDys5yNYCPHi4Pg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -24296,7 +24600,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DD",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669915",
           "Name": "",
@@ -24355,7 +24659,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:36 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:42 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f3
@@ -24371,9 +24675,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCTdG8m5ksTKX5SW8u1xZuC1yzaoFYeDh+7tRNjfjZrdwIgGYZ3iJyrfzZ4lMg9Ai5NA5JKE4eJ2hPRk7HHQwmojLc="
+        host date digest",signature="MEUCIDjjCu3iJKtA1Ir82kpwllz1EP/AP5Y1cvcoEeRPbXlYAiEA+0A/0AwYZLYskYfEGnJeifmc76icrFzmTMytIKuofPA="
       Date:
-      - Tue, 26 Apr 2022 05:03:36 GMT
+      - Wed, 27 Apr 2022 06:19:42 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -24386,16 +24690,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:36 GMT
+      - Wed, 27 Apr 2022 06:19:42 GMT
       Set-Cookie:
-      - AWSALB=z+T+Jx/3ZbiIKIMeFIaqJJbclg7XQr+wgaCPWnXoHZnAE9Sg/P2G4LiBj0h+OhOxSvRy49cq5HC+qKNjngD6pg+CjWESssDu0xvlDLEW74qiSD13QyAh9MLbisWQ;
-        Expires=Tue, 03 May 2022 05:03:36 GMT; Path=/
-      - AWSALBCORS=z+T+Jx/3ZbiIKIMeFIaqJJbclg7XQr+wgaCPWnXoHZnAE9Sg/P2G4LiBj0h+OhOxSvRy49cq5HC+qKNjngD6pg+CjWESssDu0xvlDLEW74qiSD13QyAh9MLbisWQ;
-        Expires=Tue, 03 May 2022 05:03:36 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=G87A2PS8FujiBkT06RfktIFZMsxnGHVR6rTlPrSZwLFakxsBtmD58L4uoJ5N9we9T4T0P3dlh64UbhtBHkddxvPoloSXJyJMjkZC3OlSZSrxbjAjg+ZCRvgvc7il;
+        Expires=Wed, 04 May 2022 06:19:42 GMT; Path=/
+      - AWSALBCORS=G87A2PS8FujiBkT06RfktIFZMsxnGHVR6rTlPrSZwLFakxsBtmD58L4uoJ5N9we9T4T0P3dlh64UbhtBHkddxvPoloSXJyJMjkZC3OlSZSrxbjAjg+ZCRvgvc7il;
+        Expires=Wed, 04 May 2022 06:19:42 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb6c18c6e468fa50dc236f3c32e17a4a3
+      - NB68364a46a494dbe455f4c8e1ac4514ed
       Pragma:
       - no-cache
       Cache-Control:
@@ -24425,11 +24729,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - EdK7px3tK94un4DfYaRzylki3hfrQmASOCmLRuHW3uAi_iD49jyk7w==
+      - MwOQKwoQCrIvQoHiqVPDpPF8TO4yIJh_jd8tWA7IOLTUvb6m1l1hXg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -24476,7 +24780,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F1",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f3",
           "Name": "",
@@ -24535,7 +24839,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:36 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:43 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f7
@@ -24551,9 +24855,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIFFYvhwG/hTSsk1VHZkZD5YPfMUjw00fgqLoUxQ/9gn2AiEAhwroGhCN+rJ3ST/1KCfHtwJ5E18s9BSdqly3YjOeP8Q="
+        host date digest",signature="MEUCIQDjQD5W92PRJzJOcdtidxehLhxFlpd9kTDH0rlc0fcr8wIgLPZBd4HOIJKmdnGati7lyZiV7k8ag+i11YTO7purqlI="
       Date:
-      - Tue, 26 Apr 2022 05:03:36 GMT
+      - Wed, 27 Apr 2022 06:19:43 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -24566,16 +24870,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:36 GMT
+      - Wed, 27 Apr 2022 06:19:43 GMT
       Set-Cookie:
-      - AWSALB=73S1ysM0qvoCLmPvJn2CrsrvKWuH+Tew3fqY2cHRU+5aWHBjST0VBVrVGLS8H8wjvjxRNtcurLETABkocpmy3ti08RKBIGVXcZRB4wXqRsxBNnm6+2cz7lYflQh4;
-        Expires=Tue, 03 May 2022 05:03:36 GMT; Path=/
-      - AWSALBCORS=73S1ysM0qvoCLmPvJn2CrsrvKWuH+Tew3fqY2cHRU+5aWHBjST0VBVrVGLS8H8wjvjxRNtcurLETABkocpmy3ti08RKBIGVXcZRB4wXqRsxBNnm6+2cz7lYflQh4;
-        Expires=Tue, 03 May 2022 05:03:36 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=E11F2pXi/JRJNnWsNV4OfSsDm4DelCgppWKpOIpQmGR/xqcowHMdgIk19+o11JwNCTUe7+3QsJOZAWdXWb2XhkRe0gD1k+xV0/NQrv3ZPo/w/eSVlHdZheSwTkll;
+        Expires=Wed, 04 May 2022 06:19:43 GMT; Path=/
+      - AWSALBCORS=E11F2pXi/JRJNnWsNV4OfSsDm4DelCgppWKpOIpQmGR/xqcowHMdgIk19+o11JwNCTUe7+3QsJOZAWdXWb2XhkRe0gD1k+xV0/NQrv3ZPo/w/eSVlHdZheSwTkll;
+        Expires=Wed, 04 May 2022 06:19:43 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc06e08e2bea2c31a6ce6c86b1da15dcc
+      - NB09aaf91f73031d292bdd206a59d9f65e
       Pragma:
       - no-cache
       Cache-Control:
@@ -24605,11 +24909,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - nazImvJar7z9gZ6lWXK4DuCnFirVSFRZTTVYa6pTSf0cTqQMvDKlvw==
+      - gK7q54Z4_Ct1YcdDpszJfzWSzb_f0AZDgZChc0YXCXolfX99S4j6kg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -24656,7 +24960,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F5",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f7",
           "Name": "",
@@ -24715,7 +25019,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:36 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:43 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669907
@@ -24731,9 +25035,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDBrq5rDH6biuniLCD1z+kpOBGal2rlt8lqPbWWl49jSQIgcIcS6m6A+/ELOSSo+9XJafemr8P8dCmXfRWG0j6iSjw="
+        host date digest",signature="MEUCIQCqJ1tuzWR0drP+gzYon8uRoWrnLKcDpqsKUHP58ddYjAIgGBpgD27ss57K7fRbVmbkvjVJ+sVfQ5JP9aRB3zD+fb0="
       Date:
-      - Tue, 26 Apr 2022 05:03:36 GMT
+      - Wed, 27 Apr 2022 06:19:43 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -24746,16 +25050,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:36 GMT
+      - Wed, 27 Apr 2022 06:19:43 GMT
       Set-Cookie:
-      - AWSALB=8Nb8wo2szMNLU4HdXNqPBrp8qsfUqwZl7w8ayruXCWDAESY+F+6zLv92SuriXVWVsVfPLYPskHY3SRQ/WL2IkpvZxYJ9DzPMMl8ZN+enikSwHUu0z+hLqx3aUqJB;
-        Expires=Tue, 03 May 2022 05:03:36 GMT; Path=/
-      - AWSALBCORS=8Nb8wo2szMNLU4HdXNqPBrp8qsfUqwZl7w8ayruXCWDAESY+F+6zLv92SuriXVWVsVfPLYPskHY3SRQ/WL2IkpvZxYJ9DzPMMl8ZN+enikSwHUu0z+hLqx3aUqJB;
-        Expires=Tue, 03 May 2022 05:03:36 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=HAPalEuPxVK3dcUprM0msXB8+Rh0GXX68m50Xqx+lkFo4+IDcf5nd5zZmr4GvMTQcM55oRAYM7/1aWFsxyhO5DbTFZrNuso6gtaATW189y0jt375XqLsou9EgUUp;
+        Expires=Wed, 04 May 2022 06:19:43 GMT; Path=/
+      - AWSALBCORS=HAPalEuPxVK3dcUprM0msXB8+Rh0GXX68m50Xqx+lkFo4+IDcf5nd5zZmr4GvMTQcM55oRAYM7/1aWFsxyhO5DbTFZrNuso6gtaATW189y0jt375XqLsou9EgUUp;
+        Expires=Wed, 04 May 2022 06:19:43 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBadf82b00c014dcadfe2c8cbb50066ed4
+      - NB7ce9715d604e8851a8168126021d1d86
       Pragma:
       - no-cache
       Cache-Control:
@@ -24785,11 +25089,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - zo6VfcKAyzkm1YYXTaR1R0L4-o6hqZh5PrghCH6gavbt-kPqBjPkvw==
+      - upOCtlw81u_7YANd3f5uawbwXPiWMWqBeDaVh3HGnS2ksH1GdUjCGg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -24836,7 +25140,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CF",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669907",
           "Name": "",
@@ -24895,7 +25199,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:36 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:43 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698fb
@@ -24911,9 +25215,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIAy6MPI4lYW3fQ+eRfMWI+o6D9KQGOYuwQYd+iyJ4kHcAiEAn2YbP4BX8taV8w5VdKSI0Sf6/BrgCwsgBFM680KGpG8="
+        host date digest",signature="MEUCIQCYSj6sJ4WSgY15oo/x0VBzMj4noPNwCwfF3zTczRBdsAIgO40Z8h0+s18HHDTFkYqLgEw3ZHg/s2lA/gJ9QN8WniE="
       Date:
-      - Tue, 26 Apr 2022 05:03:36 GMT
+      - Wed, 27 Apr 2022 06:19:43 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -24926,16 +25230,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:37 GMT
+      - Wed, 27 Apr 2022 06:19:43 GMT
       Set-Cookie:
-      - AWSALB=8RqOC3gPTFgjGInQCOlffP7lx436rlykG8TXTSGBKOP7qHNbjIujuyTSwIIDfhwS9AKBIh37eJ/E/oQ+DJ2Dk6f8Qg5u1uMp4Wi8SMgwekAlLizk0Ics9enAvPVX;
-        Expires=Tue, 03 May 2022 05:03:37 GMT; Path=/
-      - AWSALBCORS=8RqOC3gPTFgjGInQCOlffP7lx436rlykG8TXTSGBKOP7qHNbjIujuyTSwIIDfhwS9AKBIh37eJ/E/oQ+DJ2Dk6f8Qg5u1uMp4Wi8SMgwekAlLizk0Ics9enAvPVX;
-        Expires=Tue, 03 May 2022 05:03:37 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=jY5T7PH0xXiWiViiHg81NSfhEJ2rpjB8q8G3XfyY/0Ns4+M6juUt8x7g1ZtYga3YGpB5rcRlW6KeBnbGGRsPKhK1YCw2yxiMi0mTwV8oDq0zjKIvgZLG9ldlkh7G;
+        Expires=Wed, 04 May 2022 06:19:43 GMT; Path=/
+      - AWSALBCORS=jY5T7PH0xXiWiViiHg81NSfhEJ2rpjB8q8G3XfyY/0Ns4+M6juUt8x7g1ZtYga3YGpB5rcRlW6KeBnbGGRsPKhK1YCw2yxiMi0mTwV8oDq0zjKIvgZLG9ldlkh7G;
+        Expires=Wed, 04 May 2022 06:19:43 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB434598589637647cb9b3a7e5a6be3e6e
+      - NB1a982f08f24061763b2e011b515de2f3
       Pragma:
       - no-cache
       Cache-Control:
@@ -24965,11 +25269,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - hkwQsbkeM5qoa-NtxN4PreZzc-6PcxbnwCkGG8h7YRqhjaNKvcFfrA==
+      - lve_FV7MtH9HlInnvyfpRoxf7cJEWjZHvxf0mvzbnu8Ahk7rc8kxoA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -25016,7 +25320,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:FC",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "trunk",
           "Moid": "614ce25d4630312d416698fb",
           "Name": "",
@@ -25075,7 +25379,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:37 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:43 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669908
@@ -25091,9 +25395,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDDt0J0Y6s7duwlTa+rSsOkdNc1r1b96NiQwQ6FVW6I6wIhAJQUvQcts7rxYeFMr52X1vO4tIRRmOILcRwBnmtYnHYr"
+        host date digest",signature="MEYCIQD8yASARtc3zXCVCtSfMYiP8U/DrvJjwDlL53tpCpuEUQIhAN29Ob49e2216CSZ94LBFijjlkCZMKS4Y0WTMJeW/tem"
       Date:
-      - Tue, 26 Apr 2022 05:03:37 GMT
+      - Wed, 27 Apr 2022 06:19:43 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -25106,16 +25410,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:37 GMT
+      - Wed, 27 Apr 2022 06:19:43 GMT
       Set-Cookie:
-      - AWSALB=fc6nt0ru3WnamLdlgYuZH+cB5XgafuQurkEdxjWNUiQTj+Q+AtmJ43xd6pUJnePYq1tAqo2W5UdzMcNXFvruDfnYoEsmEZX0afPbtCESVG4748nD0Yn12JeKSAWD;
-        Expires=Tue, 03 May 2022 05:03:37 GMT; Path=/
-      - AWSALBCORS=fc6nt0ru3WnamLdlgYuZH+cB5XgafuQurkEdxjWNUiQTj+Q+AtmJ43xd6pUJnePYq1tAqo2W5UdzMcNXFvruDfnYoEsmEZX0afPbtCESVG4748nD0Yn12JeKSAWD;
-        Expires=Tue, 03 May 2022 05:03:37 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=csWR+BRbUdQ2jFHGU2ud2CTX2yYyV0IVW0VTKLpqrMfxhJVJaO8IyIzgPTeWLzTA4wNpHG8vtQAWJCrdQzH3AmmDXiYyL0tfFfvLvsulZ8qyMdc8cRGNCEvGU2j/;
+        Expires=Wed, 04 May 2022 06:19:43 GMT; Path=/
+      - AWSALBCORS=csWR+BRbUdQ2jFHGU2ud2CTX2yYyV0IVW0VTKLpqrMfxhJVJaO8IyIzgPTeWLzTA4wNpHG8vtQAWJCrdQzH3AmmDXiYyL0tfFfvLvsulZ8qyMdc8cRGNCEvGU2j/;
+        Expires=Wed, 04 May 2022 06:19:43 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB280c0add61f328ab795736efbb90cc7c
+      - NB6ce77c680a508bc5e6bde0f9d93040ec
       Pragma:
       - no-cache
       Cache-Control:
@@ -25145,11 +25449,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - b6gGctI0BV0iPxO9t8N6gJ-pyJqIN_XqJkDhLQD025N75eQya9fBdw==
+      - rev7zGvo4f9pM7UmczEmsxpo8NBNanLZapfeYzkREaaXecArtaMnZA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -25196,7 +25500,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D0",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669908",
           "Name": "",
@@ -25255,7 +25559,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:37 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:43 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990d
@@ -25271,9 +25575,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIDFBJvgBolYbuolFr5/O3FgiZV6EJRn+EGCwQfmpGoh2AiEA4J9K8h4XSUCrlizrdP2nAn+PhKQjBmRtA1wvERHDJJs="
+        host date digest",signature="MEYCIQDvdPIbcqOrTRmfRUFTeeisTiArjrLGZstLUj9yPQW1XwIhAMCq3j5Ctr702uP/8M1zCgeIVKRZ0be6p0O71wVo+lin"
       Date:
-      - Tue, 26 Apr 2022 05:03:37 GMT
+      - Wed, 27 Apr 2022 06:19:43 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -25286,16 +25590,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:37 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Set-Cookie:
-      - AWSALB=Sve3sZExWKU2sJsxHC9V0gO+M1D83OIJvrCHOqWK586Dz8N8IYHtdLYtsL5xc8VOg8neLpLLnMFUcjsXZjcAILmKl5V13dJYCtMqPf43VPnSBfWT25Oc2SElgRP+;
-        Expires=Tue, 03 May 2022 05:03:37 GMT; Path=/
-      - AWSALBCORS=Sve3sZExWKU2sJsxHC9V0gO+M1D83OIJvrCHOqWK586Dz8N8IYHtdLYtsL5xc8VOg8neLpLLnMFUcjsXZjcAILmKl5V13dJYCtMqPf43VPnSBfWT25Oc2SElgRP+;
-        Expires=Tue, 03 May 2022 05:03:37 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=eMjG23fA1B7P8hHKw1Y+za88FzSYStMuoHydU2cWyeOr0nuf/rHVctxwtch1NA65Wn2ig4VI9v9Fw52Po7szZQe3ua059GtZoNIPYKQGFB36JQ7pjz4QWOqGscIy;
+        Expires=Wed, 04 May 2022 06:19:43 GMT; Path=/
+      - AWSALBCORS=eMjG23fA1B7P8hHKw1Y+za88FzSYStMuoHydU2cWyeOr0nuf/rHVctxwtch1NA65Wn2ig4VI9v9Fw52Po7szZQe3ua059GtZoNIPYKQGFB36JQ7pjz4QWOqGscIy;
+        Expires=Wed, 04 May 2022 06:19:43 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB87b8d79b8cb9f713e4212424583f840a
+      - NB01248468e11fa6dd5cd7e860a0d540d9
       Pragma:
       - no-cache
       Cache-Control:
@@ -25325,11 +25629,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ZMZV-qrK2ojFhaObv7KhcbO-KmIMehg-et0FtTmndUzVYrRILzmxxw==
+      - c83QReC3yZtT9kgASy5TnaKetkJsDk7TQlREJv3DwOxQpdu461a-Lg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -25376,7 +25680,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D5",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990d",
           "Name": "",
@@ -25435,7 +25739,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:37 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:44 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698eb
@@ -25451,9 +25755,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIDAU2acv8cHA+bwa9X/xgdIFkhviPpS1htfsvLTWTJoSAiEAzT2It9kOvearh6YQFCHk6eCX6BKn0+xwXyCdrSv2ewE="
+        host date digest",signature="MEQCIHZA75aUV0Z5b+p13dUXYcFPB3QzrYM81/Kq0mlmRoUmAiBlnwXILLu5dYIzg5GDwZHnsRY30f52j+3DNHNGgKRlhQ=="
       Date:
-      - Tue, 26 Apr 2022 05:03:37 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -25466,16 +25770,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:37 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Set-Cookie:
-      - AWSALB=G/Sf4oxH28C0WAvaa2B7KKjzIBG1ToBd4/a4AWnZURNBfzJlwQDJP5AwZkMnHz24/QMRFfsqQhIp+wPURv89I8SyX2AmwnFO0c7WZQvmj6FmaH0WLDs2TR26ztR9;
-        Expires=Tue, 03 May 2022 05:03:37 GMT; Path=/
-      - AWSALBCORS=G/Sf4oxH28C0WAvaa2B7KKjzIBG1ToBd4/a4AWnZURNBfzJlwQDJP5AwZkMnHz24/QMRFfsqQhIp+wPURv89I8SyX2AmwnFO0c7WZQvmj6FmaH0WLDs2TR26ztR9;
-        Expires=Tue, 03 May 2022 05:03:37 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=GfRHM1N658fnwuPSY1DeeEh/6+/AJDbWpqeUlbjeLmTJd9Slp7ueAYxzjDpO3+631dbDpTyRVNXD4rB2sAihDrClvK1gJiCa33VRE+juzvzaf9S4SWr9hPtjaBth;
+        Expires=Wed, 04 May 2022 06:19:44 GMT; Path=/
+      - AWSALBCORS=GfRHM1N658fnwuPSY1DeeEh/6+/AJDbWpqeUlbjeLmTJd9Slp7ueAYxzjDpO3+631dbDpTyRVNXD4rB2sAihDrClvK1gJiCa33VRE+juzvzaf9S4SWr9hPtjaBth;
+        Expires=Wed, 04 May 2022 06:19:44 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0b3f3de98f1b3da4c18f53156922a80a
+      - NBf9e4ae910b1459ad96934c5268fe3426
       Pragma:
       - no-cache
       Cache-Control:
@@ -25505,11 +25809,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - IXKXAa2zZtqZ02aW5KduNzzbaKw4eRUHfs3VlEEJfYgwq2YpcaqtxA==
+      - ocFuFlA8L7gUf0lUxyoM772-LfFxCA_SU97aXl0Oy9eN76oB32yTUg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -25556,7 +25860,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E9",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698eb",
           "Name": "",
@@ -25615,7 +25919,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:37 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:44 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ee
@@ -25631,9 +25935,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIChtI2uawvLNh/RZHnTAuwstykIL46+3Q7fhb4NizTJlAiEA/9nJQwhs0fw+Pa8IrCYq0TEUt7sFmC3RbCiiaSO6QqQ="
+        host date digest",signature="MEUCIEQoocDoVq3dSky1mJK0MQPnxE7NtVGHITWsCJpO1KMDAiEAznIlGMSfTmThZ3Q4DNpMNxi6fLPtCBOpw/+9ESOA0wk="
       Date:
-      - Tue, 26 Apr 2022 05:03:37 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -25646,16 +25950,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:37 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Set-Cookie:
-      - AWSALB=iWr9HfS7Wl6M5ABi2BQPMfmDl/H5ESuuiS2n0mi5k9axYrG3J7VPFcgjyygyT1DPVIqKq2SXm+NRgCy7OoET8V+lchtEzsgQBFVB7pGxGYMVTu+n8J33EqlSPRhn;
-        Expires=Tue, 03 May 2022 05:03:37 GMT; Path=/
-      - AWSALBCORS=iWr9HfS7Wl6M5ABi2BQPMfmDl/H5ESuuiS2n0mi5k9axYrG3J7VPFcgjyygyT1DPVIqKq2SXm+NRgCy7OoET8V+lchtEzsgQBFVB7pGxGYMVTu+n8J33EqlSPRhn;
-        Expires=Tue, 03 May 2022 05:03:37 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=31A1pqeUSxsH+cRadOLU4L0RGtFA17/6aLy/dN4lw+MtfrCwoPjtmtCCjmW4WqmaZ17KHAGTP7yPYYL2ai9ST7+RsytN5djKZf/GRDALYEyCgayPl1X+SiAzQtOQ;
+        Expires=Wed, 04 May 2022 06:19:44 GMT; Path=/
+      - AWSALBCORS=31A1pqeUSxsH+cRadOLU4L0RGtFA17/6aLy/dN4lw+MtfrCwoPjtmtCCjmW4WqmaZ17KHAGTP7yPYYL2ai9ST7+RsytN5djKZf/GRDALYEyCgayPl1X+SiAzQtOQ;
+        Expires=Wed, 04 May 2022 06:19:44 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf0254c3aebb29b85ac049a3d83aa6199
+      - NBa8f50e5e477f3d3c649a7cbaac0bf689
       Pragma:
       - no-cache
       Cache-Control:
@@ -25685,11 +25989,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - pFDbIXubuCQTHCM3pmaitZEqH8fAbOoC-XoWHTznFSIKrafdKN1hGg==
+      - ZelPHAvL1qvvc8aT4H1ik_At_cs5pJ2zGknSIFiYIbFrOlmtGKBbDg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -25736,7 +26040,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:EC",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ee",
           "Name": "",
@@ -25795,7 +26099,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:37 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:44 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f5
@@ -25811,9 +26115,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCMUucEhRncvDVub7EZMRcZxOy5xawatMDejRuLbfSUfgIgBF331RHxPnmpbYlIiYdYAQbHUyX1bCsUSBoEskCeq34="
+        host date digest",signature="MEUCIQCEo8RvMaudZpfYH5vpoChkknkkqRGLoOCcEnDWkGSKugIgJySb2dPO01F6oj07IFnZV2qnTOL/E/U4QuDHUa4nejI="
       Date:
-      - Tue, 26 Apr 2022 05:03:37 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -25826,16 +26130,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:38 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Set-Cookie:
-      - AWSALB=FN1f/B+hkdMKfbuw+dIjeqA7Y/75MxL8UmDGxP5IPUsuZtEbA6pad8WGYEbhaunhFJ3KxE6HZq2oFj+5o2WEwTc+ipRz4FIUS76fY6wR3s5sSxrdfJoxHDH7e5yg;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/
-      - AWSALBCORS=FN1f/B+hkdMKfbuw+dIjeqA7Y/75MxL8UmDGxP5IPUsuZtEbA6pad8WGYEbhaunhFJ3KxE6HZq2oFj+5o2WEwTc+ipRz4FIUS76fY6wR3s5sSxrdfJoxHDH7e5yg;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=88NvEePlMYhmIytElPKC4NGkzleCHKQMpF/rX8nonvUPh1+UT4YjNGjk61HpkE1Nd7ApG1Z/0ix1NbSJRdlRzF4/JE/CYaxM2wspVBQzv6/FcG6JsSAAgzSG4vyP;
+        Expires=Wed, 04 May 2022 06:19:44 GMT; Path=/
+      - AWSALBCORS=88NvEePlMYhmIytElPKC4NGkzleCHKQMpF/rX8nonvUPh1+UT4YjNGjk61HpkE1Nd7ApG1Z/0ix1NbSJRdlRzF4/JE/CYaxM2wspVBQzv6/FcG6JsSAAgzSG4vyP;
+        Expires=Wed, 04 May 2022 06:19:44 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc43fac5e86cc73e627ba828d59e18f8b
+      - NB16f7e8207b9b6c6c0397dce8c634a6f2
       Pragma:
       - no-cache
       Cache-Control:
@@ -25865,11 +26169,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - AkoNQZbCnKry0T_giUHlgwd9SDDB5vO2hJ6BEoyhKzp4ABh_131MGA==
+      - mQW53o0JdT95H0jdyctL9JfZU-Er_3sTP6yT-WiD7PwHNP1-bS2cYQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -25916,7 +26220,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F3",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f5",
           "Name": "",
@@ -25975,7 +26279,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:38 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:44 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698fe
@@ -25991,9 +26295,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCID0RPKZBe8S9nrD3KXjkN5BOpnagTKLFQACJUyPJkuFOAiEAjniSEufI3ZaCWwEntCpYB2eqiSEEN4wcBDAOHZ0GUC0="
+        host date digest",signature="MEUCIQCtDXB2QTlxpkEye1Koy7UOrisN3YYmnJP4nmoOcoRZZAIgF+QCVzyVlDOeh9arz9MxEYGypB617bSMfyea2SjrVDo="
       Date:
-      - Tue, 26 Apr 2022 05:03:38 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -26006,16 +26310,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:38 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Set-Cookie:
-      - AWSALB=Y75uAFuS0teEcdgZFq/L+ZfxOM4ZDy9HdI9P+dQafc2Vc7ZdbPw/M5jZc1rPqYFDcjTEOeN84WaMJiPlR3U+o78IqP8Y5meyzVcR4qF/mFRRg0tP7n8/cxKzHGHV;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/
-      - AWSALBCORS=Y75uAFuS0teEcdgZFq/L+ZfxOM4ZDy9HdI9P+dQafc2Vc7ZdbPw/M5jZc1rPqYFDcjTEOeN84WaMJiPlR3U+o78IqP8Y5meyzVcR4qF/mFRRg0tP7n8/cxKzHGHV;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=XUdZM78FoXc7X2r4dJwdGoyY2fCfou5QbAiWrO8SsXwSZk7DJjCLidlSt1W7Eecs7uFKgsuhV5XMilr64/bm2pC1e0C7IF6tOWp70oQxKIxyw84xN/SgWdMK8jAL;
+        Expires=Wed, 04 May 2022 06:19:44 GMT; Path=/
+      - AWSALBCORS=XUdZM78FoXc7X2r4dJwdGoyY2fCfou5QbAiWrO8SsXwSZk7DJjCLidlSt1W7Eecs7uFKgsuhV5XMilr64/bm2pC1e0C7IF6tOWp70oQxKIxyw84xN/SgWdMK8jAL;
+        Expires=Wed, 04 May 2022 06:19:44 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe4532551e53162d1d9fb7e3e6e18d699
+      - NB3e81578d0390426f0fd25fe78ef13b2f
       Pragma:
       - no-cache
       Cache-Control:
@@ -26045,11 +26349,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - wKKMLZszx5sT0SeMj-9KldJUmetYOjtBR1TxJ854fUJlzpHm33rEiw==
+      - NX74PMcV8skADREXajmwXkrVtgtqgGbfHGQsaT75b-JS2v3P6he1Hw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -26096,7 +26400,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:94:08",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698fe",
           "Name": "",
@@ -26155,7 +26459,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:38 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:44 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990c
@@ -26171,9 +26475,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQC74Gj7MxHK848+gsgLXdON3jer3EuO0Vae4dTGySzfRgIhAL9wQNk8UhgyzuoCxPJn02CItn45hk2u/cZOiHtrgNtY"
+        host date digest",signature="MEUCIQDU0wSwEkXF3i0CFU/L1hC5WOLamyeMRlEZW9cfQfSgDgIgUv2pOhd/LJZddf0cdU9Nu3uMZ94XzR+QOVpLpa4QfVQ="
       Date:
-      - Tue, 26 Apr 2022 05:03:38 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -26186,16 +26490,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:38 GMT
+      - Wed, 27 Apr 2022 06:19:44 GMT
       Set-Cookie:
-      - AWSALB=k21AYHFubziCgHfOcrXZ5Q6HWsyOwYk8zOHBQtZd3d+XN3ZuxrCVGE5OWau1033NxkA2scsPugGko5yc7CBJ6XP1uVGvR4f0XJO1m6q76R0ayPSEKoyt1CkaOic+;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/
-      - AWSALBCORS=k21AYHFubziCgHfOcrXZ5Q6HWsyOwYk8zOHBQtZd3d+XN3ZuxrCVGE5OWau1033NxkA2scsPugGko5yc7CBJ6XP1uVGvR4f0XJO1m6q76R0ayPSEKoyt1CkaOic+;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=MsKMyjUnCmDYDfKnMwH9Sov1eWd4IxOBkEnmVwwOZsIeAOCNoOgd7VfUZ8vI0eIEap0FA/EwRHSbRKQCTPX5w7U1pe/ZdZz4evv0tx5+FnDeHZIYS4HScUmyl0MK;
+        Expires=Wed, 04 May 2022 06:19:44 GMT; Path=/
+      - AWSALBCORS=MsKMyjUnCmDYDfKnMwH9Sov1eWd4IxOBkEnmVwwOZsIeAOCNoOgd7VfUZ8vI0eIEap0FA/EwRHSbRKQCTPX5w7U1pe/ZdZz4evv0tx5+FnDeHZIYS4HScUmyl0MK;
+        Expires=Wed, 04 May 2022 06:19:44 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf7718b8943e19b6a6067995df2db58fe
+      - NB58e7fb788319c293550fdec0bea32654
       Pragma:
       - no-cache
       Cache-Control:
@@ -26225,11 +26529,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - m6vTxzqWJ6TJjN0BLfBgVfD5lJgTFScQuSF8Ui4LEHwIKw0RgJzFLw==
+      - uRLoP996qwNS_PqfX0OCJ6FDtowh3gW2txgbeoYDE5hgR0eF1p6uWg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -26276,7 +26580,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D4",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990c",
           "Name": "",
@@ -26335,7 +26639,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:38 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:45 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669910
@@ -26351,9 +26655,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBYPolDqUu9xoD4Ru0RDG3p6zadfNvP4ekY9sMiuNxPsAiEA2kSG63uVRqEIKLMulh6iDKtkz2LUwwLLSeD3dUynOAQ="
+        host date digest",signature="MEYCIQDQyoAxy9Epmu28wNoKZJJgZXKXj6YUtnSIAkBBxt726AIhAPSJsssePAEMjgK0denAnruLzKf+ZNToBxzCzCgd92MV"
       Date:
-      - Tue, 26 Apr 2022 05:03:38 GMT
+      - Wed, 27 Apr 2022 06:19:45 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -26366,16 +26670,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:38 GMT
+      - Wed, 27 Apr 2022 06:19:45 GMT
       Set-Cookie:
-      - AWSALB=R+moQJBVYaQAkGamwxX/rXnhP69ivLqw4rdQ67oOdxBiOHZ3jYtxycfbAIJEcgYuq6ZnGaW1R/epaHQbcuC8BiWXwb5l81ZVSLRYLqFPy0euDPs8jYs5G0W7XayI;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/
-      - AWSALBCORS=R+moQJBVYaQAkGamwxX/rXnhP69ivLqw4rdQ67oOdxBiOHZ3jYtxycfbAIJEcgYuq6ZnGaW1R/epaHQbcuC8BiWXwb5l81ZVSLRYLqFPy0euDPs8jYs5G0W7XayI;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=cVixfszMO0oggc3EfzDUYVlv5Vh+p8yKT+qTxdElgckOtjhCtS5Za7QmdQtKkoxBn18dt9GPoAG9zRRAswUbQ6qY0EM80x/JTUdXJCLn2g3EPC2ygSDInmGx+UDO;
+        Expires=Wed, 04 May 2022 06:19:45 GMT; Path=/
+      - AWSALBCORS=cVixfszMO0oggc3EfzDUYVlv5Vh+p8yKT+qTxdElgckOtjhCtS5Za7QmdQtKkoxBn18dt9GPoAG9zRRAswUbQ6qY0EM80x/JTUdXJCLn2g3EPC2ygSDInmGx+UDO;
+        Expires=Wed, 04 May 2022 06:19:45 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe10360ba7783e681537d6a4b8c6d5b43
+      - NB90576f1f71f5c28e52b22e3da94ab37a
       Pragma:
       - no-cache
       Cache-Control:
@@ -26405,11 +26709,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - oDg_OjhOWTUIObVirC2wMJkaQuCF-OxMB_FD4hkTy0a9qagT5wKV_Q==
+      - yd5InQWcsiftK-5huvzenr1VAb5dPMKEhiIDRtvZ0dy7ev35AymVxg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -26456,7 +26760,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D8",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25d4630312d41669910",
           "Name": "",
@@ -26515,7 +26819,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:38 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:45 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ed
@@ -26531,9 +26835,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCWqDFKFAC9UExUGWr3O5maZNUpM3YuXryeUZxmEIl0DQIhAL2Zg8RYRdlq9pfWnDOuhzdY8TLtX+7bxcJdda+Y9Uf7"
+        host date digest",signature="MEUCIGROmNOS2F2xHHHNxLlWkLkxQApGJK/yPMShTLkkwyaxAiEA3JWjosciX36l/uTj6UyW8f3fyuDPkixEzcQl0SHzlns="
       Date:
-      - Tue, 26 Apr 2022 05:03:38 GMT
+      - Wed, 27 Apr 2022 06:19:45 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -26546,16 +26850,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:38 GMT
+      - Wed, 27 Apr 2022 06:19:45 GMT
       Set-Cookie:
-      - AWSALB=Q3XZEPusTEzCGGtwqCbmAwIKnTWmRGQb06FpIhrC9ij6dl9TQXqjUNz5uzLD1QnpSprJKE9J4CaSTyW62rNEbviCTY2Vj1n9yNoS0eEmCJtzGmJlCJkd3eytIZFt;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/
-      - AWSALBCORS=Q3XZEPusTEzCGGtwqCbmAwIKnTWmRGQb06FpIhrC9ij6dl9TQXqjUNz5uzLD1QnpSprJKE9J4CaSTyW62rNEbviCTY2Vj1n9yNoS0eEmCJtzGmJlCJkd3eytIZFt;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=w8xUK6WWBemhLON/WRxEtvIcFX7Bh65LMQFbuCb0VB2E+qXhqdtz6plvrs/n0cBGu2uY/xeOK8mrNMIQIwOoZQclk44GfVMzBxDu1SXs68HVYJhco0cXWnWISP+E;
+        Expires=Wed, 04 May 2022 06:19:45 GMT; Path=/
+      - AWSALBCORS=w8xUK6WWBemhLON/WRxEtvIcFX7Bh65LMQFbuCb0VB2E+qXhqdtz6plvrs/n0cBGu2uY/xeOK8mrNMIQIwOoZQclk44GfVMzBxDu1SXs68HVYJhco0cXWnWISP+E;
+        Expires=Wed, 04 May 2022 06:19:45 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBdda34e6af499078329daee1d7f59d841
+      - NB7b65273e89c4ccf958b6903c08088ca4
       Pragma:
       - no-cache
       Cache-Control:
@@ -26585,11 +26889,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - xTI8rIPwwEGZBZ9QFt_SS80bGwo-O-AXwCQ2tKYYQogoNrvHGDAXuw==
+      - NPQ32ZSyvvFlZ9y7cTvlMMveSvTaHHZmw8YhAOUf-Z2hRZmcZEqtLg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -26636,7 +26940,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:EB",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ed",
           "Name": "",
@@ -26695,7 +26999,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:38 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:45 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ef
@@ -26711,9 +27015,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCICPg0UqFnDGEOkA5uwzQPkDtOXQeg1q7dMEaerlH7lylAiEArRT/hMkgTeZy6PjTOgj+rNQjVOk+aNp2g0bl/FElRX0="
+        host date digest",signature="MEUCIQDb0w8nw4/QWi4SymSnxwMEk1vZ7sT26/ZQioBQT8X+5wIgCCTcroXJxSBvmdjDqexaT/uQiDtpRt5sDXWl7YySf9s="
       Date:
-      - Tue, 26 Apr 2022 05:03:38 GMT
+      - Wed, 27 Apr 2022 06:19:45 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -26726,16 +27030,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:40 GMT
+      - Wed, 27 Apr 2022 06:19:45 GMT
       Set-Cookie:
-      - AWSALB=G5U/b7q/tszt4FqVpaWqh277mOLu5JGbOg2snYs0k+sN+f0JXVHWwo+bNQ3yZobLV80xlReHyzMyBTVEvRIf+Ui/BUQyHT5rZMr866NXlNf+6MaQpNJkgywgqDKC;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/
-      - AWSALBCORS=G5U/b7q/tszt4FqVpaWqh277mOLu5JGbOg2snYs0k+sN+f0JXVHWwo+bNQ3yZobLV80xlReHyzMyBTVEvRIf+Ui/BUQyHT5rZMr866NXlNf+6MaQpNJkgywgqDKC;
-        Expires=Tue, 03 May 2022 05:03:38 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=YNly3vlz4QIq/RwVvb4HpgF90xoGrW6cjOgkHdoCUqEWt+EJ/zarZU2MJqvqAjIFhYKY6HfgdIgkjQ4UjwqH0gAD/R/NTu99X9ZpyIFoeQL3U3APxDzxISL2FPol;
+        Expires=Wed, 04 May 2022 06:19:45 GMT; Path=/
+      - AWSALBCORS=YNly3vlz4QIq/RwVvb4HpgF90xoGrW6cjOgkHdoCUqEWt+EJ/zarZU2MJqvqAjIFhYKY6HfgdIgkjQ4UjwqH0gAD/R/NTu99X9ZpyIFoeQL3U3APxDzxISL2FPol;
+        Expires=Wed, 04 May 2022 06:19:45 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf661ad448902fcbe6adad218807026f1
+      - NB5f5d0dde91d9ccab4b2a9bb52770b16c
       Pragma:
       - no-cache
       Cache-Control:
@@ -26765,11 +27069,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ELDt9M8fivAgfKBD-qY4MiopkJaJ8PK-G4DluWw6RJmTNfSSbyN-jQ==
+      - mDBvR2fOasblmCyxCHpIIML5QmalHE3jruaFgKknxeBdbAX5C9eU2g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -26816,7 +27120,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:ED",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ef",
           "Name": "",
@@ -26875,7 +27179,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:40 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:45 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f9
@@ -26891,9 +27195,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQC2HNFvQhVtk47aeLgQbVw0Dg93oiDPLeb+82wZT/+oyQIhAJQQMvRNJKxUeNcxbJYj/O+Hfcmpk2wac/eDbaVP5E/S"
+        host date digest",signature="MEUCIQCFFpDBT3a5Pcs63YOebQlIvsU+iG6PMd9P4yqO5PHoWAIgHgacaqNQda8rpZ7USG79d1dzkouYCVdJNACGRXR5nC8="
       Date:
-      - Tue, 26 Apr 2022 05:03:40 GMT
+      - Wed, 27 Apr 2022 06:19:45 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -26906,16 +27210,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:40 GMT
+      - Wed, 27 Apr 2022 06:19:45 GMT
       Set-Cookie:
-      - AWSALB=ihR0TLUrFnooqEHjVo+QZM9O+OahdfMQqEOTrxt8UfTDJi6AuHngHFgnxXJKfBK2x9ONfm47a6Jsb1hyu8ObCvZ8wCOgYHazpl0N7PGG4iqdjAggG3HoIyKToEXN;
-        Expires=Tue, 03 May 2022 05:03:40 GMT; Path=/
-      - AWSALBCORS=ihR0TLUrFnooqEHjVo+QZM9O+OahdfMQqEOTrxt8UfTDJi6AuHngHFgnxXJKfBK2x9ONfm47a6Jsb1hyu8ObCvZ8wCOgYHazpl0N7PGG4iqdjAggG3HoIyKToEXN;
-        Expires=Tue, 03 May 2022 05:03:40 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=hVzwamKXLNhMwpw0fYVxSCo/ZkR5Tn505kj6CJ0CoK2RhmEuB6/QSW4ocCPYsvXMbVwK9QH3BCyIpiskSQylBOjuPBy1LHkwp8WA0JF6prab0lHHOnseNddoLktO;
+        Expires=Wed, 04 May 2022 06:19:45 GMT; Path=/
+      - AWSALBCORS=hVzwamKXLNhMwpw0fYVxSCo/ZkR5Tn505kj6CJ0CoK2RhmEuB6/QSW4ocCPYsvXMbVwK9QH3BCyIpiskSQylBOjuPBy1LHkwp8WA0JF6prab0lHHOnseNddoLktO;
+        Expires=Wed, 04 May 2022 06:19:45 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe3541227676c904f4adf25f8e261e37e
+      - NBe52b837c7f7d12f9ce2a8be91c17272f
       Pragma:
       - no-cache
       Cache-Control:
@@ -26945,11 +27249,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - jsKAU_VEJyKPaDx8a7g5kjBYsOtq_lVmWAJkRkXPhZ1eJDb27res-A==
+      - hgDCfJYw5FcfVaKGOkO1UV6WIzweE5cP_Mn17kZq6YFWNsLuEsuQjw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -26996,7 +27300,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F7",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f9",
           "Name": "",
@@ -27055,7 +27359,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:40 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:45 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669912
@@ -27071,9 +27375,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIEGCY+ZdjXq1kAIkJdGEILJYPdOuhV5Ts9bsEzwOtB0mAiAH2zjp6SBPd5xhfFeWJn/Vy75G0zw0aAhGi1prDLi9PA=="
+        host date digest",signature="MEUCIQCBiPKzDsfiCnW6W7UZuiDR8Z/a8v5bqwNcw9FbgDLHawIgdiY/v2DfqEorDRvJhbBL2FY2ORr6lStlNMPrgJhg7/8="
       Date:
-      - Tue, 26 Apr 2022 05:03:40 GMT
+      - Wed, 27 Apr 2022 06:19:45 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -27086,16 +27390,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:40 GMT
+      - Wed, 27 Apr 2022 06:19:46 GMT
       Set-Cookie:
-      - AWSALB=uAmwkxuI4NqJIXxf2mTxvGCJ9gslaHipEmkbFbW0i8IXuVfaQ+expwOwpbmUqUkkE5707Gt79Srhw3yjRXLrDhCKcWK74RbbwgORGvU/TXKI9LODcOmblmJZ8Whj;
-        Expires=Tue, 03 May 2022 05:03:40 GMT; Path=/
-      - AWSALBCORS=uAmwkxuI4NqJIXxf2mTxvGCJ9gslaHipEmkbFbW0i8IXuVfaQ+expwOwpbmUqUkkE5707Gt79Srhw3yjRXLrDhCKcWK74RbbwgORGvU/TXKI9LODcOmblmJZ8Whj;
-        Expires=Tue, 03 May 2022 05:03:40 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=Ff3tTOSOItaNLQcpqvLMY1bIoCaE0YMFQZNH8+C2j9SnzySJtlEKW0k460DbeYsesHYbWGoy/Zr1WHMYYMVIAc6QffRKtUiKvRKfAlUY9bdLF0AN15pyXSAdrCaV;
+        Expires=Wed, 04 May 2022 06:19:46 GMT; Path=/
+      - AWSALBCORS=Ff3tTOSOItaNLQcpqvLMY1bIoCaE0YMFQZNH8+C2j9SnzySJtlEKW0k460DbeYsesHYbWGoy/Zr1WHMYYMVIAc6QffRKtUiKvRKfAlUY9bdLF0AN15pyXSAdrCaV;
+        Expires=Wed, 04 May 2022 06:19:46 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB71c13ae61785156504f0258d3bc9f28e
+      - NBcc1211a5e4b53de3b2b45c5b375af2e8
       Pragma:
       - no-cache
       Cache-Control:
@@ -27125,11 +27429,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - VBplqu3daZmq9hXbHPijRdj84tZtweQtAw8Yuj_YylQdtVQ7hU2I6g==
+      - IVFefnTN6Mk9khDe15qG5EDfgJmw_PNYvMo0VfDezm-UqnvtogBGPA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -27176,7 +27480,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DA",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25d4630312d41669912",
           "Name": "",
@@ -27235,7 +27539,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:40 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:46 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669919
@@ -27251,9 +27555,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIDtUDjAIXEXxpuwiDGzOEFpEfPI6pGAmJgddQknYJ/WXAiBsIUOXAWjamCJusm47zvUWXWKrWMFWhIGWCSMCBPkTHg=="
+        host date digest",signature="MEQCIB/gufJmDLi537nYPj55tj/KB/JQMskqN3eu/mWEfxZ3AiBywolI1gifs4tr7n7xEGfxENpQqLfokPmURDHEKJRaTw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:40 GMT
+      - Wed, 27 Apr 2022 06:19:46 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -27266,16 +27570,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:40 GMT
+      - Wed, 27 Apr 2022 06:19:46 GMT
       Set-Cookie:
-      - AWSALB=LYr+BWJULBgJlAWPktgt4ZAWFsSQy4exdMXaIBUQ1pUECNfI5uEKMG+6rPhr5AEl/NLii81NErnn6u8qcoh+swv9tZa6l6sNNOgikO0IC+rud4l+SrJTapcbdxWv;
-        Expires=Tue, 03 May 2022 05:03:40 GMT; Path=/
-      - AWSALBCORS=LYr+BWJULBgJlAWPktgt4ZAWFsSQy4exdMXaIBUQ1pUECNfI5uEKMG+6rPhr5AEl/NLii81NErnn6u8qcoh+swv9tZa6l6sNNOgikO0IC+rud4l+SrJTapcbdxWv;
-        Expires=Tue, 03 May 2022 05:03:40 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=FOXFBby2DL7h64D9Ld/P0qP2eyoslHEWbcIM/7Q5vS7370nJkfIJZoljhOHWwgrHPYhZ8b0s1zNy8QqbthXAxFY3QBtINvDMhniPLw1q3+28TlYnpu3TPOPv0kS2;
+        Expires=Wed, 04 May 2022 06:19:46 GMT; Path=/
+      - AWSALBCORS=FOXFBby2DL7h64D9Ld/P0qP2eyoslHEWbcIM/7Q5vS7370nJkfIJZoljhOHWwgrHPYhZ8b0s1zNy8QqbthXAxFY3QBtINvDMhniPLw1q3+28TlYnpu3TPOPv0kS2;
+        Expires=Wed, 04 May 2022 06:19:46 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb2868f2d125e19abc0929648826cc010
+      - NB78e609961ca4d2fb7072b39ed59bc371
       Pragma:
       - no-cache
       Cache-Control:
@@ -27305,11 +27609,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 4T_kj4F1wA7g2SGoEJf0nqDnTJwuPBIYbLXxqQUoKrXECoSWmsNngw==
+      - v_FbdXSGUYPfimEW7ljCkTlU8xllwH-2jhn7CMA_eHG1tWm4h2m-Bw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -27356,7 +27660,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E1",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669919",
           "Name": "",
@@ -27415,7 +27719,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:40 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:46 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991e
@@ -27431,9 +27735,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCgmEneKSHbDHUUsWlGrd3xu+4d/6AGdC+jDDOd7tEXnAIhAMT4ymv/DpCkACdlTx3txJmpDcoknXwrRzvYkWu2aoYH"
+        host date digest",signature="MEUCIQDPq01v3+9c1gI/3eJP8YC/Pnnamsk4PRxt4wyxZaYBSwIgI7bHn/8KafTeSQEN4lCxtrKIm4Ub+J4Y1FMNTvoB4bc="
       Date:
-      - Tue, 26 Apr 2022 05:03:40 GMT
+      - Wed, 27 Apr 2022 06:19:46 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -27446,16 +27750,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:41 GMT
+      - Wed, 27 Apr 2022 06:19:46 GMT
       Set-Cookie:
-      - AWSALB=dQ6HEYpcWbntpM9jvqbm9+Wefj1iU8w91eTs5j8/47qod54WtgDsx0iIz+XhjJpHMwwEWwdOSRkFBr8dSkp+CFZdA/7b9AWoJzJbW+wlFhRWoJVUIQpuTxToo+ET;
-        Expires=Tue, 03 May 2022 05:03:41 GMT; Path=/
-      - AWSALBCORS=dQ6HEYpcWbntpM9jvqbm9+Wefj1iU8w91eTs5j8/47qod54WtgDsx0iIz+XhjJpHMwwEWwdOSRkFBr8dSkp+CFZdA/7b9AWoJzJbW+wlFhRWoJVUIQpuTxToo+ET;
-        Expires=Tue, 03 May 2022 05:03:41 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=pSxx6kodxRke6Ot4NDeZWWEiUQE5NkoKhrUo6Tzzxny77Ip3po5DfkRc4xKUjAZrdyrrl0g40yoLf30NjBx9gtXPJW72jVx/9+Lrsz8TCX4h2zvLuWWpxw3mPWGM;
+        Expires=Wed, 04 May 2022 06:19:46 GMT; Path=/
+      - AWSALBCORS=pSxx6kodxRke6Ot4NDeZWWEiUQE5NkoKhrUo6Tzzxny77Ip3po5DfkRc4xKUjAZrdyrrl0g40yoLf30NjBx9gtXPJW72jVx/9+Lrsz8TCX4h2zvLuWWpxw3mPWGM;
+        Expires=Wed, 04 May 2022 06:19:46 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4d748631b1ca702a084ac5bc3a5777d9
+      - NBf96503e7c80136a99376ec55ea68a919
       Pragma:
       - no-cache
       Cache-Control:
@@ -27485,11 +27789,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 9_5PiCwLzgE29okfvBc6uL1l2I2Z5kGo73KUHBjahlyYfVrO6yROVw==
+      - OKaxJS1WIQ-PnDX-kf9MucLDboQMs8b9OOB3sF_6uTEYPQDtXut-vg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -27536,7 +27840,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E6",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991e",
           "Name": "",
@@ -27595,7 +27899,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:41 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:46 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669913
@@ -27611,9 +27915,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIDrfTo1wOmBZhVtyC3Xt+atcWow2rIlq/5V9tzs1R3ShAiEA7aKU0Ia0rst1OcWSFSM9Dhir22CORsJfW5Dmjt88Jcc="
+        host date digest",signature="MEQCIFopCutGKTa2pw9c3Oc//0zwFxo5rSoH/NSun6QT2OljAiAFvNKwYgHY8J4ysDWVb2bW0euIAs6hT8VQT6vsPapZmg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:41 GMT
+      - Wed, 27 Apr 2022 06:19:46 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -27626,16 +27930,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:41 GMT
+      - Wed, 27 Apr 2022 06:19:46 GMT
       Set-Cookie:
-      - AWSALB=3F/MJ9LoWWPcd1l8lB2jieeiLMu9x2V0vasMtq/BjwHvG2DB6tyT7YPiHzJswrbz2bZ5nfEkCDGNyZqEO6y91SXMEeyGMoAsYnKcetuSsWILiBMAMaqojAjFuplU;
-        Expires=Tue, 03 May 2022 05:03:41 GMT; Path=/
-      - AWSALBCORS=3F/MJ9LoWWPcd1l8lB2jieeiLMu9x2V0vasMtq/BjwHvG2DB6tyT7YPiHzJswrbz2bZ5nfEkCDGNyZqEO6y91SXMEeyGMoAsYnKcetuSsWILiBMAMaqojAjFuplU;
-        Expires=Tue, 03 May 2022 05:03:41 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=cJ3JbR81+w08tNLzKClUyA+Q/APiSp48yh1LOjlN28GyMpZ3kBNDO6Oujkw6oSpKdDsXCxW7nxHPqnHW4quMfKJ81/mtYX2QpMlXxyq9NOJBHPOxNa3KPOcI0Nh7;
+        Expires=Wed, 04 May 2022 06:19:46 GMT; Path=/
+      - AWSALBCORS=cJ3JbR81+w08tNLzKClUyA+Q/APiSp48yh1LOjlN28GyMpZ3kBNDO6Oujkw6oSpKdDsXCxW7nxHPqnHW4quMfKJ81/mtYX2QpMlXxyq9NOJBHPOxNa3KPOcI0Nh7;
+        Expires=Wed, 04 May 2022 06:19:46 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB7904e26a16d24e54addf637f0ef744d5
+      - NB307373532824fe0e38bb7a0ad7024d3f
       Pragma:
       - no-cache
       Cache-Control:
@@ -27665,11 +27969,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - QFzQ-pWsMi1blYxvZZ9ETQMx2qXz6LQi8xMEjtqDy2L_THFmX97LWA==
+      - "-QHcwVtjs4GyNLwu98m87iS2BnnjzivaAONgqpM__8W0YhSSGj1BZw=="
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -27716,7 +28020,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DB",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25d4630312d41669913",
           "Name": "",
@@ -27775,7 +28079,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:41 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:46 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/62044b9c4630312d41c8a0c0
@@ -27791,9 +28095,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQComsEb/CtznX8j3+zQt3HN6bgxk8gqva0CNyCqQ7L9vwIgdwsFYaviaKqCqmpQhahteqb4859NK85LLCcwqfvabGo="
+        host date digest",signature="MEUCIQDW9oZb9X0P3Y5FwpSkSbPCBT9mUm4xxbNYIemafHgM3AIgWxhBH3Ux9CX661vziIb4XMVRq/LTWpyqVhxT4RHLTqc="
       Date:
-      - Tue, 26 Apr 2022 05:03:41 GMT
+      - Wed, 27 Apr 2022 06:19:46 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -27806,16 +28110,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:41 GMT
+      - Wed, 27 Apr 2022 06:19:47 GMT
       Set-Cookie:
-      - AWSALB=f4yrQd2H8pVF5VjldB1tZQYhIKKHP2rlmlwoujXPsO/u0aUMSYiuHVH7xTR4gddAJ0xE5wg7l8R0WKQrSYRSr0Qcdjfv8Ww+hQcqMNdaSiftSu2avu87F0eRpqOT;
-        Expires=Tue, 03 May 2022 05:03:41 GMT; Path=/
-      - AWSALBCORS=f4yrQd2H8pVF5VjldB1tZQYhIKKHP2rlmlwoujXPsO/u0aUMSYiuHVH7xTR4gddAJ0xE5wg7l8R0WKQrSYRSr0Qcdjfv8Ww+hQcqMNdaSiftSu2avu87F0eRpqOT;
-        Expires=Tue, 03 May 2022 05:03:41 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=2kD3Co8XOqEh2HgCAi9HfjaiWPQ1e1DO8BAtYOP5DVIiYOTWgoIJDoi5psoavXjf1Wcl33Ubk3l5/zg3e+UW3p01RH9Oldx1icURRmemo1E2sZ4xLPsSBDHbic7C;
+        Expires=Wed, 04 May 2022 06:19:47 GMT; Path=/
+      - AWSALBCORS=2kD3Co8XOqEh2HgCAi9HfjaiWPQ1e1DO8BAtYOP5DVIiYOTWgoIJDoi5psoavXjf1Wcl33Ubk3l5/zg3e+UW3p01RH9Oldx1icURRmemo1E2sZ4xLPsSBDHbic7C;
+        Expires=Wed, 04 May 2022 06:19:47 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0200425e2f74c9497511a1520c6efd51
+      - NB106f38b4316fd92fd951ce0ba133b148
       Pragma:
       - no-cache
       Cache-Control:
@@ -27845,11 +28149,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - P5s0TLJiKtEMaIbU8Ynw-v5ikWZ52mGyRMtbMrMOosQMmcRMUWGVuQ==
+      - CVCMXo8ghKXpEgYL1bDCLqyxf7ue5xrsin7PfJRhvggZ01R2AJTMNw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -27896,7 +28200,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CB",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "62044b9c4630312d41c8a0c0",
           "Name": "",
@@ -27955,7 +28259,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:41 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:47 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/62044b9c4630312d41c8a0bf
@@ -27971,9 +28275,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCb2wqyGHCwkcIhAYV10yXNs6cFfqXYki9h0fdivJEW9AIhAOXE9rxtGdCV3c51TUMvwL8UdfUbwjx0sUiNnPA5sbIR"
+        host date digest",signature="MEUCIE5tCj1r/EFTQqIAsBE2yCqQH+bvaF1WLQcgU6rXMEP5AiEA0n7of5S0zaAOyiRpXFDjsdLOhV5e+4YccEplhiBuVRw="
       Date:
-      - Tue, 26 Apr 2022 05:03:41 GMT
+      - Wed, 27 Apr 2022 06:19:47 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -27986,16 +28290,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:41 GMT
+      - Wed, 27 Apr 2022 06:19:47 GMT
       Set-Cookie:
-      - AWSALB=8YeNYTU1Uwlw3rwfHykTqbzMPaNyhN7EAmeU06BSMuwJOUXj7+chvi+ToMfyMWtunwD96ycyuLgXqxqnR/GtClphyhPDZhJgXJP9UuiNYsbHvhpcBuexwsLD2o+a;
-        Expires=Tue, 03 May 2022 05:03:41 GMT; Path=/
-      - AWSALBCORS=8YeNYTU1Uwlw3rwfHykTqbzMPaNyhN7EAmeU06BSMuwJOUXj7+chvi+ToMfyMWtunwD96ycyuLgXqxqnR/GtClphyhPDZhJgXJP9UuiNYsbHvhpcBuexwsLD2o+a;
-        Expires=Tue, 03 May 2022 05:03:41 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=SXydN+A0YzhcR1KzYTasmXK/jJmx1G0wMMcip0hy7BgDsLGBZIM+d1y/wbra+X1xnwIAaMvsdDHIy2l3uqLIP2LzP82SHeqFUfhRAzyofry8YAE2kAQqtN0BYMyZ;
+        Expires=Wed, 04 May 2022 06:19:47 GMT; Path=/
+      - AWSALBCORS=SXydN+A0YzhcR1KzYTasmXK/jJmx1G0wMMcip0hy7BgDsLGBZIM+d1y/wbra+X1xnwIAaMvsdDHIy2l3uqLIP2LzP82SHeqFUfhRAzyofry8YAE2kAQqtN0BYMyZ;
+        Expires=Wed, 04 May 2022 06:19:47 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc8f019f4cda0c9af90568bfa340ad71a
+      - NBd29e2b88b868840fb5257eeaadc415af
       Pragma:
       - no-cache
       Cache-Control:
@@ -28025,11 +28329,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 4W4kUIT70nQxvZTJVlAA28Lg2okebN6LfA6sPqyT-9R4yCt0zGaOeg==
+      - Pe88DbRKLoTpcPujqusxH_HN0aXDp1ztTtcD0teSTsD6awDC-YYl1w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -28076,7 +28380,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CA",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "62044b9c4630312d41c8a0bf",
           "Name": "",
@@ -28135,7 +28439,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:41 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:47 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/62044b9c4630312d41c8a0bd
@@ -28151,9 +28455,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQC3k3ZpbtfeU5UGmF3Jy4rWp/fUui4so8hwPDaSI7GLGQIgeNFRbDf4gUlS9KhhL+kykN2WpDVnQkCLgLTAlnOoVrE="
+        host date digest",signature="MEQCIA8MglH/gWHtzGC1aLPcAfI8Bqflx+meVo/SSVpuW8xTAiATW8pxfmpkQyZIZM87Fh4RHPBIwcvZq7AIiPt5CD5JLQ=="
       Date:
-      - Tue, 26 Apr 2022 05:03:41 GMT
+      - Wed, 27 Apr 2022 06:19:47 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -28166,16 +28470,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:42 GMT
+      - Wed, 27 Apr 2022 06:19:47 GMT
       Set-Cookie:
-      - AWSALB=ci9UJzaveku+6V0L6oZSN+wUsphqGYZURBLcOhZ4rXlWygQtvxski1RclKSPdJByOmqmbk4CUpyhTbyItAmwG09WRLD7CiurQPCukKhxy2bnQJtoxIBHCgEAumgT;
-        Expires=Tue, 03 May 2022 05:03:42 GMT; Path=/
-      - AWSALBCORS=ci9UJzaveku+6V0L6oZSN+wUsphqGYZURBLcOhZ4rXlWygQtvxski1RclKSPdJByOmqmbk4CUpyhTbyItAmwG09WRLD7CiurQPCukKhxy2bnQJtoxIBHCgEAumgT;
-        Expires=Tue, 03 May 2022 05:03:42 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=egLXcDRuLvTkj9jo8C8XxHMVJcORLtZmOaQykhN9LGSiynpOtdL59Vdiu0tbrBO3UB0AWM0/AMgPxwhTil2Eqqw8TAnG9hxF6mx+LI5CkQjvemvcTFuEB8/eofLH;
+        Expires=Wed, 04 May 2022 06:19:47 GMT; Path=/
+      - AWSALBCORS=egLXcDRuLvTkj9jo8C8XxHMVJcORLtZmOaQykhN9LGSiynpOtdL59Vdiu0tbrBO3UB0AWM0/AMgPxwhTil2Eqqw8TAnG9hxF6mx+LI5CkQjvemvcTFuEB8/eofLH;
+        Expires=Wed, 04 May 2022 06:19:47 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb611e7faa7fa518a72e631f6b12ca157
+      - NB0435cef2147ad6d879ff50b976b7b671
       Pragma:
       - no-cache
       Cache-Control:
@@ -28205,11 +28509,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - YndmSh3IYELqQWWksmmES8d0hEC-DfyZpOyO3fy1RHNH68WyvfnrNg==
+      - GL0vrVIco3Sin_Puu5iGCxJZn27EBiXgR89ceJjSMpvgnW0cx2SVgQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -28256,7 +28560,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:C8",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "62044b9c4630312d41c8a0bd",
           "Name": "",
@@ -28315,7 +28619,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:42 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:47 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/62044b9c4630312d41c8a0be
@@ -28331,9 +28635,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDpqZ++T9K/UjP7s8De9QC61zcPfvCzHekMQ8E7Fa3vSwIgDRUPN+ZS0ufQoFHf/8h/dMblb8CxR0kEv5O9LTusVGI="
+        host date digest",signature="MEUCIQDvaQdqo4+YPUl6dEtkldqw8qz8r8NLo9EmRw8/zgS+PwIgWaeOI2N8ltUgrc/FrndsugRjjLV6f+AxvauQ6eSJGFs="
       Date:
-      - Tue, 26 Apr 2022 05:03:42 GMT
+      - Wed, 27 Apr 2022 06:19:47 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -28346,16 +28650,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:42 GMT
+      - Wed, 27 Apr 2022 06:19:47 GMT
       Set-Cookie:
-      - AWSALB=ZnqA6RBDakzMkxLkC8NteI0NWVh9BEzwLqEgjfH1Fu50BFpJovTVwSFZ5RhxuXIg8tinmHMOaDxf+snkiDlKQOBQdc4kV/ckpBpt96uaHfIAe/YsOhZchBJXR+yt;
-        Expires=Tue, 03 May 2022 05:03:42 GMT; Path=/
-      - AWSALBCORS=ZnqA6RBDakzMkxLkC8NteI0NWVh9BEzwLqEgjfH1Fu50BFpJovTVwSFZ5RhxuXIg8tinmHMOaDxf+snkiDlKQOBQdc4kV/ckpBpt96uaHfIAe/YsOhZchBJXR+yt;
-        Expires=Tue, 03 May 2022 05:03:42 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=BdjHrubtnd66zzSRjcH7t/StU0tyOpJ2fhNu9afdUiAP2cJRlxdjJcn8Aw72YhXvNcbo0w9Agl94cGXP1LVBJLlWrkeOuLwLqHKfeDE5ParHE2jqP/HLI8P2X/4Y;
+        Expires=Wed, 04 May 2022 06:19:47 GMT; Path=/
+      - AWSALBCORS=BdjHrubtnd66zzSRjcH7t/StU0tyOpJ2fhNu9afdUiAP2cJRlxdjJcn8Aw72YhXvNcbo0w9Agl94cGXP1LVBJLlWrkeOuLwLqHKfeDE5ParHE2jqP/HLI8P2X/4Y;
+        Expires=Wed, 04 May 2022 06:19:47 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd0acff25f5b748d9bf167bc35d685c94
+      - NBe448d14e100fd662dae9447a30b8f2df
       Pragma:
       - no-cache
       Cache-Control:
@@ -28385,11 +28689,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 3RZU3-eIfhYm3zFxPrA9dNNvDY_4HKvjKBX-ExqZ6WBx-dF837_gbg==
+      - aKBw9v4FFpv8DzlX5l18yGl9_TvvIaJxdIaEZkpPMo2hFeqkYHJDPw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -28436,7 +28740,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:C9",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "62044b9c4630312d41c8a0be",
           "Name": "",
@@ -28495,7 +28799,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:42 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:47 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/port/Groups/614ce2a36176752d35a7eea3
@@ -28511,9 +28815,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCjBwIGIX7xl1nESliX60hhaaOG8EFsCMvKD4I412O/LAIgKTkY7UEWneFRReylwT+ZGrVFimSwfdQnQFP8i9yxSpo="
+        host date digest",signature="MEUCIA1zNk64ZyzYIgVU+TifvVgwAVQIpPslWXFQCSNOQFLxAiEAnI6s2Ynv9wnXSoOhHUy2INFI6rhIdJYHO6uJehEaw08="
       Date:
-      - Tue, 26 Apr 2022 05:03:42 GMT
+      - Wed, 27 Apr 2022 06:19:47 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -28526,16 +28830,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:42 GMT
+      - Wed, 27 Apr 2022 06:19:48 GMT
       Set-Cookie:
-      - AWSALB=hzbrjsdIwdTsdpm6bViMD06hXZJmTWUcgm4SLwuCT38KxCnMJFyBOG0CKgp/lAaeCvSltPGNb4so/5QRIiVyN2Z+37rmR5N0kAnmrwEWcbEEQBLPa+q03k+CVUif;
-        Expires=Tue, 03 May 2022 05:03:42 GMT; Path=/
-      - AWSALBCORS=hzbrjsdIwdTsdpm6bViMD06hXZJmTWUcgm4SLwuCT38KxCnMJFyBOG0CKgp/lAaeCvSltPGNb4so/5QRIiVyN2Z+37rmR5N0kAnmrwEWcbEEQBLPa+q03k+CVUif;
-        Expires=Tue, 03 May 2022 05:03:42 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=bcMXmaO1tEt46bbnO0VCdCRLwb+sYGEl9KrcIs0b8TBBLk18RV3xNi4pxhyHG8dE21IdxAcrjz1emCOW2T7057XhaMftHh005t1OAqoT+ipzZ/+tVQfGVpOv2qg9;
+        Expires=Wed, 04 May 2022 06:19:47 GMT; Path=/
+      - AWSALBCORS=bcMXmaO1tEt46bbnO0VCdCRLwb+sYGEl9KrcIs0b8TBBLk18RV3xNi4pxhyHG8dE21IdxAcrjz1emCOW2T7057XhaMftHh005t1OAqoT+ipzZ/+tVQfGVpOv2qg9;
+        Expires=Wed, 04 May 2022 06:19:47 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB70912f63a01e10af17425f7f6e95b84f
+      - NB11018577cafe7c107e0a26bed1904d15
       Pragma:
       - no-cache
       Cache-Control:
@@ -28565,11 +28869,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - XsfzxK0BeB56QGN0emYpvAQZYcQXjIzYr1zMMZjXZ0otnKl-x37u5A==
+      - "-BGOQVMiNxQrvBikCBEO-SiZP4Y4sJu47wBsxpIQlvINDbUdofYc-w=="
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -28644,7 +28948,7 @@ http_interactions:
           "Transport": "fc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:42 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:48 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/firmware/RunningFirmwares/614ce25d4630312d4166992b
@@ -28660,9 +28964,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIFILn6ktCsLJEK+wvNqddtqhAJDiUVtG6cyq729BgKBlAiBP5aCFRrge6petvNKL+si+qSfrrAwxfHg/ZyVfB3RKlQ=="
+        host date digest",signature="MEQCIGnlt7txCsNAM1su94IDH+Xa+Fwg+UUSZWJohxpBoVFPAiAwRy+VfcolAwo0lTC/R5w85UM393MsO4IPZzm2Vm9edw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:42 GMT
+      - Wed, 27 Apr 2022 06:19:48 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -28675,16 +28979,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:42 GMT
+      - Wed, 27 Apr 2022 06:19:48 GMT
       Set-Cookie:
-      - AWSALB=EuH18+DQRp9rFXk0bcogrNkGJA2QkyxJOrvz1NeRf1mOIhSBf2gVaRwEHK/xd1421uku/WI7eL3vkbt7gbyHoaq4O4YEDY/6BRWNPAb5QaTVRd4p4NmV66BSLCru;
-        Expires=Tue, 03 May 2022 05:03:42 GMT; Path=/
-      - AWSALBCORS=EuH18+DQRp9rFXk0bcogrNkGJA2QkyxJOrvz1NeRf1mOIhSBf2gVaRwEHK/xd1421uku/WI7eL3vkbt7gbyHoaq4O4YEDY/6BRWNPAb5QaTVRd4p4NmV66BSLCru;
-        Expires=Tue, 03 May 2022 05:03:42 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=1gdqsz46VaDfc1dcUFP/oU7TxN1WrRtZ/w4MdsEICcP/hIKAiKIJctLCQ9F/Y9K/zg5YHxF99O/1a3W9i8fpDQ0lmGu5K2HNe0iKNb82aI07fD9GZsGL9jb0t838;
+        Expires=Wed, 04 May 2022 06:19:48 GMT; Path=/
+      - AWSALBCORS=1gdqsz46VaDfc1dcUFP/oU7TxN1WrRtZ/w4MdsEICcP/hIKAiKIJctLCQ9F/Y9K/zg5YHxF99O/1a3W9i8fpDQ0lmGu5K2HNe0iKNb82aI07fD9GZsGL9jb0t838;
+        Expires=Wed, 04 May 2022 06:19:48 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4600c267fa6e03ecc82c54d1cbc125c0
+      - NB7d48901997b2c839d9731ecaaade2bec
       Pragma:
       - no-cache
       Cache-Control:
@@ -28714,11 +29018,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - lEVNShbBbIypFozSnV9nOl74QmmEbd7g6JNJaXaLovpcN3WX1Jrqkg==
+      - 3gk5MdmE5Qco-9jglfb3uE6AK2EMuLaoRI7zJttba0FnsPd14Vnl0g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -28753,7 +29057,7 @@ http_interactions:
             "ObjectType": "management.Controller",
             "link": "https://www.intersight.com/api/v1/management/Controllers/614ce2a36176752d35a7ee86"
           },
-          "ModTime": "2022-04-26T05:03:05.259Z",
+          "ModTime": "2022-04-27T06:15:05.815Z",
           "Moid": "614ce25d4630312d4166992b",
           "NetworkElements": [
             {
@@ -28806,7 +29110,7 @@ http_interactions:
           "Version": "9.3(5)I42(1f)"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:42 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:48 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/PhysicalSummaries
@@ -28822,9 +29126,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIDcFUsiFf+cNMOeJLOI3pU7G19NpCGhJvK+m2A60N7R4AiEAlrrB1pfywZmW3sjxVoBzVFrbyURqNGDGfZvD4vCoUqE="
+        host date digest",signature="MEUCIQCeFkbBQw9kQejr4HqyI+vj6UrdjB+Jnd/12XqnMl+IGgIgQI5/RdgpuCDtDU0bzmEFIbeL5eQ3kqym4FN431Zz7KE="
       Date:
-      - Tue, 26 Apr 2022 05:03:42 GMT
+      - Wed, 27 Apr 2022 06:19:48 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -28837,16 +29141,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:43 GMT
+      - Wed, 27 Apr 2022 06:19:48 GMT
       Set-Cookie:
-      - AWSALB=TU1k2wkv3ejTSd6Jx80Bnx6vJe3Wc2+rPTOyNsvopSYEbXxS+H/Olu3IFwmjBHEzoyuCI3+ZXQ2QM2oQMxu9AVeV3n4fkGlaVpWoztl94qgGmL8IR4Aw8v03AfGM;
-        Expires=Tue, 03 May 2022 05:03:42 GMT; Path=/
-      - AWSALBCORS=TU1k2wkv3ejTSd6Jx80Bnx6vJe3Wc2+rPTOyNsvopSYEbXxS+H/Olu3IFwmjBHEzoyuCI3+ZXQ2QM2oQMxu9AVeV3n4fkGlaVpWoztl94qgGmL8IR4Aw8v03AfGM;
-        Expires=Tue, 03 May 2022 05:03:42 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=2YTMOGSwI2M0g1jkpzIZumqKflm+R9/YDN8AnmT+xdhoFFqF4TP+FXL8n0fQvtROxZuMffahsb3khBPtp2xZASDYiJxEvOm7eUMmglOAd6r0ePP9rZ2LZ9lZtPKm;
+        Expires=Wed, 04 May 2022 06:19:48 GMT; Path=/
+      - AWSALBCORS=2YTMOGSwI2M0g1jkpzIZumqKflm+R9/YDN8AnmT+xdhoFFqF4TP+FXL8n0fQvtROxZuMffahsb3khBPtp2xZASDYiJxEvOm7eUMmglOAd6r0ePP9rZ2LZ9lZtPKm;
+        Expires=Wed, 04 May 2022 06:19:48 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf0dac6cce0ea27599712ed69704bd9ef
+      - NBaad0f6f7072fa72ac3342e86593c75ec
       Pragma:
       - no-cache
       Cache-Control:
@@ -28876,11 +29180,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - xPqiGscFi9RO1d3a9Vwqj0fqRs7EZWX9mgTs1Un9sslUJU2g6RpTvQ==
+      - NftMbwBgDEwUac8A3VOL8vuD1yMrBHiz6SksnWvd7gB6lKfF-2DBJg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -29065,7 +29369,7 @@ http_interactions:
               "ManagementMode": "Intersight",
               "MemorySpeed": "3200",
               "MgmtIpAddress": "100.66.11.155",
-              "ModTime": "2022-04-26T05:03:37.107Z",
+              "ModTime": "2022-04-27T06:12:47.046Z",
               "Model": "UCSX-210C-M6",
               "Moid": "62558eb26176752d36f43a77",
               "Name": "LAB02D02F01-1-2",
@@ -29170,27 +29474,11 @@ http_interactions:
               "HardwareUuid": "D0D77522-FA5B-4B24-A183-66BF636342FE",
               "InventoryDeviceInfo": null,
               "Ipv4Address": "127.0.0.1",
-              "KvmIpAddresses": [
-                {
-                  "Address": "100.66.11.151",
-                  "Category": "Equipment",
-                  "ClassId": "compute.IpAddress",
-                  "DefaultGateway": "100.66.11.129",
-                  "Dn": "",
-                  "HttpPort": 80,
-                  "HttpsPort": 443,
-                  "KvmPort": 2068,
-                  "KvmVlan": 0,
-                  "Name": "Outband",
-                  "ObjectType": "compute.IpAddress",
-                  "Subnet": "255.255.255.192",
-                  "Type": "MgmtInterface"
-                }
-              ],
+              "KvmIpAddresses": [],
               "ManagementMode": "Intersight",
               "MemorySpeed": "3200",
-              "MgmtIpAddress": "100.66.11.151",
-              "ModTime": "2022-04-26T05:03:41.064Z",
+              "MgmtIpAddress": "",
+              "ModTime": "2022-04-27T05:52:51.759Z",
               "Model": "UCSX-210C-M6",
               "Moid": "6266ce226176752d36c8fe12",
               "Name": "LAB02D02F01-1-3",
@@ -29202,7 +29490,7 @@ http_interactions:
               "NumFcHostInterfaces": 0,
               "NumThreads": 112,
               "ObjectType": "compute.PhysicalSummary",
-              "OperPowerState": "on",
+              "OperPowerState": "off",
               "OperReason": [],
               "OperState": "",
               "Operability": "",
@@ -29265,7 +29553,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:43 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:49 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/search/SearchItems?$filter=(Lifecycle%20eq%20%27Decommissioned%27)%20and%20(IndexMotypes%20eq%20%20%27equipment.Identity%27)
@@ -29281,9 +29569,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCI72Ud4wXnWHXBW3wJjxVFJtQF/jn4mZwjLH1VtiivNAIhAMrwf80gSle7RaOlKnrKQNrd+WsJ++0BMtaZCRvk6TmQ"
+        host date digest",signature="MEYCIQC2qqxbvudXXrKDPvT63lHqdAVj3Zi0pQ0DhXUhRHqbuQIhAOF7WA9FC6ThukORGWTSr+fUXieVkKWhSzpU9edEPY4j"
       Date:
-      - Tue, 26 Apr 2022 05:03:43 GMT
+      - Wed, 27 Apr 2022 06:19:49 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -29298,16 +29586,16 @@ http_interactions:
       Content-Length:
       - '1866'
       Date:
-      - Tue, 26 Apr 2022 05:03:43 GMT
+      - Wed, 27 Apr 2022 06:19:49 GMT
       Set-Cookie:
-      - AWSALB=Zz4GjkWD6CLCKeQk72W5krU0bPnmyWR4G6kX1iJurtVCWCkMvqTG3YEN/mMcvsMtsBjzfG7N29mN7Txf1WuKfKVWbxNNzFW7W/kCYKKZ5KrYcZUdfjRWRmzPd/r8;
-        Expires=Tue, 03 May 2022 05:03:43 GMT; Path=/
-      - AWSALBCORS=Zz4GjkWD6CLCKeQk72W5krU0bPnmyWR4G6kX1iJurtVCWCkMvqTG3YEN/mMcvsMtsBjzfG7N29mN7Txf1WuKfKVWbxNNzFW7W/kCYKKZ5KrYcZUdfjRWRmzPd/r8;
-        Expires=Tue, 03 May 2022 05:03:43 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=XBQOw6hKiaUgtlNA1G2OAtzKkFKX+QWX8pZQneOtbQxmU5B0BhP0kJrck0tYh0NWXFf2raha4lUI/QBO8CSBAYDeFVVLTunvDO4Kj3TrpLgWl316Ft5TvEeZo06Q;
+        Expires=Wed, 04 May 2022 06:19:49 GMT; Path=/
+      - AWSALBCORS=XBQOw6hKiaUgtlNA1G2OAtzKkFKX+QWX8pZQneOtbQxmU5B0BhP0kJrck0tYh0NWXFf2raha4lUI/QBO8CSBAYDeFVVLTunvDO4Kj3TrpLgWl316Ft5TvEeZo06Q;
+        Expires=Wed, 04 May 2022 06:19:49 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4fb235505a192d502206b7d152e1e331
+      - NB9cb1928ffc9a77f3faa93811c8c833e1
       Pragma:
       - no-cache
       Cache-Control:
@@ -29337,11 +29625,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - d_7AoeRYeVSqVUzALqA0d8J-M2USOoj75IQhyylBqevek1pPFcDnJg==
+      - uqvoUV4jWt9hJ_zJyTm3lQEqpoL8C0BOdFcctWVQZIue2scmKU7Y1g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -29402,7 +29690,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:43 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:49 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/RackUnits
@@ -29418,9 +29706,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCby1sr4VERn8NI4bc0goLLxAUCOa9yfP6zHXw68x4rBQIhANIvmn1V7eHx1RS0zv0CpM4va22vwPr8fTv19tFVp0CP"
+        host date digest",signature="MEYCIQDCQriTpVU+ySi5ugvW+tGQPAScHeQjN2R0bycocpaltAIhAIwk3b+ra2pSM7N1Lcyt6Jl7wqfXqzMbHE2rWXa9IWWb"
       Date:
-      - Tue, 26 Apr 2022 05:03:43 GMT
+      - Wed, 27 Apr 2022 06:19:49 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -29435,16 +29723,16 @@ http_interactions:
       Content-Length:
       - '60'
       Date:
-      - Tue, 26 Apr 2022 05:03:43 GMT
+      - Wed, 27 Apr 2022 06:19:49 GMT
       Set-Cookie:
-      - AWSALB=DJzr6WbMeMJeRaVgnEb7BZjFhKElPzGHbWxPAwMxkw1exnRqLQbT6vwbE0pgmxdfu4gqiXHrGsnXVk/+JdiYS6eFJRMUAb3dgPp3PkSvCHX9a/Bq7PV3dfcSxDyj;
-        Expires=Tue, 03 May 2022 05:03:43 GMT; Path=/
-      - AWSALBCORS=DJzr6WbMeMJeRaVgnEb7BZjFhKElPzGHbWxPAwMxkw1exnRqLQbT6vwbE0pgmxdfu4gqiXHrGsnXVk/+JdiYS6eFJRMUAb3dgPp3PkSvCHX9a/Bq7PV3dfcSxDyj;
-        Expires=Tue, 03 May 2022 05:03:43 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=NqtUtshvkEbnP0xiGpfsJLwdu3g8xCPBcSyutqBgEhwRHtGbWF29CSrikDAClxCMHvSa4gdk6MmWYsmA7UVffdQpdmU0d873PRTvUepX/9h0pnhvH4KYKoyc9QRu;
+        Expires=Wed, 04 May 2022 06:19:49 GMT; Path=/
+      - AWSALBCORS=NqtUtshvkEbnP0xiGpfsJLwdu3g8xCPBcSyutqBgEhwRHtGbWF29CSrikDAClxCMHvSa4gdk6MmWYsmA7UVffdQpdmU0d873PRTvUepX/9h0pnhvH4KYKoyc9QRu;
+        Expires=Wed, 04 May 2022 06:19:49 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB1436ac30e94a932f1f49351fb53e2eee
+      - NBafcd5181ff06a8658b4ad65fea593fc5
       Pragma:
       - no-cache
       Cache-Control:
@@ -29474,11 +29762,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - X5xyiUXKm-WwLneQ0l8a91FvvuA_jow9EaCGtkTGgkChIeb4b8etJg==
+      - EqJCV8WU0csXPSNihVxzvZcUSoyjJCqvs8Kn5hC4tYzFAH6XvZERWA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -29487,7 +29775,7 @@ http_interactions:
           "Results": []
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:43 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:49 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/firmware/FirmwareSummaries
@@ -29503,9 +29791,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIFg4EqtjW67Jvs6Dv+bl7jZbFXEPHjz+oRYTOHPz6+9mAiBVAL0Wxk5f6h2sF1/9IM/FiAMx8vDGLt5VPL6NyA4eqQ=="
+        host date digest",signature="MEUCIQC5irXg1EE1NFDtJPpq/5Qf0jrrNK/NvRhtAB1XKewIPQIgR4c6eRL2xTmjEzTc8JMi/gjccXtRmEUZ18OIOh2K0pw="
       Date:
-      - Tue, 26 Apr 2022 05:03:43 GMT
+      - Wed, 27 Apr 2022 06:19:49 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -29518,16 +29806,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:43 GMT
+      - Wed, 27 Apr 2022 06:19:49 GMT
       Set-Cookie:
-      - AWSALB=78kngI6fcUojD4eZkhZds/Xoxiec+/gO/YMznwcoVuGSOfT8PiZCgxtznmWDhHXLFvS4rSx85r1voDEtSGbj0Lt/KZeqR6NUOC31Fs3jI/Gdvx+xjg30erLZWpIG;
-        Expires=Tue, 03 May 2022 05:03:43 GMT; Path=/
-      - AWSALBCORS=78kngI6fcUojD4eZkhZds/Xoxiec+/gO/YMznwcoVuGSOfT8PiZCgxtznmWDhHXLFvS4rSx85r1voDEtSGbj0Lt/KZeqR6NUOC31Fs3jI/Gdvx+xjg30erLZWpIG;
-        Expires=Tue, 03 May 2022 05:03:43 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=YjHcaFFrESzWg6MS/zr34T89rAGYPGFPu2nh0Hne+I5hc0863IJHdheRalmbAaGc7MnKNbWclpMnehJ6ihX9CAzBxnmvOJpRuWv2BKnCrB6aoJvBI7XQeZB3KxsU;
+        Expires=Wed, 04 May 2022 06:19:49 GMT; Path=/
+      - AWSALBCORS=YjHcaFFrESzWg6MS/zr34T89rAGYPGFPu2nh0Hne+I5hc0863IJHdheRalmbAaGc7MnKNbWclpMnehJ6ihX9CAzBxnmvOJpRuWv2BKnCrB6aoJvBI7XQeZB3KxsU;
+        Expires=Wed, 04 May 2022 06:19:49 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe5e683b1d207914de300f3047a4642f8
+      - NB8bff2abba09ea70f0e067b9a91ad4cf0
       Pragma:
       - no-cache
       Cache-Control:
@@ -29557,11 +29845,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - C1GrgvUWC1KpZICTexalNJz0mSd86shWRITBzRvy_Q0g9EyyB4ajng==
+      - FgUfquNYXLR7Fc78_axLtaxIbo2PyiYbQTzf1LVKIH42U5fx09AHJw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -30101,7 +30389,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:44 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:49 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/network/Elements
@@ -30117,9 +30405,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCtosGvmTmA5GHWwGn8pQiKCpKg9gwwmZCdTjiscrBS9QIgc5xfswpUHapu7MJ/4DT28puFc6jqWWrqvIIeZfBYN/c="
+        host date digest",signature="MEUCIGRVonsFioaR4AkxiHr8soCIuGLflMPZMdnxKOwAj29yAiEAs6YWzaYxoPvZqYLlIWRy1XaPx3LplChh1MH97+ni0Cg="
       Date:
-      - Tue, 26 Apr 2022 05:03:44 GMT
+      - Wed, 27 Apr 2022 06:19:49 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -30132,16 +30420,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:44 GMT
+      - Wed, 27 Apr 2022 06:19:49 GMT
       Set-Cookie:
-      - AWSALB=BVgwinG5zqg3CIXu6rn9OH7wqx4M4AOeOhrhn1M8NGJGIo4PwFnUivN2WGCEpmo4qtBxBnncY4m8BfibyUfffvEWs2LG16GiHGXRczEGPcb+G2zBfJGHLt7J7maI;
-        Expires=Tue, 03 May 2022 05:03:44 GMT; Path=/
-      - AWSALBCORS=BVgwinG5zqg3CIXu6rn9OH7wqx4M4AOeOhrhn1M8NGJGIo4PwFnUivN2WGCEpmo4qtBxBnncY4m8BfibyUfffvEWs2LG16GiHGXRczEGPcb+G2zBfJGHLt7J7maI;
-        Expires=Tue, 03 May 2022 05:03:44 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=SHJ8NV1JvEO4dKZ9elY0C6RRsovS/YWx5wlWbJcgAXd7up3jXNRXkO9BTuw3o+nS77PRot0Tn3IeVR8RxQ9zfzhhoviHTW5krGG6xsdtVhQG1YvXIC8u9cfc/Ocd;
+        Expires=Wed, 04 May 2022 06:19:49 GMT; Path=/
+      - AWSALBCORS=SHJ8NV1JvEO4dKZ9elY0C6RRsovS/YWx5wlWbJcgAXd7up3jXNRXkO9BTuw3o+nS77PRot0Tn3IeVR8RxQ9zfzhhoviHTW5krGG6xsdtVhQG1YvXIC8u9cfc/Ocd;
+        Expires=Wed, 04 May 2022 06:19:49 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB457f8b4afb63bdf1be1349fab7787283
+      - NB4190197af6c893df8b538a11ecb1760c
       Pragma:
       - no-cache
       Cache-Control:
@@ -30171,11 +30459,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - F69h5tcgx27Zvk6oAGnPtrqd2Km2F5yA2qpSnLk0ZqvdFSd_mF7eUg==
+      - 5iP6MMzQAQ2B77e8eQ2P9uF_ZdWCYY2LKP8x6AZNmTIisMvlbJ-o4g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -30259,7 +30547,7 @@ http_interactions:
               },
               "ManagementEntity": null,
               "ManagementMode": "Intersight",
-              "ModTime": "2022-04-26T05:02:29.61Z",
+              "ModTime": "2022-04-27T06:18:30.57Z",
               "Model": "UCS-FI-6454",
               "Moid": "614ce2a16176752d35a7ec96",
               "NetworkFcZoneInfo": null,
@@ -30475,7 +30763,7 @@ http_interactions:
               },
               "ManagementEntity": null,
               "ManagementMode": "Intersight",
-              "ModTime": "2022-04-26T05:03:05.271Z",
+              "ModTime": "2022-04-27T06:19:06.133Z",
               "Model": "UCS-FI-6454",
               "Moid": "614ce2a36176752d35a7edbd",
               "NetworkFcZoneInfo": null,
@@ -30617,7 +30905,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:44 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:50 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/equipment/Chasses
@@ -30633,9 +30921,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIBhOTXYvyaJ7Z/c/E7XN2pUtdNC+sV35QowLev1NUmaiAiBbOlQT95EHx1zocaBCCZi6DLMNTnLGFa+mTXHPeMT3Yg=="
+        host date digest",signature="MEUCIAS1lJbA+GSk/agu+Pi3N2sHN2Ekg+Vk7H9g5e2TJwqgAiEAr6IkgEVZ4kyAF03W1MkFgX/uCw7KkxIQCCPpF1SomyA="
       Date:
-      - Tue, 26 Apr 2022 05:03:44 GMT
+      - Wed, 27 Apr 2022 06:19:50 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -30648,16 +30936,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:44 GMT
+      - Wed, 27 Apr 2022 06:19:50 GMT
       Set-Cookie:
-      - AWSALB=uqncttrh+lKwCg4FbSpzCrgmm+XbzGdwhoBLrxg0tLi4W+fpZEqbXA9y2E75i7TYejE9Gf0m+ew8niItGFPuvioFNdzCnvqDGeCk0u/z7VdfwT3I41BM5jbq2gFe;
-        Expires=Tue, 03 May 2022 05:03:44 GMT; Path=/
-      - AWSALBCORS=uqncttrh+lKwCg4FbSpzCrgmm+XbzGdwhoBLrxg0tLi4W+fpZEqbXA9y2E75i7TYejE9Gf0m+ew8niItGFPuvioFNdzCnvqDGeCk0u/z7VdfwT3I41BM5jbq2gFe;
-        Expires=Tue, 03 May 2022 05:03:44 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=XMIggEyB8zkQyvYDIJUboFEWt5PVol3dpEBnd/7sOV7Vyu+9rawOmL/Up4Rqm/UdHU9ok+e8l21X2XS10IlrYGpz5iyRBWKntI+LnKJHC/uaOzDwJXdhUYgjpwyO;
+        Expires=Wed, 04 May 2022 06:19:50 GMT; Path=/
+      - AWSALBCORS=XMIggEyB8zkQyvYDIJUboFEWt5PVol3dpEBnd/7sOV7Vyu+9rawOmL/Up4Rqm/UdHU9ok+e8l21X2XS10IlrYGpz5iyRBWKntI+LnKJHC/uaOzDwJXdhUYgjpwyO;
+        Expires=Wed, 04 May 2022 06:19:50 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa1abbfde78509a0a80fc064cf909da71
+      - NBa5da9decaf40ec06c5db370fc93fbfa2
       Pragma:
       - no-cache
       Cache-Control:
@@ -30687,11 +30975,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - cmycX8AsNkUUpHaZOQGoeuceXv9f7xtMilsoQ2SljwpNBt9PWM9q4A==
+      - d-bGt0nEXGASF0_W6VUZfnNTMecCqVMmHBMot-rl12B5ORzw_nB7BA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -30914,7 +31202,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:44 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:50 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/asset/DeviceRegistrations/620574346f72612d33f2d664
@@ -30930,9 +31218,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDalPKg1EbJoJ68eJtu87ONT9+Kih+YXqX/A1ubejrwvQIgCmgLYpcEomq3sCK6Co/EcZay09IR4kPbSjYWCoZFeG4="
+        host date digest",signature="MEYCIQD2BeoLsrqPk9Htd6StQWgkzJ+HUUteh7CFOjohalzM/AIhAJorIKMyo/daC/gt+RFpb84hCXVh4xCmriVGWtos0gS0"
       Date:
-      - Tue, 26 Apr 2022 05:03:44 GMT
+      - Wed, 27 Apr 2022 06:19:50 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -30945,16 +31233,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:44 GMT
+      - Wed, 27 Apr 2022 06:19:50 GMT
       Set-Cookie:
-      - AWSALB=xA2gjjblhg4fkjV2VcGPG1+nuNSzW8QGSiDiTOqCOMqJf1qIi80SxKclXYWPr1cOD51u9I6i+5FpbSAZ0OGeQasCDpB72Y6YQvIlJ9CZ0UY5nIA1HqyI3HcPrgmP;
-        Expires=Tue, 03 May 2022 05:03:44 GMT; Path=/
-      - AWSALBCORS=xA2gjjblhg4fkjV2VcGPG1+nuNSzW8QGSiDiTOqCOMqJf1qIi80SxKclXYWPr1cOD51u9I6i+5FpbSAZ0OGeQasCDpB72Y6YQvIlJ9CZ0UY5nIA1HqyI3HcPrgmP;
-        Expires=Tue, 03 May 2022 05:03:44 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=BbEbP5LolLALPgztvIFLgPD6gXlrgb22m5N3nJSDeZ8eN3MIkfBttxSOZDsbyXoq5qVAp1obYL5fyt4+vD4mkvaHbmKBzuWkt3udmZXSZhm11C5P/fPm9HSJ3myU;
+        Expires=Wed, 04 May 2022 06:19:50 GMT; Path=/
+      - AWSALBCORS=BbEbP5LolLALPgztvIFLgPD6gXlrgb22m5N3nJSDeZ8eN3MIkfBttxSOZDsbyXoq5qVAp1obYL5fyt4+vD4mkvaHbmKBzuWkt3udmZXSZhm11C5P/fPm9HSJ3myU;
+        Expires=Wed, 04 May 2022 06:19:50 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb8d3e7e9bde59c9572a952c9750c79e3
+      - NBa0ace71c09646663b2188b56eb1a76cf
       Pragma:
       - no-cache
       Cache-Control:
@@ -30984,11 +31272,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - CII4w6L5SH-KqSuGvKMxU8T5dniMTA0lahazzp7iiZG06Y3bQh-Z4g==
+      - 39LSiIaMthBBQzdodabbVg8fMCjWP2Y2gqIwHrW-W6NgU0uO_zV9EQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -31102,7 +31390,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:44 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:50 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/6205743e6176752d366ee76e
@@ -31118,9 +31406,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBBZ23GADFzs/lFpdonlefby05RO6kEI4ijRd2muH+bsAiEA43gEQNQvC0NPmqJK1hOV7JRA5ZWGozmy6sOETPQXCsw="
+        host date digest",signature="MEUCIDO0KI6CtnYfxoz3ItmKTHSsc4B4QtrhIR1EwdunFIZTAiEAnkaz/FovG4vbqNBJzqsdWETnk2goA4TTSLc0/FBGJ9s="
       Date:
-      - Tue, 26 Apr 2022 05:03:44 GMT
+      - Wed, 27 Apr 2022 06:19:50 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -31133,16 +31421,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:44 GMT
+      - Wed, 27 Apr 2022 06:19:50 GMT
       Set-Cookie:
-      - AWSALB=Uht/HlTGav47i4AeRFbP9mB3rQofNzxUVJMCsJAWhqVbxT/wSLOnNCa/Og4N1qjfROd64hPkbwZRcYhSdZGsLOwLN9OKHJhwvB6bmfRdM8Ta/oJzSQ6zl04TyGqm;
-        Expires=Tue, 03 May 2022 05:03:44 GMT; Path=/
-      - AWSALBCORS=Uht/HlTGav47i4AeRFbP9mB3rQofNzxUVJMCsJAWhqVbxT/wSLOnNCa/Og4N1qjfROd64hPkbwZRcYhSdZGsLOwLN9OKHJhwvB6bmfRdM8Ta/oJzSQ6zl04TyGqm;
-        Expires=Tue, 03 May 2022 05:03:44 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=puwBqdRO8wL2Q4kFqu1GY42aKQoWwobp31T7qHLiJluJpvnf2hVL6tuXMQsw0ejFPVaxObB9HUzwz4YL90ciYQUqTfX9cw2P83/7VnQ613N4wodm9m3AvHnXlLOq;
+        Expires=Wed, 04 May 2022 06:19:50 GMT; Path=/
+      - AWSALBCORS=puwBqdRO8wL2Q4kFqu1GY42aKQoWwobp31T7qHLiJluJpvnf2hVL6tuXMQsw0ejFPVaxObB9HUzwz4YL90ciYQUqTfX9cw2P83/7VnQ613N4wodm9m3AvHnXlLOq;
+        Expires=Wed, 04 May 2022 06:19:50 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf4fc05a2c6b8cae8e6fad1b21948945c
+      - NBb04704272368bb30a55490b8efb91b6d
       Pragma:
       - no-cache
       Cache-Control:
@@ -31172,11 +31460,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - C3nmQl5oQCrokY2SAbJk_dkJYeYqz-5NzZ04KXlAYctZ8HPXOS3gFw==
+      - Fo6WNxImzRONQkKklqedc4V32klXs_OKP24Gb0RKiNKVVJau__BoIw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -31404,7 +31692,7 @@ http_interactions:
           }
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:44 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:50 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/asset/DeviceContractInformations
@@ -31420,9 +31708,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIB4NbDbEd+5dGr0ecXW9unw07scgQEbUm2OcIRpnlX+1AiEA3u9Faq7iZEaLQAe/IMKeLnCMxmX+VNjvMGyCOG/aEHk="
+        host date digest",signature="MEUCIGc54ZQ3A5fVTmu2CuoHi463l1FimUPf6VcuZDL9QinoAiEAq3SsI5ARpUe7204nwpWrstewNYJgy/0iSQP5M7+MqS0="
       Date:
-      - Tue, 26 Apr 2022 05:03:44 GMT
+      - Wed, 27 Apr 2022 06:19:50 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -31435,16 +31723,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:45 GMT
+      - Wed, 27 Apr 2022 06:19:51 GMT
       Set-Cookie:
-      - AWSALB=ihmpXv72tJ9xOPXyOGWm/hk8KXt/NvV8zwwNrstLC0y9MpWfAWfsGpf01WBblg/xBMC+X8tfDhIM0mX8vU7wftLoeSPSYN61ISEfotxXrclvwSulYiCcpFvUm5B4;
-        Expires=Tue, 03 May 2022 05:03:45 GMT; Path=/
-      - AWSALBCORS=ihmpXv72tJ9xOPXyOGWm/hk8KXt/NvV8zwwNrstLC0y9MpWfAWfsGpf01WBblg/xBMC+X8tfDhIM0mX8vU7wftLoeSPSYN61ISEfotxXrclvwSulYiCcpFvUm5B4;
-        Expires=Tue, 03 May 2022 05:03:45 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ZVI6QSucBDSWgM2AtKVvthMK3TW8qR0X7y3+unZarhFFsZLsZImhy/V0GFJ+l6cQiJs1FiJHq8iPBB9CkU+jfIhj6IgWtnaqtKI67s32nKb26WRQMEpJHIwMUvey;
+        Expires=Wed, 04 May 2022 06:19:50 GMT; Path=/
+      - AWSALBCORS=ZVI6QSucBDSWgM2AtKVvthMK3TW8qR0X7y3+unZarhFFsZLsZImhy/V0GFJ+l6cQiJs1FiJHq8iPBB9CkU+jfIhj6IgWtnaqtKI67s32nKb26WRQMEpJHIwMUvey;
+        Expires=Wed, 04 May 2022 06:19:50 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd8d242e26134015b55c1a71427270c85
+      - NBc61bb466671a2367f3e03d59b29d75d5
       Pragma:
       - no-cache
       Cache-Control:
@@ -31474,11 +31762,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - t4ioFVYaGzbVH6rUSFfje2Qv3Tz-QtX5qWoSeYcgH5cZwFmLfrP0SA==
+      - jn5GIpzSQAKzRR4FtC94leK-yzPBr-vu1uzyWVvbNEUwa_Rl23Nmzw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -31519,7 +31807,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 0,
-              "ContractUpdatedTime": "2022-04-25T19:34:18.844Z",
+              "ContractUpdatedTime": "2022-04-26T19:14:20.539Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2021-09-23T20:25:04.245Z",
               "DeviceId": "FDO2441072Q",
@@ -31556,7 +31844,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T19:34:19.654Z",
+              "ModTime": "2022-04-26T19:14:21.375Z",
               "Moid": "614ce2a06265722d300a2fba",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -31682,7 +31970,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 0,
-              "ContractUpdatedTime": "2022-04-25T19:34:18.844Z",
+              "ContractUpdatedTime": "2022-04-26T19:14:20.539Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2021-09-23T20:25:04.258Z",
               "DeviceId": "FDO244106VJ",
@@ -31719,7 +32007,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T19:34:19.651Z",
+              "ModTime": "2022-04-26T19:14:21.373Z",
               "Moid": "614ce2a06265722d300a2fbd",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -31845,7 +32133,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 0,
-              "ContractUpdatedTime": "2022-04-25T19:14:17.174Z",
+              "ContractUpdatedTime": "2022-04-26T18:54:20.602Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2021-09-23T21:02:49.27Z",
               "DeviceId": "FOX2510P5HJ",
@@ -31882,7 +32170,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T19:14:17.694Z",
+              "ModTime": "2022-04-26T18:54:21.76Z",
               "Moid": "614ceb796265722d300ba340",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -32008,7 +32296,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 1,
-              "ContractUpdatedTime": "2022-04-25T05:54:16.862Z",
+              "ContractUpdatedTime": "2022-04-27T05:14:03.802Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2022-02-10T20:23:16.499Z",
               "DeviceId": "FCH25057ANX",
@@ -32045,7 +32333,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T05:54:18.154Z",
+              "ModTime": "2022-04-27T05:14:04.85Z",
               "Moid": "620574346265722d307aad85",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -32172,7 +32460,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 0,
-              "ContractUpdatedTime": "2022-04-25T09:04:40.938Z",
+              "ContractUpdatedTime": "2022-04-26T08:44:54.36Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2022-04-12T14:37:29.703Z",
               "DeviceId": "FCH250671HR",
@@ -32209,7 +32497,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T09:04:41.842Z",
+              "ModTime": "2022-04-26T08:44:54.478Z",
               "Moid": "62558ea96265722d30dbc05b",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -32336,7 +32624,7 @@ http_interactions:
               "ContractStatus": "Not Covered",
               "ContractStatusReason": "",
               "ContractUnavailableRetryCount": 0,
-              "ContractUpdatedTime": "2022-04-25T16:36:56.693Z",
+              "ContractUpdatedTime": "2022-04-26T16:24:20.957Z",
               "CoveredProductLineEndDate": "",
               "CreateTime": "2022-04-25T16:36:41.966Z",
               "DeviceId": "FCH250671KU",
@@ -32373,7 +32661,7 @@ http_interactions:
               "ItemType": "CHASSIS",
               "MaintenancePurchaseOrderNumber": "",
               "MaintenanceSalesOrderNumber": "",
-              "ModTime": "2022-04-25T16:36:56.714Z",
+              "ModTime": "2022-04-26T16:24:22.247Z",
               "Moid": "6266ce196265722d30834541",
               "ObjectType": "asset.DeviceContractInformation",
               "Owners": [
@@ -32469,7 +32757,7 @@ http_interactions:
           ]
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:45 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:51 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/equipment/LocatorLeds/62057dfe6176752d36708b2a
@@ -32485,9 +32773,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCICvd/DTxGkwXJvC2URAwrdOEyf25OM+IS+hGgdkE/YvZAiBskJHzxmH4Guv9a+UJj9ap4nAiWMDBYHV2AmaXDh7S9Q=="
+        host date digest",signature="MEQCIBt/vytuj6pjK5M61eurC5te0ZhECE7af6A56qIr4F1WAiAfHEksmQ67jNF6dGpz7JpM4XBXN1j3F32Q4ya9k7kumg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:45 GMT
+      - Wed, 27 Apr 2022 06:19:51 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -32500,16 +32788,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:45 GMT
+      - Wed, 27 Apr 2022 06:19:51 GMT
       Set-Cookie:
-      - AWSALB=DefGXY1iISz3swTUiFVIsTzSHD78TZGQlDsI9hcFx6SiPcj9kkfkGK0L8NpI33qLuf97Q2oSzM9KzuV7FeSzbjjM2fWTp0W5oN7pb3iuvLuUDHf2IQxdd4qxQ85g;
-        Expires=Tue, 03 May 2022 05:03:45 GMT; Path=/
-      - AWSALBCORS=DefGXY1iISz3swTUiFVIsTzSHD78TZGQlDsI9hcFx6SiPcj9kkfkGK0L8NpI33qLuf97Q2oSzM9KzuV7FeSzbjjM2fWTp0W5oN7pb3iuvLuUDHf2IQxdd4qxQ85g;
-        Expires=Tue, 03 May 2022 05:03:45 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=U/voyFxcALxGPKcxcMpU32/WSADtZv17TS1q7yRzQ7jdT7WuTmW/5/9H1k7RBv29v7YMpwFTnV9CPzlQEHOy+gkHC0TLjnRKHmKVQ12qrX2S98p6EeHsF36wOzZg;
+        Expires=Wed, 04 May 2022 06:19:51 GMT; Path=/
+      - AWSALBCORS=U/voyFxcALxGPKcxcMpU32/WSADtZv17TS1q7yRzQ7jdT7WuTmW/5/9H1k7RBv29v7YMpwFTnV9CPzlQEHOy+gkHC0TLjnRKHmKVQ12qrX2S98p6EeHsF36wOzZg;
+        Expires=Wed, 04 May 2022 06:19:51 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb3a988dd45244e944eff95d453367b42
+      - NB3d63bc0cc435b2ecee02ad6af1dc9103
       Pragma:
       - no-cache
       Cache-Control:
@@ -32539,11 +32827,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 6-mvHg9ip8NCC129wNskngmu72qtTNqBKnsi3x-xIY5WvWBthV3fVg==
+      - o45Oat0_bFYKXmzqcYXHldJvtia1FgNDZbnXwyFRdpOElKc_qbr0tw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -32620,7 +32908,7 @@ http_interactions:
           "Tags": []
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:45 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:51 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/6205743e6176752d366ee76e
@@ -32636,9 +32924,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIBW10vC9w4szoL1osAHigmPZb/yXgM1WYEqCOx8vP6MyAiAYdGarGvgqUGnXzlNoc6O8XCLknm6PG21ChRIsaHSSfg=="
+        host date digest",signature="MEYCIQCIVuJiC2FRF3CtG67LNBt+hdFM3Qf4+LfB7tIKl7lxSAIhAII2EoXPE5dyCWFWDuL0JYO14mRsY2WvUkSxFUPzuW7H"
       Date:
-      - Tue, 26 Apr 2022 05:03:45 GMT
+      - Wed, 27 Apr 2022 06:19:51 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -32651,16 +32939,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:45 GMT
+      - Wed, 27 Apr 2022 06:19:51 GMT
       Set-Cookie:
-      - AWSALB=RWkzOzHnuvYLGNplPumjF3IvfaXwXuOptwsIri3Xmbvfy3pVT+oy5hgZdzeghXqeUl7htd/TRB9d0R8CGQ2U5m0jBGN681wrJbvSvlowsuDUK81XyRzkjp6TiVGR;
-        Expires=Tue, 03 May 2022 05:03:45 GMT; Path=/
-      - AWSALBCORS=RWkzOzHnuvYLGNplPumjF3IvfaXwXuOptwsIri3Xmbvfy3pVT+oy5hgZdzeghXqeUl7htd/TRB9d0R8CGQ2U5m0jBGN681wrJbvSvlowsuDUK81XyRzkjp6TiVGR;
-        Expires=Tue, 03 May 2022 05:03:45 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=IHqEz/4HLQWyMUH9/O+GS7whAlmauWe7LXEhZAbk2KYeITgtDoDKgT+PDILok4miU7ApopvmFW7R3Tft0W1HqLeX1I1dV4IaCO9wRoYJ5FOgP0kjjM9CF4/CjMh0;
+        Expires=Wed, 04 May 2022 06:19:51 GMT; Path=/
+      - AWSALBCORS=IHqEz/4HLQWyMUH9/O+GS7whAlmauWe7LXEhZAbk2KYeITgtDoDKgT+PDILok4miU7ApopvmFW7R3Tft0W1HqLeX1I1dV4IaCO9wRoYJ5FOgP0kjjM9CF4/CjMh0;
+        Expires=Wed, 04 May 2022 06:19:51 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB28e4bdf7278528ecc0402c1f914645b2
+      - NBef27c6b73834378db05fc53f43f9abb8
       Pragma:
       - no-cache
       Cache-Control:
@@ -32690,11 +32978,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - hbUg_LW3Vsij8cV87yPdJuWN13f7Anih7Bvi9X_Y1dzY8TqtNAL3kQ==
+      - djYsfzM-ZFpwS0VNGTkcpiPru-ebY9F-IeKWbaIxOPsmY7-05WvWtw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -32922,7 +33210,7 @@ http_interactions:
           }
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:45 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:51 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Boards/620587946176752d3672361d
@@ -32938,9 +33226,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCO9diAEtTY7WqZHJzEbL95UxJKU/ZRbBmfzw+d/JcsRQIgFoik5GXOVYsJSxV1ScoOoBvZ8gyQASlNZKL2SwkUyxA="
+        host date digest",signature="MEUCIEZ005aayfZhoP214KQKFRgwb3u+dUh8SWevavwEV4o3AiEAistgfbUyzqu0MiJOLcoPLJlaOlo+WOnzR0uS8IYJkms="
       Date:
-      - Tue, 26 Apr 2022 05:03:45 GMT
+      - Wed, 27 Apr 2022 06:19:51 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -32953,16 +33241,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:45 GMT
+      - Wed, 27 Apr 2022 06:19:51 GMT
       Set-Cookie:
-      - AWSALB=E4tk3RSoJIKrvgnQfHknejYvu2fzX01TTBFwCMMz4JNoRXHXjHLxDyxkpbpTaFKf5tuYgySpZmk7OTYSPZYH+qs/DmMgMv7mFzGASoE8SCY6DkB1D6mjqEN9oH5r;
-        Expires=Tue, 03 May 2022 05:03:45 GMT; Path=/
-      - AWSALBCORS=E4tk3RSoJIKrvgnQfHknejYvu2fzX01TTBFwCMMz4JNoRXHXjHLxDyxkpbpTaFKf5tuYgySpZmk7OTYSPZYH+qs/DmMgMv7mFzGASoE8SCY6DkB1D6mjqEN9oH5r;
-        Expires=Tue, 03 May 2022 05:03:45 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=PyBd1mWrvtiITfQycQ7Hmt5T2tAfjaBCqcuC00Di8hA4AcCUZQK5U91Vf10WHsWPLgLQz6738zim93UsN4tZCTIrMOwdWeH6vg6HwcgqdHseeIhh7op4vtknkDDn;
+        Expires=Wed, 04 May 2022 06:19:51 GMT; Path=/
+      - AWSALBCORS=PyBd1mWrvtiITfQycQ7Hmt5T2tAfjaBCqcuC00Di8hA4AcCUZQK5U91Vf10WHsWPLgLQz6738zim93UsN4tZCTIrMOwdWeH6vg6HwcgqdHseeIhh7op4vtknkDDn;
+        Expires=Wed, 04 May 2022 06:19:51 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3175034799f2e25da85154805b65ee9e
+      - NBdd45a060fdfe3e4bb8a02417d463ed69
       Pragma:
       - no-cache
       Cache-Control:
@@ -32992,11 +33280,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Ybcu7qF1KP71ZlJ_PuhHYNZoTGmfsy_ScVHD4CC92Dlxbv9fKlK6gw==
+      - aE8Ar_aG3hLrKh-Db-oXcMEbkdyPOnGAbFcIl52-bqkix-RUBO0cPg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -33124,7 +33412,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:45 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:51 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/adapter/Units/620587956176752d3672375f
@@ -33140,9 +33428,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHU1na2Ht24Ys8HuGJ+f8p5dLCEfld9FDTb/YMgIqHBtAiEA+JIWdkY4RNpgYwD6WrqnFIXjWU6YMoowYzUPk5fXOv4="
+        host date digest",signature="MEQCIAMoEAm2QfeJJ1IRl1GIqrHWPk5padw/A35vXcMJUzmBAiBl9mQ6NEzgQ3SXb5JGGPzom0TX/PwvFk7VnP2hzN/ByA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:45 GMT
+      - Wed, 27 Apr 2022 06:19:51 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -33155,16 +33443,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:46 GMT
+      - Wed, 27 Apr 2022 06:19:52 GMT
       Set-Cookie:
-      - AWSALB=/qau9fcapho3fACSBIJ/gGWXmtk5YKlb82ga4AUF3pCzZIlhRNtUyNR5kFqsef4UiDwAAMQr/m5QbiFxpiCMNxyp3L4BUenoKC/1pGwlVDM9I9niRaJ1qWRHvPwZ;
-        Expires=Tue, 03 May 2022 05:03:46 GMT; Path=/
-      - AWSALBCORS=/qau9fcapho3fACSBIJ/gGWXmtk5YKlb82ga4AUF3pCzZIlhRNtUyNR5kFqsef4UiDwAAMQr/m5QbiFxpiCMNxyp3L4BUenoKC/1pGwlVDM9I9niRaJ1qWRHvPwZ;
-        Expires=Tue, 03 May 2022 05:03:46 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=puKynqryfhEkFudxTpQmH40uXEk714BsGJP52z/j0nyPENOnuVbNIpxOrj/zrZXAfSfB+/oNlcCl//8CLUR8qt5+5bSb0521m3IEqzc7D6+ptHJvertpt1XqWRuN;
+        Expires=Wed, 04 May 2022 06:19:52 GMT; Path=/
+      - AWSALBCORS=puKynqryfhEkFudxTpQmH40uXEk714BsGJP52z/j0nyPENOnuVbNIpxOrj/zrZXAfSfB+/oNlcCl//8CLUR8qt5+5bSb0521m3IEqzc7D6+ptHJvertpt1XqWRuN;
+        Expires=Wed, 04 May 2022 06:19:52 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6634d8c64fad54dd1494f44c403d7216
+      - NB49c96b38b7c011fc68d5cd3c47c2bc5e
       Pragma:
       - no-cache
       Cache-Control:
@@ -33194,11 +33482,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - QN7DMzkqj_NiQSh-j4GkW0PrPRzWEZCkjRaPXOBWs-QXXjAGCS_f5g==
+      - MlyUSZJahuQt2ZYhPdmWcUabH84RgO2eGOpbuRcfT9JKDf2zL3tOyA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -33344,7 +33632,7 @@ http_interactions:
           "Vid": ""
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:46 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:52 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/asset/DeviceRegistrations/62558ea96f72612d33c6b0c9
@@ -33360,9 +33648,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCCIq4Tok0qu0pLxwloq9vXTShfZZXbMa+iFTN69IV8kgIgckFJe04nVGyADXD1jFW1e0IElfWexYQuT1+5gDNFfcA="
+        host date digest",signature="MEUCIQDGFcgjhZaP7FtW6FCJQo2fM5Kp4E5sDdTN3dlFYOApOQIgaXzKryFlKINrS8flwmgwBBvRgtIMefXdh8FTrMDcOnE="
       Date:
-      - Tue, 26 Apr 2022 05:03:46 GMT
+      - Wed, 27 Apr 2022 06:19:52 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -33375,16 +33663,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:46 GMT
+      - Wed, 27 Apr 2022 06:19:52 GMT
       Set-Cookie:
-      - AWSALB=u6fQ4yacndTj9YvbkjYWer9qlZ4wxhli2QZcFp8RHUW85AtdWRQMEoOiNilxJxO4OnNsUO/C/x4ywE9kyek5oheb/jCIUiBI74CAMrPs4D/f5UeJ8LhnCAP5Dufn;
-        Expires=Tue, 03 May 2022 05:03:46 GMT; Path=/
-      - AWSALBCORS=u6fQ4yacndTj9YvbkjYWer9qlZ4wxhli2QZcFp8RHUW85AtdWRQMEoOiNilxJxO4OnNsUO/C/x4ywE9kyek5oheb/jCIUiBI74CAMrPs4D/f5UeJ8LhnCAP5Dufn;
-        Expires=Tue, 03 May 2022 05:03:46 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=Rw+HdFoY++QR4LQfAsFga6eoxH89NrV8OydOVTZAJi2ndotKcNoYs5snKyCkGpr9NIVhJeRL48/drukvJD+WlmeGjHR0q7mqjzOfaIcb27z8IdfNM9kQ8jL7Un1D;
+        Expires=Wed, 04 May 2022 06:19:52 GMT; Path=/
+      - AWSALBCORS=Rw+HdFoY++QR4LQfAsFga6eoxH89NrV8OydOVTZAJi2ndotKcNoYs5snKyCkGpr9NIVhJeRL48/drukvJD+WlmeGjHR0q7mqjzOfaIcb27z8IdfNM9kQ8jL7Un1D;
+        Expires=Wed, 04 May 2022 06:19:52 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB64b5b9eede8464d441729e3947782697
+      - NB0598c01e2fbe597d605052bc41b5cf5a
       Pragma:
       - no-cache
       Cache-Control:
@@ -33414,11 +33702,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 28xjXFA7S6-eZ0Synsquj-yf5cGHzG6NVac5aqd7PE1fLLeX_ULuXA==
+      - ni1f0hDjLcV9dcvQuK48xlknDueu8OIUmCt09Oku-nkyzetbC0k6AA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -33532,7 +33820,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:46 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:52 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/62558eb26176752d36f43a77
@@ -33548,9 +33836,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQC8ovNelRoZ7sk0oLE14L7xLF1LRx1N/6fjEcCTGATzUwIgcvA/24jcOocSMtFz748VDAxelGT4e/Po+yJQYeBv1pU="
+        host date digest",signature="MEUCIQDbQiv1waVS+RRmXQrcqJGCRCWE1DRUYc6kOv6tGlWEcwIgUZzrz14+BcvOf4I75DKoc+Ep4Ui/Ow+e3Oj5jbZ6qt8="
       Date:
-      - Tue, 26 Apr 2022 05:03:46 GMT
+      - Wed, 27 Apr 2022 06:19:52 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -33563,16 +33851,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:46 GMT
+      - Wed, 27 Apr 2022 06:19:52 GMT
       Set-Cookie:
-      - AWSALB=PNFq2EB2aok2rwuasFz9+NFhCGYKZI3EftLw+OnU//Bhj4Y4GpNrITujrRii1jYqJJSp0CLHNlHdJZ7RJ006Bvb26hcP5YmjtH2Pv0idqFJx2W/VpTma1Wd6Svb/;
-        Expires=Tue, 03 May 2022 05:03:46 GMT; Path=/
-      - AWSALBCORS=PNFq2EB2aok2rwuasFz9+NFhCGYKZI3EftLw+OnU//Bhj4Y4GpNrITujrRii1jYqJJSp0CLHNlHdJZ7RJ006Bvb26hcP5YmjtH2Pv0idqFJx2W/VpTma1Wd6Svb/;
-        Expires=Tue, 03 May 2022 05:03:46 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ZA6X8HHtqzPlDhI+bhAs1XUxGLlTtxf9THkuQD8Bc1NZtUj8sGm97mrjJHLz6ft+ywgkxOsOJLKH1XE0+1e8sg90u/4oQ7KYdXxq933h0Sfzmktv4vXhYztXClon;
+        Expires=Wed, 04 May 2022 06:19:52 GMT; Path=/
+      - AWSALBCORS=ZA6X8HHtqzPlDhI+bhAs1XUxGLlTtxf9THkuQD8Bc1NZtUj8sGm97mrjJHLz6ft+ywgkxOsOJLKH1XE0+1e8sg90u/4oQ7KYdXxq933h0Sfzmktv4vXhYztXClon;
+        Expires=Wed, 04 May 2022 06:19:52 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0f05ba58860f5f72af86ebe025fac1ac
+      - NB1cab98c8d6e9196865f8e54b9fee6c3a
       Pragma:
       - no-cache
       Cache-Control:
@@ -33602,11 +33890,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - w1B0lkQCQNT8j_0cuhzG72gW-iB0eQhcA-YbiDF6l_MkC2eKzAP_Jg==
+      - ZpnZZ1n9prCYEoVmXksRX6hM5qvh79unbF16B29yuMR7NiubGB2Lig==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -33823,7 +34111,7 @@ http_interactions:
           "Vmedia": null
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:46 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:52 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/equipment/LocatorLeds/62558eb96176752d36f43d12
@@ -33839,9 +34127,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCkJkexAJLhUxtIIRKfCmqy/tVtdnoOgMyflZLwFV5ckAIhALqto7vot1SsHVaLQaEZhihl35+9oaL/Lv05lHnnCAym"
+        host date digest",signature="MEUCIBsjNbg4+gxNvmLV9osCc72H6fjAfifQqA9yqXFLkuCHAiEA1zhPjtf7gk6SAYpJOuEdFTfL88pQCPaY1Y5pNRug9Gk="
       Date:
-      - Tue, 26 Apr 2022 05:03:46 GMT
+      - Wed, 27 Apr 2022 06:19:52 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -33854,16 +34142,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:46 GMT
+      - Wed, 27 Apr 2022 06:19:52 GMT
       Set-Cookie:
-      - AWSALB=KE2lvw1VGXoIEnr9KWdIKBQjZHIIdI09pZUQ/h6jEPou5scQ1it5Aj9xYFTIxiXYZGlute2ry6EdRAMk+rPt4Rz8mms/YDs3yiucoZquWo8OLvL7Rn3NcH2QVeB0;
-        Expires=Tue, 03 May 2022 05:03:46 GMT; Path=/
-      - AWSALBCORS=KE2lvw1VGXoIEnr9KWdIKBQjZHIIdI09pZUQ/h6jEPou5scQ1it5Aj9xYFTIxiXYZGlute2ry6EdRAMk+rPt4Rz8mms/YDs3yiucoZquWo8OLvL7Rn3NcH2QVeB0;
-        Expires=Tue, 03 May 2022 05:03:46 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=fGfN47ns+E5cygiUm+mGRaO7SulxpOlByhywzu5NhEj/K6s6AixhzJJLe87XGeOaEUW4n5aLFqQUIH2AjgT5TqBGjTdb/R8aMABfgGmLrbjBgtuDZhKKfMEHHbKk;
+        Expires=Wed, 04 May 2022 06:19:52 GMT; Path=/
+      - AWSALBCORS=fGfN47ns+E5cygiUm+mGRaO7SulxpOlByhywzu5NhEj/K6s6AixhzJJLe87XGeOaEUW4n5aLFqQUIH2AjgT5TqBGjTdb/R8aMABfgGmLrbjBgtuDZhKKfMEHHbKk;
+        Expires=Wed, 04 May 2022 06:19:52 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa90c87c8270a84d5abf108d30c8bb33d
+      - NB0d6c0618fa620d67018b0b6d5207a338
       Pragma:
       - no-cache
       Cache-Control:
@@ -33893,11 +34181,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - xqX5_AEL82hZoVMAvOuhsSuG6fHcm0SgZ2meXoQ9YhovfaBPr2wn_w==
+      - yeQ3fqRq7j-YNcWwgxq-syRBJtHZkmCvhi_SVl51wQCM8-WQmw4Txg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -33974,7 +34262,7 @@ http_interactions:
           "Tags": []
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:46 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:52 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/62558eb26176752d36f43a77
@@ -33990,9 +34278,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCHd9ZxSlNqiyJ9YmYRGUiVRi5KFsFUVzgop27P04onLQIhANEpbxbN2GyyJ5hrO0+4UNq5dPVHdTLkM3wRs+fqVXNc"
+        host date digest",signature="MEUCIQDqYBLnuZa+PruHbAJ2L6rVZEUL0YUYIO2qQpBlKVVuJQIga0dZrH7BXTF9mI7QAdTz0RaSlxfsfzv28nDXFpkXqrY="
       Date:
-      - Tue, 26 Apr 2022 05:03:46 GMT
+      - Wed, 27 Apr 2022 06:19:52 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -34005,16 +34293,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:46 GMT
+      - Wed, 27 Apr 2022 06:19:52 GMT
       Set-Cookie:
-      - AWSALB=I42zA4X+ceEUNG4NPDgt3Osz4o0bmvXqFXeH89IxiJYIA0+jlft/fPpBEc1JcF1hBXy512WVYURVQsJx4LhPt2Tef+LoBuqetLx/eBPmfUkz251dAzymg30rsewt;
-        Expires=Tue, 03 May 2022 05:03:46 GMT; Path=/
-      - AWSALBCORS=I42zA4X+ceEUNG4NPDgt3Osz4o0bmvXqFXeH89IxiJYIA0+jlft/fPpBEc1JcF1hBXy512WVYURVQsJx4LhPt2Tef+LoBuqetLx/eBPmfUkz251dAzymg30rsewt;
-        Expires=Tue, 03 May 2022 05:03:46 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=W222FaEPErO0eLIdvL8YL3TzxrEqUtP9pZUe4BsdmkxUcp/agmzuJgo5hUPaCgEmK2NUZ5fekNysBejnq11spypqII2VdcLy8PayCGJ72Oc1p2+N38i3diPSS1Ui;
+        Expires=Wed, 04 May 2022 06:19:52 GMT; Path=/
+      - AWSALBCORS=W222FaEPErO0eLIdvL8YL3TzxrEqUtP9pZUe4BsdmkxUcp/agmzuJgo5hUPaCgEmK2NUZ5fekNysBejnq11spypqII2VdcLy8PayCGJ72Oc1p2+N38i3diPSS1Ui;
+        Expires=Wed, 04 May 2022 06:19:52 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBbb2e26c5e8906487ebe89043a606d1b6
+      - NBd0e5c9c9e8e123442b827e9bcc771d93
       Pragma:
       - no-cache
       Cache-Control:
@@ -34044,11 +34332,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - xQ-GmVeV3mFvU8SBUtTm7SLebmlvheoQ-CBVnZpByIVCwFEFXEdfGw==
+      - T4rQvSHRGn9m5yyhB3R4Ih7rc8riLxnQ639AY2sVMf4ZuRrF4RmUfA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -34265,7 +34553,7 @@ http_interactions:
           "Vmedia": null
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:46 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:52 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Boards/625590a56176752d36f4c0a8
@@ -34281,9 +34569,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIFQZXopm2EOZwX4huq2C6oKsQ37ed6QC9Zc33WudOSsNAiBoLNUd8TKwwOnkHEK5tugg2ERLEH6V4Dc1PV1S+kViTA=="
+        host date digest",signature="MEYCIQDRFatmUWZdH2G+ypUd09FQVAE5rhvxCVwo2Xw9cyjdQgIhAIBR9s9iO4Z7A1cILl1RutRIyspab7Ax1+ofM3N/5q2+"
       Date:
-      - Tue, 26 Apr 2022 05:03:46 GMT
+      - Wed, 27 Apr 2022 06:19:52 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -34296,16 +34584,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:53 GMT
       Set-Cookie:
-      - AWSALB=A/j0V/kSgmxEy76t1AwUTSEdKacZSTaloklv5nRbyqmQcYsoU9nBN7T3FcJoh58zAD2wNqECF46tFQ9i8udLWJ2NVdH/HNAmUeASO9T74SsQlATNRrLnfCw1qx1D;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/
-      - AWSALBCORS=A/j0V/kSgmxEy76t1AwUTSEdKacZSTaloklv5nRbyqmQcYsoU9nBN7T3FcJoh58zAD2wNqECF46tFQ9i8udLWJ2NVdH/HNAmUeASO9T74SsQlATNRrLnfCw1qx1D;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=N8TZ0rirU/Q26HV3ql3WUpDGIQJbe8Ci/c5SraHVGVRk3xpCU6wcgfAdFKSFY3+mXz9/U/3MRS5gR4TNDrQlYHxxIcFshpaiVdjyCzYxsX+mILh0ZQ0DkKeDVkmT;
+        Expires=Wed, 04 May 2022 06:19:53 GMT; Path=/
+      - AWSALBCORS=N8TZ0rirU/Q26HV3ql3WUpDGIQJbe8Ci/c5SraHVGVRk3xpCU6wcgfAdFKSFY3+mXz9/U/3MRS5gR4TNDrQlYHxxIcFshpaiVdjyCzYxsX+mILh0ZQ0DkKeDVkmT;
+        Expires=Wed, 04 May 2022 06:19:53 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb8f0b65e7736301a28387d1305c5c3fa
+      - NB0da3db9f854a7eaa64a59e0302f6fd23
       Pragma:
       - no-cache
       Cache-Control:
@@ -34335,11 +34623,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 5Ewey4CXY9zuYq4e-gVlRUYUfoSv5zGRN0fF6OFb0C-N_pk5bbNBow==
+      - KTRoIf9BsKS7YrhFzAMr3ufuSYMmO6gXAyWq2fp0YS5acwpHNITHdQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -34467,7 +34755,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:47 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:53 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/adapter/Units/625590a66176752d36f4c1ce
@@ -34483,9 +34771,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCW/AcFqNk6yGkDCyIenrH9LhyMAi1Zb2kM4/+yrEGAywIhAK/RdE2lmnBOJsO9bZ2O1/TfKTzDST6e4Bs9OrEafgNZ"
+        host date digest",signature="MEQCICh6Mkz8TLNA1HO5ZBbAS9z31SWZAxcdcuJlM+Ke46qeAiAS7h8bpNaVj7KsSPgg2xek0CC1/0QZcVbf2ZtpSQnTvA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:53 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -34498,16 +34786,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:53 GMT
       Set-Cookie:
-      - AWSALB=VXf6+2vx1pMPshd5u7jN5eP51rxJd3hj2a9XBwXpJH201JKJJZcJOEicJXz5ALVoSjetniZLBMrOPnbF0KJkKwIl8K5Mymz/URJk17RVR1f5ARiwvWPknuIcKKI6;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/
-      - AWSALBCORS=VXf6+2vx1pMPshd5u7jN5eP51rxJd3hj2a9XBwXpJH201JKJJZcJOEicJXz5ALVoSjetniZLBMrOPnbF0KJkKwIl8K5Mymz/URJk17RVR1f5ARiwvWPknuIcKKI6;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=tFixksSTUxdsko6EOhjXVzZIZ6rZJDkgsmtx13BdJ2EJy+c+vMcIo91QTBMPLDDjug6M9w7MnMptmB1D16q/RmF65oRm3Tmbe2zbWDVXt5g2Br3i9uC6NW4gZ+Hx;
+        Expires=Wed, 04 May 2022 06:19:53 GMT; Path=/
+      - AWSALBCORS=tFixksSTUxdsko6EOhjXVzZIZ6rZJDkgsmtx13BdJ2EJy+c+vMcIo91QTBMPLDDjug6M9w7MnMptmB1D16q/RmF65oRm3Tmbe2zbWDVXt5g2Br3i9uC6NW4gZ+Hx;
+        Expires=Wed, 04 May 2022 06:19:53 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6d2a77ef98a6cd57dee1d6723779eac9
+      - NBa6680077b7a0568b2946ef1989dbcba5
       Pragma:
       - no-cache
       Cache-Control:
@@ -34537,11 +34825,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - lYOTS6tbw-VFF2-1FzAbldULjnHz05Z5d6XMHPeP2ifAoC-smFiOGA==
+      - Ez8jRrYNlAk8hgUmR9mkqQgHyuD5l8Ndit4Xf9xC95dM5aWW6qGO8w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -34687,7 +34975,7 @@ http_interactions:
           "Vid": ""
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:47 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:53 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/asset/DeviceRegistrations/6266ce196f72612d33dfcc93
@@ -34703,9 +34991,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDZNy9NLS8e5HX4k+BD05FI02TY1OKCpLqIpbAF19BaawIhAPKUZjrIACRdTVNSMwrwXVT/kDmTKjTKjzrTEcOxGuga"
+        host date digest",signature="MEUCIQD8WZ5tW5Dfs7URdLdCNSrJ6rcNrjHE6oP9gPCHXOwmEwIgCnnT/BR9PHLUOTXDMcVGK0NiOAtiVM8sJ+z/8nbX4LI="
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:53 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -34718,16 +35006,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:53 GMT
       Set-Cookie:
-      - AWSALB=fPZjgIsuelKReX54I2YExDzOkm8ZLTXfiFIJ1Aj/SM4irE7oYA33Bb0gufHLmeLEkdeDzzUVI/MJKRylM408G7FEM3YOHcGTB5HLJAj6ixPoh9/4eY1fw2ckxoZx;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/
-      - AWSALBCORS=fPZjgIsuelKReX54I2YExDzOkm8ZLTXfiFIJ1Aj/SM4irE7oYA33Bb0gufHLmeLEkdeDzzUVI/MJKRylM408G7FEM3YOHcGTB5HLJAj6ixPoh9/4eY1fw2ckxoZx;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=AbernsOqJ4klLbBifnyxTzNMDWGAcAVj7zln5xEVEqZyFWUf1YhwyWpyIzMUg60ikWpub8UJFwT26UYN2DIoZNurAi1Bk3raWOUDUitPASjyjwAatBZMOquRc3xn;
+        Expires=Wed, 04 May 2022 06:19:53 GMT; Path=/
+      - AWSALBCORS=AbernsOqJ4klLbBifnyxTzNMDWGAcAVj7zln5xEVEqZyFWUf1YhwyWpyIzMUg60ikWpub8UJFwT26UYN2DIoZNurAi1Bk3raWOUDUitPASjyjwAatBZMOquRc3xn;
+        Expires=Wed, 04 May 2022 06:19:53 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6d09ae73ea9995bcc9f76de58c7af177
+      - NB1eb73b8b3a0df375ee419db776202fc5
       Pragma:
       - no-cache
       Cache-Control:
@@ -34757,11 +35045,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - lN2ZMWmCflc5SRY9F80lYwMpudm6V2MB8CwTSROoDITy1iw5w7YMBA==
+      - S2q-TPvBnQ0sOnhTjqG8QdgDXIcFceCRnm--yfFrWpnR_QAwK3zzPg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -34875,7 +35163,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:47 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:53 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/6266ce226176752d36c8fe12
@@ -34891,9 +35179,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIFzB7+MjPFofmEpSKgCS+3Vfq6MqJyNuDKumduZI9Pt0AiBcT7fuDjcwHYBwXaPs5695sAG378r1ytZEbovcULKxlA=="
+        host date digest",signature="MEUCIQCJIR2/51IvZBuz2pw2BsUKz+IfTQ4gPSAUSQJn+ErXuAIgRwDf0wAGw7sYA22hEtnbSbigIB8PznkbJ9ZJ3f+BswY="
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:53 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -34906,16 +35194,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:53 GMT
       Set-Cookie:
-      - AWSALB=29RSrlB4zy/2Q78sUgNZ7EJYl/PdK5fmmYva3lW5pOMgjlSYgTFCrj5OI+qHEy6JJEz4uUQUpGP81rSX7Sln3pbT4tPv+iVXGgGEfYiF2NH8Uv7E+uM0AmUoizRR;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/
-      - AWSALBCORS=29RSrlB4zy/2Q78sUgNZ7EJYl/PdK5fmmYva3lW5pOMgjlSYgTFCrj5OI+qHEy6JJEz4uUQUpGP81rSX7Sln3pbT4tPv+iVXGgGEfYiF2NH8Uv7E+uM0AmUoizRR;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=YZgdiTFXiAP+IZAB/Gic7S7IblgcrZIieRxEHEL6tSmlzXhot3E/oYyu3O1m3DGJKwjdEsBZx7doWZUIJ6s/CBbUZG7oqoJ2nYxGKNim2McL/P2koFsIWZGHz+L6;
+        Expires=Wed, 04 May 2022 06:19:53 GMT; Path=/
+      - AWSALBCORS=YZgdiTFXiAP+IZAB/Gic7S7IblgcrZIieRxEHEL6tSmlzXhot3E/oYyu3O1m3DGJKwjdEsBZx7doWZUIJ6s/CBbUZG7oqoJ2nYxGKNim2McL/P2koFsIWZGHz+L6;
+        Expires=Wed, 04 May 2022 06:19:53 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3b7109434682d4c7880c83ffdf1284b1
+      - NB21c63736e2152a12431ee9ab567f5697
       Pragma:
       - no-cache
       Cache-Control:
@@ -34945,11 +35233,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ZQ4tAF3rESveLlsZJKwKESmKdxu_OqwNz9Eyhsi904eWfYAMw8pc4A==
+      - svs6SSyZWBjq07mYdMloffyoi-wiUos4sBV8OEC1mKyBbVz2llqT7A==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -35044,23 +35332,7 @@ http_interactions:
           "GraphicsCards": [],
           "HardwareUuid": "D0D77522-FA5B-4B24-A183-66BF636342FE",
           "InventoryDeviceInfo": null,
-          "KvmIpAddresses": [
-            {
-              "Address": "100.66.11.151",
-              "Category": "Equipment",
-              "ClassId": "compute.IpAddress",
-              "DefaultGateway": "100.66.11.129",
-              "Dn": "",
-              "HttpPort": 80,
-              "HttpsPort": 443,
-              "KvmPort": 2068,
-              "KvmVlan": 0,
-              "Name": "Outband",
-              "ObjectType": "compute.IpAddress",
-              "Subnet": "255.255.255.192",
-              "Type": "MgmtInterface"
-            }
-          ],
+          "KvmIpAddresses": [],
           "LocatorLed": {
             "ClassId": "mo.MoRef",
             "Moid": "6266cf0e6176752d36c945d2",
@@ -35076,8 +35348,8 @@ http_interactions:
             "ObjectType": "compute.BladeIdentity",
             "link": "https://www.intersight.com/api/v1/compute/BladeIdentities/614cebe66f62692d30838637"
           },
-          "MgmtIpAddress": "100.66.11.151",
-          "ModTime": "2022-04-26T05:03:41.034Z",
+          "MgmtIpAddress": "",
+          "ModTime": "2022-04-27T05:52:51.686Z",
           "Model": "UCSX-210C-M6",
           "Moid": "6266ce226176752d36c8fe12",
           "Name": "LAB02D02F01-1-3",
@@ -35089,7 +35361,7 @@ http_interactions:
           "NumFcHostInterfaces": 0,
           "NumThreads": 112,
           "ObjectType": "compute.Blade",
-          "OperPowerState": "on",
+          "OperPowerState": "off",
           "OperReason": [],
           "OperState": "",
           "Operability": "",
@@ -35166,7 +35438,7 @@ http_interactions:
           "Vmedia": null
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:47 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:53 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/equipment/LocatorLeds/6266cf0e6176752d36c945d2
@@ -35182,9 +35454,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDBvOmF/Ax8gVvXoL1i1VvqhvycG5C7BQ8shR1boT1L1wIgXBro0mfK1pc9toPnfbbHblQnY6bS94995swbQfGbAA0="
+        host date digest",signature="MEQCIDH98GaufywJh2mK0GNSjt8OQtyWSmkbvHibWxxf50eMAiAmezzvaNxMxHhE70DpCqjk7IIv+GZ33K2vA2GjxGLi8A=="
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:53 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -35197,16 +35469,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:54 GMT
       Set-Cookie:
-      - AWSALB=nHYYIZaTbCtPCdAqQMrAFhCW3i2YA3NhT7s67wG2n2AimkcGFdQtCXm/2ye6tNJyweRYF7VeePm8iVpZItb4IsuBjo0EmrPOmMBxIhvZJ7MRGDkXjZdsO4z817O5;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/
-      - AWSALBCORS=nHYYIZaTbCtPCdAqQMrAFhCW3i2YA3NhT7s67wG2n2AimkcGFdQtCXm/2ye6tNJyweRYF7VeePm8iVpZItb4IsuBjo0EmrPOmMBxIhvZJ7MRGDkXjZdsO4z817O5;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=JCzVEBCfTtyC4Qd6Cmvo6OPEQqVAkz0t3eCpwHsx0JFwkCwMk+CnALwtx9d3Vw2x52wTMgu7b/gxhVun1BloHOeqrsiHYjndmS8+wSzJxUTRHr5XlBk63fLgn9Dg;
+        Expires=Wed, 04 May 2022 06:19:54 GMT; Path=/
+      - AWSALBCORS=JCzVEBCfTtyC4Qd6Cmvo6OPEQqVAkz0t3eCpwHsx0JFwkCwMk+CnALwtx9d3Vw2x52wTMgu7b/gxhVun1BloHOeqrsiHYjndmS8+wSzJxUTRHr5XlBk63fLgn9Dg;
+        Expires=Wed, 04 May 2022 06:19:54 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB57e568ac8acc8852ba3b01ffd08c38dd
+      - NBe8e718ccdf0c4d600cae7852131129f3
       Pragma:
       - no-cache
       Cache-Control:
@@ -35236,11 +35508,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - OOscQxy6enGSrfO99kJn-4MhoUR6gGCMSWA1qHUS01yMYnzEFsHzDA==
+      - B2JrH1HFjZErVESmL1cOaNxNXUzhvYhaBWLZY_GZCREZIXKIGeSDAw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -35276,7 +35548,7 @@ http_interactions:
           "EquipmentChassis": null,
           "EquipmentFex": null,
           "InventoryDeviceInfo": null,
-          "ModTime": "2022-04-26T05:02:26.735Z",
+          "ModTime": "2022-04-27T05:52:51.69Z",
           "Moid": "6266cf0e6176752d36c945d2",
           "ObjectType": "equipment.LocatorLed",
           "OperState": "off",
@@ -35317,7 +35589,7 @@ http_interactions:
           "Tags": []
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:47 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:54 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Blades/6266ce226176752d36c8fe12
@@ -35333,9 +35605,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIDnAIbhqTpyiRKK87qO+6USTAYvK2Hap8rQAUoxhqBfYAiBBK2n6Wr6Titc01+8+7n5GeWt0by60bfV8srNT+to7/Q=="
+        host date digest",signature="MEQCICdIDEmJsDEyf/A9t5Qth4nyK6Tb6w4eJX69cn9+zwUzAiAq0Lx4xK8Sbbof0ONoBWdarhJBFFFiVYgSK37Miuf3HQ=="
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:54 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -35348,16 +35620,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:47 GMT
+      - Wed, 27 Apr 2022 06:19:54 GMT
       Set-Cookie:
-      - AWSALB=JAiiK9mPKeBxYJ/4g7KYSzbOjCnQq/rw9D6D9u3ZbWA+g7+K6PBvYPjXREPytC0Nuf3Nr913eQvnlUhKuW+eU0TD5Kdcwwiuxe1rCiCQT2D2AsYk4H/qzl5t5Tur;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/
-      - AWSALBCORS=JAiiK9mPKeBxYJ/4g7KYSzbOjCnQq/rw9D6D9u3ZbWA+g7+K6PBvYPjXREPytC0Nuf3Nr913eQvnlUhKuW+eU0TD5Kdcwwiuxe1rCiCQT2D2AsYk4H/qzl5t5Tur;
-        Expires=Tue, 03 May 2022 05:03:47 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=KBsyx6Fr8fe/+2QyMbn9ZzxAMZlPlgzcsIqb1NJKq5gk+4CpZUuItgUhescjafrIamzP7IbGY9bQwo+u+8NW3HC9zMARwFoUja3RfMnFhAWq2Pbhk72UZM6g8yCk;
+        Expires=Wed, 04 May 2022 06:19:54 GMT; Path=/
+      - AWSALBCORS=KBsyx6Fr8fe/+2QyMbn9ZzxAMZlPlgzcsIqb1NJKq5gk+4CpZUuItgUhescjafrIamzP7IbGY9bQwo+u+8NW3HC9zMARwFoUja3RfMnFhAWq2Pbhk72UZM6g8yCk;
+        Expires=Wed, 04 May 2022 06:19:54 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb59b38c82c1ae276609ed3a20107d691
+      - NBd668cdd6b592604060c429ddfbb917d5
       Pragma:
       - no-cache
       Cache-Control:
@@ -35387,11 +35659,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 9RaTJoABLPUwcmzcqeY_HW1h0S4pj6RG4xqKL3pqTBh-n_qHJVSjAg==
+      - y1BLBPYd-uhkLRYcKBy0gUW-fwp6KdRWYBDbekT-kw4IaFHvAXDBxg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -35486,23 +35758,7 @@ http_interactions:
           "GraphicsCards": [],
           "HardwareUuid": "D0D77522-FA5B-4B24-A183-66BF636342FE",
           "InventoryDeviceInfo": null,
-          "KvmIpAddresses": [
-            {
-              "Address": "100.66.11.151",
-              "Category": "Equipment",
-              "ClassId": "compute.IpAddress",
-              "DefaultGateway": "100.66.11.129",
-              "Dn": "",
-              "HttpPort": 80,
-              "HttpsPort": 443,
-              "KvmPort": 2068,
-              "KvmVlan": 0,
-              "Name": "Outband",
-              "ObjectType": "compute.IpAddress",
-              "Subnet": "255.255.255.192",
-              "Type": "MgmtInterface"
-            }
-          ],
+          "KvmIpAddresses": [],
           "LocatorLed": {
             "ClassId": "mo.MoRef",
             "Moid": "6266cf0e6176752d36c945d2",
@@ -35518,8 +35774,8 @@ http_interactions:
             "ObjectType": "compute.BladeIdentity",
             "link": "https://www.intersight.com/api/v1/compute/BladeIdentities/614cebe66f62692d30838637"
           },
-          "MgmtIpAddress": "100.66.11.151",
-          "ModTime": "2022-04-26T05:03:41.034Z",
+          "MgmtIpAddress": "",
+          "ModTime": "2022-04-27T05:52:51.686Z",
           "Model": "UCSX-210C-M6",
           "Moid": "6266ce226176752d36c8fe12",
           "Name": "LAB02D02F01-1-3",
@@ -35531,7 +35787,7 @@ http_interactions:
           "NumFcHostInterfaces": 0,
           "NumThreads": 112,
           "ObjectType": "compute.Blade",
-          "OperPowerState": "on",
+          "OperPowerState": "off",
           "OperReason": [],
           "OperState": "",
           "Operability": "",
@@ -35608,7 +35864,7 @@ http_interactions:
           "Vmedia": null
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:48 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:54 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/compute/Boards/6266d0016176752d36c9870d
@@ -35624,9 +35880,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIEuzhPLvC9KBDWptJnMS2QWvlRtICRPAbOBPeUfLlYQzAiEAxIKyl1HT1uvyWw9yVgqF7MZx6+gMBFjCvNntbXv06PM="
+        host date digest",signature="MEYCIQC3syjEB5lskMbUhNiwrtSYC9LQrgyaSjdwNDmvbE6BdQIhAP0BbckBX5rNFih1sUOGPPfZpGgN7GdVzVYbCLBcnTNJ"
       Date:
-      - Tue, 26 Apr 2022 05:03:48 GMT
+      - Wed, 27 Apr 2022 06:19:54 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -35639,16 +35895,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:48 GMT
+      - Wed, 27 Apr 2022 06:19:54 GMT
       Set-Cookie:
-      - AWSALB=7rkleX/eZsRvLRFpGDqTqB3BZ50XmSPZSOaLsrFDMSBtW63sehttOXc1FvDc0rKNLuAHmNQeqJp3l6er7lawUaIfM9BUxORwUM7Msl2DGJDl+JSIw0zUa1v0OviZ;
-        Expires=Tue, 03 May 2022 05:03:48 GMT; Path=/
-      - AWSALBCORS=7rkleX/eZsRvLRFpGDqTqB3BZ50XmSPZSOaLsrFDMSBtW63sehttOXc1FvDc0rKNLuAHmNQeqJp3l6er7lawUaIfM9BUxORwUM7Msl2DGJDl+JSIw0zUa1v0OviZ;
-        Expires=Tue, 03 May 2022 05:03:48 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=Wu+EIlj2WQQj8QEXxlZMvR9kHjKiNbfQ6Gz0ljTk1qdVQW8xCNuVykLQ0KzxE1spgwaMYqiklMjEUeruhJv4MmROP2U6ESlRyS2JLjALSXyj1OYpo8lKJp7++Lgc;
+        Expires=Wed, 04 May 2022 06:19:54 GMT; Path=/
+      - AWSALBCORS=Wu+EIlj2WQQj8QEXxlZMvR9kHjKiNbfQ6Gz0ljTk1qdVQW8xCNuVykLQ0KzxE1spgwaMYqiklMjEUeruhJv4MmROP2U6ESlRyS2JLjALSXyj1OYpo8lKJp7++Lgc;
+        Expires=Wed, 04 May 2022 06:19:54 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBbcf312b59c4499fce91878c9ad1798ab
+      - NBc86e6eb1e4f9c22a79648efcf4e23988
       Pragma:
       - no-cache
       Cache-Control:
@@ -35678,11 +35934,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 87ysnfY0gBQ_ueXSMBXFp-ySfSWFkvY-6BLgD14zYY7qgLkim6PohA==
+      - l03HNd4rWzmqqkVZKHTWWDIjCd-WqYi8YERlx5WomPEG6NeUheFFSQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -35742,7 +35998,7 @@ http_interactions:
               "link": "https://www.intersight.com/api/v1/memory/Arrays/6266d0016176752d36c98710"
             }
           ],
-          "ModTime": "2022-04-26T05:02:26.695Z",
+          "ModTime": "2022-04-27T05:52:51.645Z",
           "Model": "UCSX-210C-M6",
           "Moid": "6266d0016176752d36c9870d",
           "ObjectType": "compute.Board",
@@ -35810,7 +36066,7 @@ http_interactions:
           "Vendor": "Cisco Systems Inc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:48 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:54 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/adapter/Units/6266d0036176752d36c98837
@@ -35826,9 +36082,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIHyugV6HCKgSPAEUefy4cjpTm8q0POTeUrbrguDnDKhCAiBzDJD5vLZXQN1epx/jqw3rAnwDcCdnghLi3UaNxPTxKg=="
+        host date digest",signature="MEUCIHcjeYC4QMnjVxceS0Y0Us/95c4RKutCgwAfeRLZYlgxAiEAg//KeLoD42y9cmfI9cdUWsr1zMvGnGZe6K7YDHzAOoo="
       Date:
-      - Tue, 26 Apr 2022 05:03:48 GMT
+      - Wed, 27 Apr 2022 06:19:54 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -35841,16 +36097,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:48 GMT
+      - Wed, 27 Apr 2022 06:19:54 GMT
       Set-Cookie:
-      - AWSALB=9/G2i5sIrh/MmcUaZQu2lKQJTVHPudrmFUrM8NCyd10AzT8PSB4OfYZkp44k13TlfZX/7pWhAcVGH4U6XXuY8sYUMmub0o6t62HjBwpC/aGWtJ0lHPKpg8gas3m/;
-        Expires=Tue, 03 May 2022 05:03:48 GMT; Path=/
-      - AWSALBCORS=9/G2i5sIrh/MmcUaZQu2lKQJTVHPudrmFUrM8NCyd10AzT8PSB4OfYZkp44k13TlfZX/7pWhAcVGH4U6XXuY8sYUMmub0o6t62HjBwpC/aGWtJ0lHPKpg8gas3m/;
-        Expires=Tue, 03 May 2022 05:03:48 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=VCS4U2cjB4O02qWjR4SdkPzRE4V783ZxLzgqmkvuESSHrO7nKI6nFcuGECs6UFja/ntl/kbCcCNlRU7ieJ6w/VIgPFxPr5d0Te1l6q33ps/1cNMuRCkGZYUpgd77;
+        Expires=Wed, 04 May 2022 06:19:54 GMT; Path=/
+      - AWSALBCORS=VCS4U2cjB4O02qWjR4SdkPzRE4V783ZxLzgqmkvuESSHrO7nKI6nFcuGECs6UFja/ntl/kbCcCNlRU7ieJ6w/VIgPFxPr5d0Te1l6q33ps/1cNMuRCkGZYUpgd77;
+        Expires=Wed, 04 May 2022 06:19:54 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB234e72431c620893c6af087b58c3bda3
+      - NBfbeac0895f3bb311c0ba8e2b4f016970
       Pragma:
       - no-cache
       Cache-Control:
@@ -35880,11 +36136,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 7mutGVPZ1qF3K1MNLw0Ha8LPWHu-pLmhGBkcCOnqYwJv-Cg5_FDFnQ==
+      - _AkpPfTvhqJTywzbDP72QfULWtVY0fdFaPRE9GCvb7w3rUzcI3LlCw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -35965,7 +36221,7 @@ http_interactions:
           "HostIscsiIfs": [],
           "Integrated": "",
           "InventoryDeviceInfo": null,
-          "ModTime": "2022-04-25T16:45:00.111Z",
+          "ModTime": "2022-04-26T11:34:06.615Z",
           "Model": "UCSX-V4-Q25GML",
           "Moid": "6266d0036176752d36c98837",
           "ObjectType": "adapter.Unit",
@@ -36017,7 +36273,7 @@ http_interactions:
           "Vid": ""
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:48 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:54 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/equipment/LocatorLeds/614cebe56176752d35abb3e6
@@ -36033,9 +36289,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIACw3jlYEi4pQPebVHsYGDioZAlWCcj9odMTqEnoKAZTAiBYm7/I33mz1TOldozTDXiTQej6JXQzRjk9+LAVEInP3Q=="
+        host date digest",signature="MEQCICDAGyYmUnnHnX+2R8TlL3TqchVjGeh8/XAIgn8YvdrEAiB3PFN0YyYfkSZSZovILkEPwkb6nYANL428HlBSTZJdzw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:48 GMT
+      - Wed, 27 Apr 2022 06:19:54 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -36048,16 +36304,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:48 GMT
+      - Wed, 27 Apr 2022 06:19:55 GMT
       Set-Cookie:
-      - AWSALB=nboVm76aqpPCg2z/qbKTLyCU/YOhuN81UzApbb4H8fMvppTug5bk0oYJ9omNImciSdaYKlkHQcSRqOoEHuifB7MT5RQv4kcFw8Qj4S2HmmUlkv6obnhfwm2fTL9A;
-        Expires=Tue, 03 May 2022 05:03:48 GMT; Path=/
-      - AWSALBCORS=nboVm76aqpPCg2z/qbKTLyCU/YOhuN81UzApbb4H8fMvppTug5bk0oYJ9omNImciSdaYKlkHQcSRqOoEHuifB7MT5RQv4kcFw8Qj4S2HmmUlkv6obnhfwm2fTL9A;
-        Expires=Tue, 03 May 2022 05:03:48 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=+cO6wsRtSlfUzH1rtKMCqIxcqwElgPxTMHRtkh1y+OCcV85yXCKcR6ECzzQxn0b+7yjFeNH8Hzcitisu2QMtxN/LAE2aPlYPGenzvUIWRJJ2m8cf/4q378TGeirV;
+        Expires=Wed, 04 May 2022 06:19:55 GMT; Path=/
+      - AWSALBCORS=+cO6wsRtSlfUzH1rtKMCqIxcqwElgPxTMHRtkh1y+OCcV85yXCKcR6ECzzQxn0b+7yjFeNH8Hzcitisu2QMtxN/LAE2aPlYPGenzvUIWRJJ2m8cf/4q378TGeirV;
+        Expires=Wed, 04 May 2022 06:19:55 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB63fb7c2672f1f984a5a7f46c251b1828
+      - NB89dd4685420ad5a7da221ea4d8c4bb82
       Pragma:
       - no-cache
       Cache-Control:
@@ -36087,11 +36343,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Mw2lFLRe01Q6KLoj9Ceq5c_tXG9Ggo2iyDCEpf6KiOeN3cqY3EfqTg==
+      - sthyaMXwuV3uL2uM32TbY57SsuOsXTqv_q1RNJ31JXAFwtX4JfiPyQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -36161,10 +36417,10 @@ http_interactions:
           "Tags": []
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:48 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:55 GMT
 - request:
     method: get
-    uri: https://intersight.com/api/v1/equipment/SwitchCards/614ce25a4630312d42bf1d1a
+    uri: https://intersight.com/api/v1/network/ElementSummaries/614ce2a16176752d35a7ec96
     body:
       encoding: US-ASCII
       string: ''
@@ -36177,9 +36433,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCG1t70k4LOxG1+7FqZAjxfS1wTmeFTxD/OD2yORDaf/AIhAOZQxV4/w4T/V+A3PRSyStjTnG+GXtjlKV4ZMqDOZLex"
+        host date digest",signature="MEYCIQD1aEmEDkqdVa0d0La450f7om97Mw2z6k69+rp4o/RoVgIhAL2J5FSu8deaTnnyRj4POiLP28dCje5nD5xcW3MIvx26"
       Date:
-      - Tue, 26 Apr 2022 05:03:48 GMT
+      - Wed, 27 Apr 2022 06:19:55 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -36192,16 +36448,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:49 GMT
+      - Wed, 27 Apr 2022 06:19:55 GMT
       Set-Cookie:
-      - AWSALB=zGbiHUdkNKZkPveycsU5rQBUnJhpQogrqbdvLYwXOhJDKL/fDLcpgitioT0znhgIeJDUAuagy93IfQz2oISylcQBP2GbIZ7JXkFdZC2yOFDXeg0N4IsKvzUXZ83G;
-        Expires=Tue, 03 May 2022 05:03:49 GMT; Path=/
-      - AWSALBCORS=zGbiHUdkNKZkPveycsU5rQBUnJhpQogrqbdvLYwXOhJDKL/fDLcpgitioT0znhgIeJDUAuagy93IfQz2oISylcQBP2GbIZ7JXkFdZC2yOFDXeg0N4IsKvzUXZ83G;
-        Expires=Tue, 03 May 2022 05:03:49 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=j3zcopdg1/Gh0V62BKz35/yQOMDbWzQ4pao/+znobc+LdKRGUVbJfT2jBye9SPjGXRqtE2ZDcf7eWZ334GlXa7DSAFRJI+8yZbEWiLS36K1mfEvL8PkirvyLM0gf;
+        Expires=Wed, 04 May 2022 06:19:55 GMT; Path=/
+      - AWSALBCORS=j3zcopdg1/Gh0V62BKz35/yQOMDbWzQ4pao/+znobc+LdKRGUVbJfT2jBye9SPjGXRqtE2ZDcf7eWZ334GlXa7DSAFRJI+8yZbEWiLS36K1mfEvL8PkirvyLM0gf;
+        Expires=Wed, 04 May 2022 06:19:55 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB2b6467be30cd261e20b6f098c27f3488
+      - NBebbf3612e1794527f59adf83baf98de8
       Pragma:
       - no-cache
       Cache-Control:
@@ -36231,11 +36487,187 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - LX3lzZ1szndYK-hnUUhi7ZDRFpbVQtXDv0qSjRo6tykn5VZl1iDYHA==
+      - YjIB-p7YXpMKXt2kI8qMPlmloz1iAx4F-tje2UkuVcuPbpEZZlDGdw==
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "AccountMoid": "5ed10e437564612d3352cc2d",
+          "AdminEvacState": "disabled",
+          "AdminInbandInterfaceState": "disabled",
+          "AlarmSummary": {
+            "ClassId": "compute.AlarmSummary",
+            "Critical": 0,
+            "ObjectType": "compute.AlarmSummary",
+            "Warning": 1
+          },
+          "Ancestors": [],
+          "AvailableMemory": "",
+          "Chassis": "",
+          "ClassId": "network.ElementSummary",
+          "ConfModTs": "",
+          "ConfModTsBackup": "",
+          "CreateTime": "2021-09-23T20:25:05.943Z",
+          "DeviceMoId": "614ce29f6f72612d307f5ed4",
+          "Dn": "switch-FDO244106VJ",
+          "DomainGroupMoid": "5ed10e437564612d3352cc37",
+          "EthernetMode": "",
+          "EthernetSwitchingMode": "end-host",
+          "FaultSummary": 0,
+          "FcMode": "",
+          "FcSwitchingMode": "end-host",
+          "Firmware": "",
+          "InbandIpAddress": "0.0.0.0",
+          "InbandIpGateway": "0.0.0.0",
+          "InbandIpMask": "255.255.255.0",
+          "InbandVlan": 0,
+          "Ipv4Address": "",
+          "ManagementMode": "Intersight",
+          "ModTime": "2022-04-27T06:18:30.869Z",
+          "Model": "UCS-FI-6454",
+          "Moid": "614ce2a16176752d35a7ec96",
+          "Name": "LAB02D02F01 FI-B",
+          "NumEtherPorts": 54,
+          "NumEtherPortsConfigured": 6,
+          "NumEtherPortsLinkUp": 4,
+          "NumExpansionModules": 0,
+          "NumFcPorts": 0,
+          "NumFcPortsConfigured": 0,
+          "NumFcPortsLinkUp": 0,
+          "ObjectType": "network.ElementSummary",
+          "OperEvacState": "disabled",
+          "Operability": "online",
+          "OutOfBandIpAddress": "100.66.11.142",
+          "OutOfBandIpGateway": "100.66.11.129",
+          "OutOfBandIpMask": "255.255.255.192",
+          "OutOfBandIpv4Address": "",
+          "OutOfBandIpv4Gateway": "",
+          "OutOfBandIpv4Mask": "",
+          "OutOfBandIpv6Address": "",
+          "OutOfBandIpv6Gateway": "",
+          "OutOfBandIpv6Prefix": "",
+          "OutOfBandMac": "00:3A:9C:DA:78:C0",
+          "Owners": [
+            "5ed10e437564612d3352cc2d",
+            "614ce29f6f72612d307f5ed4"
+          ],
+          "PartNumber": "",
+          "PermissionResources": [
+            {
+              "ClassId": "mo.MoRef",
+              "Moid": "5ed10e456972652d30b39b49",
+              "ObjectType": "organization.Organization",
+              "link": "https://www.intersight.com/api/v1/organization/Organizations/5ed10e456972652d30b39b49"
+            },
+            {
+              "ClassId": "mo.MoRef",
+              "Moid": "614caf8f6972652d30d65a53",
+              "ObjectType": "organization.Organization",
+              "link": "https://www.intersight.com/api/v1/organization/Organizations/614caf8f6972652d30d65a53"
+            }
+          ],
+          "Presence": "",
+          "RegisteredDevice": {
+            "ClassId": "mo.MoRef",
+            "Moid": "614ce29f6f72612d307f5ed4",
+            "ObjectType": "asset.DeviceRegistration",
+            "link": "https://www.intersight.com/api/v1/asset/DeviceRegistrations/614ce29f6f72612d307f5ed4"
+          },
+          "Revision": "0",
+          "Rn": "",
+          "Serial": "FDO244106VJ",
+          "SharedScope": "",
+          "SourceObjectType": "network.Element",
+          "Status": "",
+          "SwitchId": "B",
+          "SwitchType": "FabricInterconnect",
+          "SystemUpTime": "",
+          "Tags": [],
+          "Thermal": "ok",
+          "TotalMemory": 64265,
+          "Vendor": "Cisco Systems, Inc.",
+          "Version": "9.3(5)I42(1f)"
+        }
+    http_version:
+  recorded_at: Wed, 27 Apr 2022 06:19:55 GMT
+- request:
+    method: get
+    uri: https://intersight.com/api/v1/equipment/SwitchCards/614ce25a4630312d42bf1d1a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.1.3/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
+        host date digest",signature="MEUCIECU2P6XsBAx4aIQX3JyA74zhur1zwVJKMUCSOw/LH1aAiEA3RjVYhttrL03oFKZ6xa0XfEPGfHQ8xkHnIAs440Hqlw="
+      Date:
+      - Wed, 27 Apr 2022 06:19:55 GMT
+      Digest:
+      - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 27 Apr 2022 06:19:55 GMT
+      Set-Cookie:
+      - AWSALB=yrhu1hxOyPSaaw5JxowmshmBu27CdNJTwImkTt303jZG8U1pMwthSt1CKAPmFprSEtL16jpfNHijymY5Bd6YpJ7dl9/DkBEwXx4lb1pXrzwXwU89KMvrxQHw8kNw;
+        Expires=Wed, 04 May 2022 06:19:55 GMT; Path=/
+      - AWSALBCORS=yrhu1hxOyPSaaw5JxowmshmBu27CdNJTwImkTt303jZG8U1pMwthSt1CKAPmFprSEtL16jpfNHijymY5Bd6YpJ7dl9/DkBEwXx4lb1pXrzwXwU89KMvrxQHw8kNw;
+        Expires=Wed, 04 May 2022 06:19:55 GMT; Path=/; SameSite=None; Secure
+      Server:
+      - nginx
+      X-Starship-Traceid:
+      - NB6fef21ddbe9e54c564ee8e5ec54d0d05
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Security-Policy:
+      - 'base-uri ''self'' https://cdn.intersight.com/; child-src ''self'' https://www.intersight.com/
+        https://cdn.intersight.com/  https://cloudsso.cisco.com https://www.cisco.com/
+        https://id.cisco.com; default-src ''self'' https://cdn.intersight.com/; font-src
+        ''self'' data: https://cdn.intersight.com/; frame-ancestors ''self''; img-src
+        ''self'' data: https://cdn.intersight.com/; style-src ''self'' ''unsafe-inline''
+        https://cdn.intersight.com/; object-src ''none''; form-action ''self'' https://www.intersight.com/
+        https://cloudsso.cisco.com https://www.cisco.com/ https://id.cisco.com; script-src
+        ''self'' https://cdn.intersight.com/; sandbox allow-modals allow-scripts allow-same-origin
+        allow-popups allow-forms allow-downloads; connect-src ''self'' https://cdn.intersight.com/
+        https://status.intersight.com https://download.intersight.com/ wss://socket.intersight.com
+        wss://intersight.com; frame-src ''self'' blob: https://www.intersight.com/
+        https://cdn.intersight.com/  https://cloudsso.cisco.com https://www.cisco.com/
+        https://id.cisco.com;'
+      X-Xss-Protection:
+      - 1; mode=block;
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - ZAG50-C1
+      X-Amz-Cf-Id:
+      - zm9jCjss8tBoVCX7-cS1yNyKN6NET6LBfAPZXEp5sjwsCYFtwarO1g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -36271,7 +36703,7 @@ http_interactions:
           "FcSwitchingMode": "end-host",
           "HwVersion": "",
           "InventoryDeviceInfo": null,
-          "ModTime": "2022-04-26T04:32:29.265Z",
+          "ModTime": "2022-04-27T06:18:30.57Z",
           "Model": "UCS-FI-6454",
           "Moid": "614ce25a4630312d42bf1d1a",
           "Name": "",
@@ -36381,7 +36813,7 @@ http_interactions:
           "Vendor": "Cisco Systems, Inc."
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:49 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:55 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/port/Groups/614ce2a26176752d35a7ed6f
@@ -36397,9 +36829,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDAqAXIfeFz3tPOZbGLQJb6b+cgqilCXl9sX2X3JnEk0QIhAKzH9pI1fFOgezTs3k+/F4jy7VAjjST0lBvUtEh6I647"
+        host date digest",signature="MEUCIQDtxeZOrelkBV4gwuBCfwtRz27zsFY45FSb1tkjjMQepwIgTsriXgRRjxCtsvazwZDgeL4H0jYc0j7LKOpQC9uZ2E0="
       Date:
-      - Tue, 26 Apr 2022 05:03:49 GMT
+      - Wed, 27 Apr 2022 06:19:55 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -36412,16 +36844,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:49 GMT
+      - Wed, 27 Apr 2022 06:19:55 GMT
       Set-Cookie:
-      - AWSALB=Yh3ajvYjFJXSKSFO8oTCoXPA3g0AP6QvsGN5xc5SjaCvwcBH8NMGNrYeCSSDKKOMFTTnW6tb93k3i6ujtByDfsh6y4VdNYotffPGB5qCVgZ3uEIaQoereha8toe1;
-        Expires=Tue, 03 May 2022 05:03:49 GMT; Path=/
-      - AWSALBCORS=Yh3ajvYjFJXSKSFO8oTCoXPA3g0AP6QvsGN5xc5SjaCvwcBH8NMGNrYeCSSDKKOMFTTnW6tb93k3i6ujtByDfsh6y4VdNYotffPGB5qCVgZ3uEIaQoereha8toe1;
-        Expires=Tue, 03 May 2022 05:03:49 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=14HKSpL39MSL7d8Qcw0hhIunlGS8TCZ7IGvCJnqtQcHNeJnUs+T1RdiFVc6ICXu9rGOR27xjUt1Y5AS+I5oh2LRdJdqs8JMc3ikEGoT0FIqRJecd8IFYuC2CjGmn;
+        Expires=Wed, 04 May 2022 06:19:55 GMT; Path=/
+      - AWSALBCORS=14HKSpL39MSL7d8Qcw0hhIunlGS8TCZ7IGvCJnqtQcHNeJnUs+T1RdiFVc6ICXu9rGOR27xjUt1Y5AS+I5oh2LRdJdqs8JMc3ikEGoT0FIqRJecd8IFYuC2CjGmn;
+        Expires=Wed, 04 May 2022 06:19:55 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB96c2405c01246efe7077c403b27d8076
+      - NB226f8b9a9fc45765ada107e672020145
       Pragma:
       - no-cache
       Cache-Control:
@@ -36451,11 +36883,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - BFaslvOEHOjwhNxd0S3SqD1aLpfB9ZF7MZMijHFFEUnb3-xaWoAe7Q==
+      - CpqcsfWj044MPrKax-PAwqRRGHFiTOkKJWsLBUoEn21nD7W2ktwhEA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -36855,7 +37287,7 @@ http_interactions:
           "Transport": "ether"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:49 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:55 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d67
@@ -36871,9 +37303,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCICQpYu5ndeNyb7n8o/GMSmAxn8KJH0cPl3i1qTDNe6RcAiEA2bwQ/+LfZaQ1H6CSYSNeX4Rb+OFhr34ceb7RgkC1lfw="
+        host date digest",signature="MEYCIQCRG6H44AaiYUj+8/nW+PZYhCg/FYgPi4pqXS8vvtrTgwIhANX0IiB+0htVIFjvmWfWtrKcL/QJ3nrNUmNf2ZWnYZ5B"
       Date:
-      - Tue, 26 Apr 2022 05:03:49 GMT
+      - Wed, 27 Apr 2022 06:19:55 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -36886,16 +37318,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:49 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Set-Cookie:
-      - AWSALB=Fp9oeyKGDClKZqqr3yFvgPJH0vTMGgTbCDpsVL94o+cAnGifT53ivgUetAnCClsJO/beFYZ8IEIaCBovuQwfKe+45YT+ey6z4sKr2j1EzncxqiiptKoQnpNjY0Yz;
-        Expires=Tue, 03 May 2022 05:03:49 GMT; Path=/
-      - AWSALBCORS=Fp9oeyKGDClKZqqr3yFvgPJH0vTMGgTbCDpsVL94o+cAnGifT53ivgUetAnCClsJO/beFYZ8IEIaCBovuQwfKe+45YT+ey6z4sKr2j1EzncxqiiptKoQnpNjY0Yz;
-        Expires=Tue, 03 May 2022 05:03:49 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=YmsVcTltlon19TribPfiBbbKNir9J2/ErY2LTiOC35IpEGXEeZteljL8XMEJQ2rFHItiKG7KJAzVmxjj+YX0NhvW2XT+hri5QH/RKxE+uwW+mbGd0lApAXDFCC4X;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/
+      - AWSALBCORS=YmsVcTltlon19TribPfiBbbKNir9J2/ErY2LTiOC35IpEGXEeZteljL8XMEJQ2rFHItiKG7KJAzVmxjj+YX0NhvW2XT+hri5QH/RKxE+uwW+mbGd0lApAXDFCC4X;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB136ee73be8d37610180c9290bd91254e
+      - NBfe91adf90bd9195c3a0868e8964b4f25
       Pragma:
       - no-cache
       Cache-Control:
@@ -36925,11 +37357,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - z0NVzGbJF44tJWkcBJWXiYxb2qgWGamZLMxEWncCDh7fotJvKPLDCA==
+      - eom4erbCvDzc7kCiG4HAlZDZ8GrUe8kPVJWijIuhouScVejNYsHRLQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -36976,7 +37408,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F1",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d67",
           "Name": "",
@@ -37035,7 +37467,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:49 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:56 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6a
@@ -37051,9 +37483,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIEDsK6VRid1kd3GSkhAhJAmL9vHyvPgu2SdL1+2reh4jAiEAhfYNQKKG0083Pqgx+vHcQPBKMI7cpiZ1Vsyd4SUwYgo="
+        host date digest",signature="MEUCIQCCRIwxkH3///Wq82rk+oBi4os9zuTMzkT368SLt5+iRgIgCcaRoVTt2JyVxrng3vOYFwCXHIFua7ex92asZhUx1KA="
       Date:
-      - Tue, 26 Apr 2022 05:03:49 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -37066,16 +37498,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:49 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Set-Cookie:
-      - AWSALB=Z7CPT0/6RUcaxug6sJb7o+gkhJAWnNaBakj/NDTQcslsO0cs9qpY6ahZnPP5ICQgxzEzt2RqNEN8+koavKWZeAmOHdu54WbPP3o14CTFD36zrCo7SPuaYTf+GMNb;
-        Expires=Tue, 03 May 2022 05:03:49 GMT; Path=/
-      - AWSALBCORS=Z7CPT0/6RUcaxug6sJb7o+gkhJAWnNaBakj/NDTQcslsO0cs9qpY6ahZnPP5ICQgxzEzt2RqNEN8+koavKWZeAmOHdu54WbPP3o14CTFD36zrCo7SPuaYTf+GMNb;
-        Expires=Tue, 03 May 2022 05:03:49 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=7pW4RqIGeScF4jMNhVcRDCmzkHZ1EKt/PEW655VQKKfy9wAgabjKcReNhSx9yIyj54Iv3/hQ/4B2Ob6O0RtYOYDtjjILfiidN2yXKh4TORh7uu0PRqOMrzMrbs3A;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/
+      - AWSALBCORS=7pW4RqIGeScF4jMNhVcRDCmzkHZ1EKt/PEW655VQKKfy9wAgabjKcReNhSx9yIyj54Iv3/hQ/4B2Ob6O0RtYOYDtjjILfiidN2yXKh4TORh7uu0PRqOMrzMrbs3A;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf83a628a0fd57515081d8d1774c629a7
+      - NBfe2be3cf4346435971fd786ef65406c6
       Pragma:
       - no-cache
       Cache-Control:
@@ -37105,11 +37537,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 3TUQeQtakJ4h_7RgcacgMkx23EvWLvqIFjNWTkarnWgH_R4rTLHDog==
+      - T40PCSZi7LYrPlmLXGi9VzNdNgimGD4hsIEAYRfZX_5VW2PrVYvwIQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -37156,7 +37588,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F4",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d6a",
           "Name": "",
@@ -37215,7 +37647,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:49 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:56 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d71
@@ -37231,9 +37663,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIHw+2dT4Pb1Z7dl1POVXhbE5U3xvcQY+vPvapBlTdL+sAiA7KJy5Ag319QKDJXLKs+jfzbRwnirx9zfU5gkJKGIlaA=="
+        host date digest",signature="MEQCIGHLl2yDyyIWT5mNAAXeKHhF/F7yDEg0Sl7lWYyGWccGAiBeO1koW2j6JbrinuKlLlf0WCtwuwMI8jaiyUJK1NIvNg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:49 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -37246,16 +37678,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:50 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Set-Cookie:
-      - AWSALB=5LCVOtGzptdIwlTnPuSFM6cDWX2mU87AZI7UapcjgiDRyabXIfkn00s81nvSbOhYXv0MU75Bb4cYVZIi6OvKFY/Df8e0oyY86ClaLBrxWheHmB1F2OgPxlDne+fG;
-        Expires=Tue, 03 May 2022 05:03:50 GMT; Path=/
-      - AWSALBCORS=5LCVOtGzptdIwlTnPuSFM6cDWX2mU87AZI7UapcjgiDRyabXIfkn00s81nvSbOhYXv0MU75Bb4cYVZIi6OvKFY/Df8e0oyY86ClaLBrxWheHmB1F2OgPxlDne+fG;
-        Expires=Tue, 03 May 2022 05:03:50 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=1T/AdwQla3b6RDlN2K1xGNupcZg0TtBIatSuQaU95GHiXzYDAFKV+P/yazPwpJnl9e6qdxc/U8bWLONgn77NBNU4Y0/VQP2DzSjE3Scmr/4n1qzTtvt1Aej8LrML;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/
+      - AWSALBCORS=1T/AdwQla3b6RDlN2K1xGNupcZg0TtBIatSuQaU95GHiXzYDAFKV+P/yazPwpJnl9e6qdxc/U8bWLONgn77NBNU4Y0/VQP2DzSjE3Scmr/4n1qzTtvt1Aej8LrML;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf2f88a1aecade8854ff6591f8267b55e
+      - NBcad9499c711b1127b20d072ab5a60e39
       Pragma:
       - no-cache
       Cache-Control:
@@ -37285,11 +37717,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 5TZDWj_GPfCEvSFStK3sB4IjV8DpYYXEmZ5wIR8sKai1YF5WCJ3gww==
+      - r6hsa4IZ7TRv-0cvJZUvOxvdr7RLDSMiX0WOk5FC2EKj-0T8MLd4Hw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -37336,7 +37768,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:79:04",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d71",
           "Name": "",
@@ -37395,7 +37827,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:50 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:56 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8b
@@ -37411,9 +37843,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDOSh73rw5Q2V0wk80ZpA3m6Zb/r+MLzHXgbidgzKITvgIhAOlMxavhVoNsevKBwLlUadlzXZNZLh/tvntATJPubiwa"
+        host date digest",signature="MEYCIQCvKjUytkmF+SI3ivbHEeTpLkxqKxxsblnan34SCK1eawIhANWhOwgXP0eHKvuYLdDJVrpVlTzM+f+PeALyOp42Z/2C"
       Date:
-      - Tue, 26 Apr 2022 05:03:50 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -37426,16 +37858,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:50 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Set-Cookie:
-      - AWSALB=kvSy5VTjlHYCBgfiKN8VOSXEuLQMqUeBN+H9iwg9NZcEi9JgY+ysESNSdLUFtLsOwUQaBHd8dh9Qq/HjKYXzQyd6qmdtNE8ZHw3KSjNGgpEPrj2ivzUXUGtfB1mI;
-        Expires=Tue, 03 May 2022 05:03:50 GMT; Path=/
-      - AWSALBCORS=kvSy5VTjlHYCBgfiKN8VOSXEuLQMqUeBN+H9iwg9NZcEi9JgY+ysESNSdLUFtLsOwUQaBHd8dh9Qq/HjKYXzQyd6qmdtNE8ZHw3KSjNGgpEPrj2ivzUXUGtfB1mI;
-        Expires=Tue, 03 May 2022 05:03:50 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=l7n5ACjzPhgL3WR0MDdHxMccdTJoxWf3GShHYPVciW5ZOQ7U/IrnjZeNm93V6mMttzLVPLDNOILFBezKBQWmQ97AqA+tSH715IkS2RwLIBhXEurGhOvN6V/SyFwt;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/
+      - AWSALBCORS=l7n5ACjzPhgL3WR0MDdHxMccdTJoxWf3GShHYPVciW5ZOQ7U/IrnjZeNm93V6mMttzLVPLDNOILFBezKBQWmQ97AqA+tSH715IkS2RwLIBhXEurGhOvN6V/SyFwt;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB03a571b2500be5586f4bd43321e662ae
+      - NB835ecfd41b284c81d6c34a5239dfb896
       Pragma:
       - no-cache
       Cache-Control:
@@ -37465,11 +37897,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - RfCtXN3u8ezdVjVtAQAEGe76h0sUd8dkmcDwdAlbgSY_A0b5GuthnQ==
+      - 8Uk4xUSFVbTjiWgG3eScupuKcRgQ2jYqLWQT_hjxApEzns6j3D13zA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -37516,7 +37948,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DF",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8b",
           "Name": "",
@@ -37575,7 +38007,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:50 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:56 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8d
@@ -37591,9 +38023,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDmKS+M13arcEtVm7HvIk0qEQQJrqHekkfuJlK29nKWaAIhAMyg68F7qwy/+uJKmScSqzbsTU/vwL4rVu+Rr9zyRLwe"
+        host date digest",signature="MEUCIQDPWbLk8Gbx0ySGNPk7pTyMN5fCZx+s6534p64atvMCEwIgDrHKa21h0WlEoOg8+9N+QPHiTJ+CvRSlS0ayggCReOw="
       Date:
-      - Tue, 26 Apr 2022 05:03:50 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -37606,16 +38038,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:50 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Set-Cookie:
-      - AWSALB=l6IKhaXd3nTnww+OY2LYy1aVB/PGP8IRFTThtodUITRzxDII/4AlnGNrfywvRIxqw/wjILpY7baWP4hX17UkyE5rh5Wfp/IL7QNqZQsz3stIhyBGSik7skp5ME2I;
-        Expires=Tue, 03 May 2022 05:03:50 GMT; Path=/
-      - AWSALBCORS=l6IKhaXd3nTnww+OY2LYy1aVB/PGP8IRFTThtodUITRzxDII/4AlnGNrfywvRIxqw/wjILpY7baWP4hX17UkyE5rh5Wfp/IL7QNqZQsz3stIhyBGSik7skp5ME2I;
-        Expires=Tue, 03 May 2022 05:03:50 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=OuryW6Dpn+YF9dvgXKQ+kyHSsRVWkWySMypMMdZr4qVfLVWm6SC7a8MBD/eerF/efKG0rURoE9NgVX3p0HrDcEX6W6lPIbpwfskin5cByg1QxwCNhChC8L3X2KOo;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/
+      - AWSALBCORS=OuryW6Dpn+YF9dvgXKQ+kyHSsRVWkWySMypMMdZr4qVfLVWm6SC7a8MBD/eerF/efKG0rURoE9NgVX3p0HrDcEX6W6lPIbpwfskin5cByg1QxwCNhChC8L3X2KOo;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb620952ed7cfcca54e018a511965de86
+      - NB126ffe82a94c40745d5bb9db0788a374
       Pragma:
       - no-cache
       Cache-Control:
@@ -37645,11 +38077,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - vAt8JGEVaTN1sJWnaP4WGZSrXBp08QIw7S1fK026XsaB23o-HxQ04g==
+      - X_1RcByS9-7IqP_HY3lFfvk6yGXbfYgx4nLJAXJcJeLl8jkIt49FnQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -37696,7 +38128,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E1",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8d",
           "Name": "",
@@ -37755,7 +38187,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:50 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:56 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d91
@@ -37771,9 +38203,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBOIyv957y+0oXOajdmeBLLaXDSqyPhLU+2QbfMkU9gPAiEAp8HcvEmODpf81jyQhUdQIeL+R/ZNlxk3ZlRwy1o82X4="
+        host date digest",signature="MEYCIQDz1l5deqyllCn/1Vf7uq1QmMv9EaVgFb6Nml6qlO4n0wIhALg6WQ8lXW25M+WxFm+xOQNBY4q79Sm2rlXxBbFYvk4W"
       Date:
-      - Tue, 26 Apr 2022 05:03:50 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -37786,16 +38218,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:51 GMT
+      - Wed, 27 Apr 2022 06:19:56 GMT
       Set-Cookie:
-      - AWSALB=rtIgFG7OgaD76qFCjHxJf46L+8BVeo17+mWemDOObujB6mUfmxkjWf99FH2IIhLJ9cD0/vrMQEWUZO88HLJtnA0tZw0ls1wKSOrtb+holdxqy2gLVH1jzETw+Tdn;
-        Expires=Tue, 03 May 2022 05:03:50 GMT; Path=/
-      - AWSALBCORS=rtIgFG7OgaD76qFCjHxJf46L+8BVeo17+mWemDOObujB6mUfmxkjWf99FH2IIhLJ9cD0/vrMQEWUZO88HLJtnA0tZw0ls1wKSOrtb+holdxqy2gLVH1jzETw+Tdn;
-        Expires=Tue, 03 May 2022 05:03:50 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=mDnwcuGPpW6u0j8gcmz57Uz5LgipoNs4crmNt0UwErcKRgPCdArJACUZAsLXotpabZchcWi5msFHijYoLj7FYVpjbVS9FunzOTawus2Rv6UQw2F6/qqwFwQdyqpK;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/
+      - AWSALBCORS=mDnwcuGPpW6u0j8gcmz57Uz5LgipoNs4crmNt0UwErcKRgPCdArJACUZAsLXotpabZchcWi5msFHijYoLj7FYVpjbVS9FunzOTawus2Rv6UQw2F6/qqwFwQdyqpK;
+        Expires=Wed, 04 May 2022 06:19:56 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3d57169317656083351026f074b1a8d1
+      - NB9fc71ab40f2dc575e416180b8321a92a
       Pragma:
       - no-cache
       Cache-Control:
@@ -37825,11 +38257,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - gMn0JAxHSmonKEzDEBbJYZOYaSdYMRuOKPogitnwxjDGJkjdwq2niA==
+      - AwLe8BtQCdyVU7Dh7gieK8tJ5bKawmADsWlbmcR6Pcc822GEo-TKMA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -37876,7 +38308,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E5",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d91",
           "Name": "",
@@ -37935,7 +38367,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:51 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:57 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d63
@@ -37951,9 +38383,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCICW0ygEIqkVgRDYLjNYpT4IAoavVqZZZJUgP9gALzr2pAiBD+/kixxU/M4buKvHMqNII06wLNYJAE+HfnW36Vy1mTg=="
+        host date digest",signature="MEQCIQD9WOyZAWTBN6UFR1CiRMPF70MWqU/02WWl6On6YhjZyQIfPl4aOAGcGfkYWvOU15mWy1+kjCZYbBCz0ASoe7IRxA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:51 GMT
+      - Wed, 27 Apr 2022 06:19:57 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -37966,16 +38398,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:51 GMT
+      - Wed, 27 Apr 2022 06:19:57 GMT
       Set-Cookie:
-      - AWSALB=na8mug/6zKjG2fDC/7zJnon2deWc8vNeUquiZNyncJ6mqzksyEc98TGDqXwVB3vpe7U7oX70gRs68r6ti2sjlxvPi/pwUFfv8ga/lmzX+xeWPdOzCFxhgK1pWNQh;
-        Expires=Tue, 03 May 2022 05:03:51 GMT; Path=/
-      - AWSALBCORS=na8mug/6zKjG2fDC/7zJnon2deWc8vNeUquiZNyncJ6mqzksyEc98TGDqXwVB3vpe7U7oX70gRs68r6ti2sjlxvPi/pwUFfv8ga/lmzX+xeWPdOzCFxhgK1pWNQh;
-        Expires=Tue, 03 May 2022 05:03:51 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=4WMLsWTpdWB4VlwTJ2aKwZVB7lD3Fuusxd9G69MFZLkA7WEwfZSKPXS0WH1ZA3RMb3oVMB/QGOk7vUDE1Io2TQQfDKEYn7D2ZCM+nmsCFFrfEJNA7TYJv1OAl/wt;
+        Expires=Wed, 04 May 2022 06:19:57 GMT; Path=/
+      - AWSALBCORS=4WMLsWTpdWB4VlwTJ2aKwZVB7lD3Fuusxd9G69MFZLkA7WEwfZSKPXS0WH1ZA3RMb3oVMB/QGOk7vUDE1Io2TQQfDKEYn7D2ZCM+nmsCFFrfEJNA7TYJv1OAl/wt;
+        Expires=Wed, 04 May 2022 06:19:57 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB45c3b9e6d3d69996fe6b9b46c74d10b0
+      - NBdbcbcfa1b6c76fc4b0e83cf0c37b88d4
       Pragma:
       - no-cache
       Cache-Control:
@@ -38005,11 +38437,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - q7XGuRQJzDrKaEusI0rk3EZ1Y9YEPnTDmOt4-AXUGgcI3wcJrG_Klg==
+      - fws3bQMs8r7XQkFGp-U84Hp4mpiaXtUTN_epsE1i6cfx1ZnuVZ_hNA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -38056,7 +38488,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:ED",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d63",
           "Name": "",
@@ -38115,7 +38547,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:51 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:57 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d64
@@ -38131,9 +38563,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIFG8IE42ksbXrVvGkfgedKlFfgi6KznMXLXPMqGw6YiHAiEAntWcZ1pl3XJw3HxBnqMF+iT5VJTaQZXwf8/1L6MWkrY="
+        host date digest",signature="MEQCICOUZ2ULZjvXxX2icnWBU9hyQRzIU3Q7VR2vrz31VtGgAiBmI0yFKYlKYolm8IGWaueOlHNwPTwHcG9oCHnJHsiS0A=="
       Date:
-      - Tue, 26 Apr 2022 05:03:51 GMT
+      - Wed, 27 Apr 2022 06:19:57 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -38146,16 +38578,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:51 GMT
+      - Wed, 27 Apr 2022 06:19:57 GMT
       Set-Cookie:
-      - AWSALB=OnS/Dnu0dpKOTWNbHa/dj4WnW1Mvcz6jwkO3EDaTK/+apSVGo4XJEazU4WZ6zUvqSuSIBcBz88BEM7Z9XKV/o/ZuYcGtLF2Nh0SRhDYEEsWj3vP7iW8k7Nd5oiFS;
-        Expires=Tue, 03 May 2022 05:03:51 GMT; Path=/
-      - AWSALBCORS=OnS/Dnu0dpKOTWNbHa/dj4WnW1Mvcz6jwkO3EDaTK/+apSVGo4XJEazU4WZ6zUvqSuSIBcBz88BEM7Z9XKV/o/ZuYcGtLF2Nh0SRhDYEEsWj3vP7iW8k7Nd5oiFS;
-        Expires=Tue, 03 May 2022 05:03:51 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=wC36UPGQsTfqXNxnoCEWalVfg72LP9jMRJAleOQbOouk/88IGluHFQO4WsdfTKPmHKCbxlcIB23JxJmNWGNKE6G5eJOhK2L8b7e+P0llhaUQqn7eHeHWFgiBCiIc;
+        Expires=Wed, 04 May 2022 06:19:57 GMT; Path=/
+      - AWSALBCORS=wC36UPGQsTfqXNxnoCEWalVfg72LP9jMRJAleOQbOouk/88IGluHFQO4WsdfTKPmHKCbxlcIB23JxJmNWGNKE6G5eJOhK2L8b7e+P0llhaUQqn7eHeHWFgiBCiIc;
+        Expires=Wed, 04 May 2022 06:19:57 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB666a8638be000d698dc201c9e3af1673
+      - NBfe99850388258d8a32b3e15aa102e4a1
       Pragma:
       - no-cache
       Cache-Control:
@@ -38185,11 +38617,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 5JUg6Y1yadP-NkcGVoxhhYVp4VOhqFoWzCdXS50zziGC4k7FnadV_Q==
+      - PXP9l0bubShFzJlzcqRZk3r8f2aeNS7E_4JMc-We4UokSiQ5FW3rDQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -38236,7 +38668,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:EE",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d64",
           "Name": "",
@@ -38295,7 +38727,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:51 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:57 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d66
@@ -38311,9 +38743,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIDecg6l1Hni/ctGb6MeS6/+ymhuLu4+AlOb+imUbFYvBAiBoLPGd5BVhFcko6DvJ7pcTFUKedRjKShjxppOznjgBHQ=="
+        host date digest",signature="MEYCIQD/xSyzHuDDAdCaU7r2IS+iF64y44A2/1Bz1CAakHFKQwIhAJ3Z11P7UhP4n6M6eOHPdrrAxIeveGdOEswZnFWI5ovg"
       Date:
-      - Tue, 26 Apr 2022 05:03:51 GMT
+      - Wed, 27 Apr 2022 06:19:57 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -38326,16 +38758,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:51 GMT
+      - Wed, 27 Apr 2022 06:19:57 GMT
       Set-Cookie:
-      - AWSALB=jEmYF4CoUua/eMtSUE3gwWnCafnv8sXKVnqAIR/txLAhSQz145GPUSKh5UOa4XrxXHlOnxm60HVEvCrYdUOO8zww4tl4/ahmwnbxructo5NgrD5vNvvIBFyr2rFd;
-        Expires=Tue, 03 May 2022 05:03:51 GMT; Path=/
-      - AWSALBCORS=jEmYF4CoUua/eMtSUE3gwWnCafnv8sXKVnqAIR/txLAhSQz145GPUSKh5UOa4XrxXHlOnxm60HVEvCrYdUOO8zww4tl4/ahmwnbxructo5NgrD5vNvvIBFyr2rFd;
-        Expires=Tue, 03 May 2022 05:03:51 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=IpbdC0jq3PBR3ep0Om79sHS7a33ibWNt0BXO+3jQPFh6gXDZ6mDCy7s0R/27cdu2CiinRgpgrA/16LHdTq+zG+QNp85UEmjU9Y2HXdOwIIEA/uVHtoRLFLaUaX0t;
+        Expires=Wed, 04 May 2022 06:19:57 GMT; Path=/
+      - AWSALBCORS=IpbdC0jq3PBR3ep0Om79sHS7a33ibWNt0BXO+3jQPFh6gXDZ6mDCy7s0R/27cdu2CiinRgpgrA/16LHdTq+zG+QNp85UEmjU9Y2HXdOwIIEA/uVHtoRLFLaUaX0t;
+        Expires=Wed, 04 May 2022 06:19:57 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB02244f2206fdd314909ef8266ed11c11
+      - NBae5df9f69f42e17ae83838ee48476b62
       Pragma:
       - no-cache
       Cache-Control:
@@ -38365,11 +38797,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - NxUAEQFUp3qLRdllghWzAEQZyfe5OxVS36dCLNHtaDv_O0OiF_G0gQ==
+      - Xb5vEsOhEd0rYDSkahYyem-FsMUMYqxwAN9no0RfnQlwcZVlabjORg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -38416,7 +38848,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F0",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d66",
           "Name": "",
@@ -38475,7 +38907,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:51 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:57 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7c
@@ -38491,9 +38923,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCvWJ8d+7xSukxmber55G5KimdNkYhUwfWB9uEEoySDPQIhAOVX8lv0xu+1FTHfaaz7twuxqx/0y4ZP5eCwUu6ABeUU"
+        host date digest",signature="MEYCIQDkDNp88U3vmUCz3qPc6C+nTCYP4AkuWJDC5r3C713sdwIhAMhGU9Y27r1PGd+i8cl/yiriSccel1uA4jHRtIEJU+Xg"
       Date:
-      - Tue, 26 Apr 2022 05:03:51 GMT
+      - Wed, 27 Apr 2022 06:19:57 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -38506,16 +38938,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:52 GMT
+      - Wed, 27 Apr 2022 06:19:57 GMT
       Set-Cookie:
-      - AWSALB=zCpquIvHNDLocFmgEN/a8c27iE0MYgjUs4fqWK4DEAHB36rKXmNcIzebWJjjKF4r84ieQv0CMX35mpJxuqrmThkgzbFoJFg1qmvMlxrcot4cAwULEFXzzLmrZtfI;
-        Expires=Tue, 03 May 2022 05:03:51 GMT; Path=/
-      - AWSALBCORS=zCpquIvHNDLocFmgEN/a8c27iE0MYgjUs4fqWK4DEAHB36rKXmNcIzebWJjjKF4r84ieQv0CMX35mpJxuqrmThkgzbFoJFg1qmvMlxrcot4cAwULEFXzzLmrZtfI;
-        Expires=Tue, 03 May 2022 05:03:51 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=+z+JpnpzKatVRuiVkT3UKTHNLSnJsqzJL4h05QXtZepF7uk9xtJDIZcErEIs+q1WdHAyLFoLU4iTnIBVBBOvSn7o1PYVv3eU+ODRpR0rrcP5Rw+GG+WbP6ljXfXH;
+        Expires=Wed, 04 May 2022 06:19:57 GMT; Path=/
+      - AWSALBCORS=+z+JpnpzKatVRuiVkT3UKTHNLSnJsqzJL4h05QXtZepF7uk9xtJDIZcErEIs+q1WdHAyLFoLU4iTnIBVBBOvSn7o1PYVv3eU+ODRpR0rrcP5Rw+GG+WbP6ljXfXH;
+        Expires=Wed, 04 May 2022 06:19:57 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBeba5e6e0656f8a16c6421ec5e7eb2d13
+      - NB202097103f0a8862658bb6138301c536
       Pragma:
       - no-cache
       Cache-Control:
@@ -38545,11 +38977,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - OnoFqmmdF0lxK5d09oapbHRpmEo86QiABO3i0s-Z8cITGThuSCer0w==
+      - M3pdcU63fbSeNjN13PTYXP6Yyc_tqHPf109BvyLGSEUyoURJJhGf3Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -38596,7 +39028,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D0",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7c",
           "Name": "",
@@ -38655,7 +39087,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:52 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:57 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d93
@@ -38671,9 +39103,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCMrPs5JyLSAkd7N1j0hF4f0q4qs/Fcn6uTGNPS+Jo92gIhAN2mOXJerG3LtKeDJuN00gYIMngNrdBwrAZV44Z8dNSV"
+        host date digest",signature="MEUCIG6WcFVVVoQV89fmpKSg2dOAJ3Q++Cjs9uCt5B/9+EUQAiEAza+F7rAbqv8jfCYpJFBQEwTBfuwq9M+o6TApOxaC+/g="
       Date:
-      - Tue, 26 Apr 2022 05:03:52 GMT
+      - Wed, 27 Apr 2022 06:19:57 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -38686,16 +39118,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:52 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Set-Cookie:
-      - AWSALB=bPh3/5tm4zO/Qt7mQuTv9BrmpLhLs+UnHToqc80IhqZSDbRyfbwHk2e2RPzyC5K3tdJs+OxMAgyxzhRiAX2v8oapaxKz8CwwBPqheuIuzxdGDaYV+JYXKr/nG7oJ;
-        Expires=Tue, 03 May 2022 05:03:52 GMT; Path=/
-      - AWSALBCORS=bPh3/5tm4zO/Qt7mQuTv9BrmpLhLs+UnHToqc80IhqZSDbRyfbwHk2e2RPzyC5K3tdJs+OxMAgyxzhRiAX2v8oapaxKz8CwwBPqheuIuzxdGDaYV+JYXKr/nG7oJ;
-        Expires=Tue, 03 May 2022 05:03:52 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=KcVFpw3iHDaT2dFh6TD/G21H1laX6RSHOOsL+O9ywu/0Kh/CQd+/Oq638hZV384rr3L5oVdQv4hpjAtHM0aEZAscaM/P5xcJtGv/zuapt4AFpmBjmtHntton0ILO;
+        Expires=Wed, 04 May 2022 06:19:57 GMT; Path=/
+      - AWSALBCORS=KcVFpw3iHDaT2dFh6TD/G21H1laX6RSHOOsL+O9ywu/0Kh/CQd+/Oq638hZV384rr3L5oVdQv4hpjAtHM0aEZAscaM/P5xcJtGv/zuapt4AFpmBjmtHntton0ILO;
+        Expires=Wed, 04 May 2022 06:19:57 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6b58479c1101e9ad767448b78cd88349
+      - NB2c454115a79ceaea0480bd65fccd312b
       Pragma:
       - no-cache
       Cache-Control:
@@ -38725,11 +39157,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - FYB2tjOqrBadsyd5lm85cNOioeobGUnLjFZYAaaPZInQ6UtBsSM88A==
+      - PC3MAEWZEQFNMuRjSeJujIDH3DHBi6jEXzrIAf8BayC1elXhl9tP8g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -38776,7 +39208,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E7",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d93",
           "Name": "",
@@ -38835,7 +39267,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:52 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:58 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d62
@@ -38851,9 +39283,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQC5urO1/sjwfNohWzcYKSljpeT05NWciB3mSmHQK7i8CQIhAOBR553menXc/H3I3lDJpd5eQAunD0G84hrGtWdXRxQi"
+        host date digest",signature="MEUCIQD4Pd9WtOGIotWIJm7cXeeCf9/a/QnbMDOwkxeDQ+UPUgIgWNI4p995h+j1OnntaholePt1RFyVPEexjLvSpIkb8+I="
       Date:
-      - Tue, 26 Apr 2022 05:03:52 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -38866,16 +39298,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:52 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Set-Cookie:
-      - AWSALB=Te/tm5SaNR7sFv7eaRBW6A3O4gVQYE9qm3PsNFm+TWjYpi6P+Vu3C1Rk7HFMF1QJUgQaXl+Nx2Jk94KDo5V8xBWUbIwOQd07wXzFfMMWGB/adG8Tgm3MQFVYBh4L;
-        Expires=Tue, 03 May 2022 05:03:52 GMT; Path=/
-      - AWSALBCORS=Te/tm5SaNR7sFv7eaRBW6A3O4gVQYE9qm3PsNFm+TWjYpi6P+Vu3C1Rk7HFMF1QJUgQaXl+Nx2Jk94KDo5V8xBWUbIwOQd07wXzFfMMWGB/adG8Tgm3MQFVYBh4L;
-        Expires=Tue, 03 May 2022 05:03:52 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=8b5NgVjnv4M/MW9C3ErTsrzPdWX8Yshi00AR/Z6pHNDc7hicg+dJ3iBgpfmWn9ywEVGdczDVI9SKdSxNAYuaBixS3I83si48B3Xit4r/V8lzDNo0T78M2RdCNESC;
+        Expires=Wed, 04 May 2022 06:19:58 GMT; Path=/
+      - AWSALBCORS=8b5NgVjnv4M/MW9C3ErTsrzPdWX8Yshi00AR/Z6pHNDc7hicg+dJ3iBgpfmWn9ywEVGdczDVI9SKdSxNAYuaBixS3I83si48B3Xit4r/V8lzDNo0T78M2RdCNESC;
+        Expires=Wed, 04 May 2022 06:19:58 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3d0cea4a43639c408c0ae36bbea15f08
+      - NBf888440b31202d9c0916f13e117e5243
       Pragma:
       - no-cache
       Cache-Control:
@@ -38905,11 +39337,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - pOcRmkDZAQWid4vnGCNxdgtqJkrpIryPNNq9qBAtrBRynFAx3Bz8kg==
+      - LFvDmwux7uEDpo2ete0o6FHwPde89Ag28cfAPxpzrNuOHybtsoV9jA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -38956,7 +39388,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:EC",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d62",
           "Name": "",
@@ -39015,7 +39447,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:52 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:58 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7a
@@ -39031,9 +39463,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIB6LBQIUxNznOQPYH2Y+qNZ8CZ2c6l7V8g9FOShDhQ4YAiB3RZip70n6fe1UE/TRVkC2suiWl/2OGHFIOkgtmuU+Bg=="
+        host date digest",signature="MEQCIFGCHHF41ETwZKOvhTOQ88h9Yu52SRUSm285khHRx0ZVAiAiDoUWp+J8a51BZ1GSimUVO4ISlWC7KR1rt2rvUySKWw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:52 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -39046,16 +39478,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:52 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Set-Cookie:
-      - AWSALB=rq/X7o9aw3AzyCgqyXegDmsTx5Dcjz2cePCX+c4UlTnGJOT2ur/xn+gPVtk/o2mS66g6sjo4qCdKsU0zPDPOmrTa2L5UfcCFw5yPIkHCddlso7R8eOn0f7gfmWXM;
-        Expires=Tue, 03 May 2022 05:03:52 GMT; Path=/
-      - AWSALBCORS=rq/X7o9aw3AzyCgqyXegDmsTx5Dcjz2cePCX+c4UlTnGJOT2ur/xn+gPVtk/o2mS66g6sjo4qCdKsU0zPDPOmrTa2L5UfcCFw5yPIkHCddlso7R8eOn0f7gfmWXM;
-        Expires=Tue, 03 May 2022 05:03:52 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=IxaELz3RIbW9RatlcWqLwYml9LhN9uclJiT8BGQKLUvJ5xExY47yr2RcAWJT+VFwnHAAF0jOucHGvD8itqC4DF6TdJgAPmTwdHztMQ/Q5fFQzAMvqWstYm8aCsJK;
+        Expires=Wed, 04 May 2022 06:19:58 GMT; Path=/
+      - AWSALBCORS=IxaELz3RIbW9RatlcWqLwYml9LhN9uclJiT8BGQKLUvJ5xExY47yr2RcAWJT+VFwnHAAF0jOucHGvD8itqC4DF6TdJgAPmTwdHztMQ/Q5fFQzAMvqWstYm8aCsJK;
+        Expires=Wed, 04 May 2022 06:19:58 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0c9256f84b6e34a2bd791b888f3ab423
+      - NB952007c0faf8b9725722a5dfb9daac1f
       Pragma:
       - no-cache
       Cache-Control:
@@ -39085,11 +39517,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 3ZhXN03IkaH0hCzrKgU5gyWM31kX_iqZp8xxnHcdCN80votJr8sFuA==
+      - ps_xfudluAB3yeCiLZomgQf7nQDzgabZ7A-hiDRkoHV2FM1YVDmGIA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -39136,7 +39568,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CE",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7a",
           "Name": "",
@@ -39195,7 +39627,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:52 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:58 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7b
@@ -39211,9 +39643,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDI6UfVkDMz2/yxYd5VpHzAdGGWBHCoX69D3N+q9mgCgQIgf7c1HWDMjULEAzTz6yr78nypRYKMnq7X5rrigzjwThI="
+        host date digest",signature="MEQCIF4I1dCSk95ewENXGYfGO4oDU2HPup+v0VDmSoiaTpRJAiA3pGjc3YyAvc2/ruyihA0wFs3yu399v9DIJig6hW0DAw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:52 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -39226,16 +39658,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Set-Cookie:
-      - AWSALB=NASr858Pj90pQc5Nwo9kBScpfW/1zVCANdGcvi88rrRcGFaO0rH37z47OR0XpwZcq46kceds1NxhdJoUf5BIflPKi5GZi2JcaTA5qqTzW5I6VYl0u50xa/0jNRrh;
-        Expires=Tue, 03 May 2022 05:03:52 GMT; Path=/
-      - AWSALBCORS=NASr858Pj90pQc5Nwo9kBScpfW/1zVCANdGcvi88rrRcGFaO0rH37z47OR0XpwZcq46kceds1NxhdJoUf5BIflPKi5GZi2JcaTA5qqTzW5I6VYl0u50xa/0jNRrh;
-        Expires=Tue, 03 May 2022 05:03:52 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=nCz+Cx4nuWPtyanlHsK6YgsKYC1kuFrI7LTJxUHHeLW83E1wbPKnAyHz6M8HJMMWiw5Er6YVLp5NVqMaCqsLANmi6pGke98l9AJQ/L67XChh8vIKDbBY0y6oPq8c;
+        Expires=Wed, 04 May 2022 06:19:58 GMT; Path=/
+      - AWSALBCORS=nCz+Cx4nuWPtyanlHsK6YgsKYC1kuFrI7LTJxUHHeLW83E1wbPKnAyHz6M8HJMMWiw5Er6YVLp5NVqMaCqsLANmi6pGke98l9AJQ/L67XChh8vIKDbBY0y6oPq8c;
+        Expires=Wed, 04 May 2022 06:19:58 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3c2c19954be1d61a5882ca1173d28f0d
+      - NBf0746526e6eb663c0fa1f7fc550dc7df
       Pragma:
       - no-cache
       Cache-Control:
@@ -39265,11 +39697,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - zzyqI8mvpflItE3Qo0lTI4vcGyGcUN8EsVHMiBXVW9AZI1JIAfxA-A==
+      - FWlnIbLPNGX6bnIkYWnZAvZMizF8qfYI08irERLsU9E6ZqP-ViYzwg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -39316,7 +39748,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CF",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7b",
           "Name": "",
@@ -39375,7 +39807,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:53 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:58 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8e
@@ -39391,9 +39823,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCICrAmpqNRzJsQEGWlU8qInJYLKKE4Lp0j0vV71/yeAp/AiEAjuCwvOma38nIGjz/trXftJlMF/u/kcP6hlcSqdMSK0A="
+        host date digest",signature="MEUCIHzSoOECuy9pxWWUY6oJnPe7bICYSP4+e5e8gNVoa4kVAiEA8Sk75ICuZ4ynG0aZAgWLmUBBu/w4ay5uAUJ3TQm747Q="
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -39406,16 +39838,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Set-Cookie:
-      - AWSALB=orOtgW3VV4x7q6YPwltOKLf9+UDslRGrAMkjSZeZRJNUlNwG9ohmZTQofGqKOUpw3QRCKs/VsYNhyNiS4N/oyxEVIOiPCuAfU2FvgGeh7qov10eZ+KO+DXVIgPrb;
-        Expires=Tue, 03 May 2022 05:03:53 GMT; Path=/
-      - AWSALBCORS=orOtgW3VV4x7q6YPwltOKLf9+UDslRGrAMkjSZeZRJNUlNwG9ohmZTQofGqKOUpw3QRCKs/VsYNhyNiS4N/oyxEVIOiPCuAfU2FvgGeh7qov10eZ+KO+DXVIgPrb;
-        Expires=Tue, 03 May 2022 05:03:53 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=EESScmHU3P8gI/FqSXLnSKN4eGTCuzHt6NZGd2xDibdtfALweJ5bWBnmLmbFypBhIVvSdjJeQB9+RFNSBDrrsXOYZIQNtOl3lk60SgnZI1lJDRA/1G4G1hTEruDz;
+        Expires=Wed, 04 May 2022 06:19:58 GMT; Path=/
+      - AWSALBCORS=EESScmHU3P8gI/FqSXLnSKN4eGTCuzHt6NZGd2xDibdtfALweJ5bWBnmLmbFypBhIVvSdjJeQB9+RFNSBDrrsXOYZIQNtOl3lk60SgnZI1lJDRA/1G4G1hTEruDz;
+        Expires=Wed, 04 May 2022 06:19:58 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB923c46d92078723d445181a5d4118174
+      - NB382f4a0db69d8d88ad06abbbd0bb3ff2
       Pragma:
       - no-cache
       Cache-Control:
@@ -39445,11 +39877,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - MG-nzSMk7OQozGjCGV8GmK3zHKc6RpJA-wwUqMPdpD_ZR6yM0hLMCQ==
+      - nQfJU22nPavrLcueqWs8iidUdQXdN2OK3kxGbdp6-rl5fptCzIUe-w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -39496,7 +39928,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E2",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8e",
           "Name": "",
@@ -39555,7 +39987,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:53 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:58 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d69
@@ -39571,9 +40003,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIH1ZubwKhFgE8FquBpnkN6UBBYFIrZDarTEZsW7jBw7GAiEAhpwvXf9HTjlJeJD+wHYJeLeX+uWPT2zAsqm0VZouJtg="
+        host date digest",signature="MEUCIQCnv/MSxD29cF8ODDicykVhbn5EfPZiiuEa5i2pjxERLgIgAUsN/FbGI8hyPlvqCABi1U3+1+Rc4Gj/1m6mkfvvGmw="
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -39586,16 +40018,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Set-Cookie:
-      - AWSALB=O5jgbG1kQDYeu9dgGLKwLK0/OgV1kskKITyYLzzdlW+jsQY9liIRoroWlQvEj23bzP/tB8VlJ02r3/fC/wS8nLjT9Eg+v3bX2t/BkA4UOJqeKcQXo4ubggaJfayp;
-        Expires=Tue, 03 May 2022 05:03:53 GMT; Path=/
-      - AWSALBCORS=O5jgbG1kQDYeu9dgGLKwLK0/OgV1kskKITyYLzzdlW+jsQY9liIRoroWlQvEj23bzP/tB8VlJ02r3/fC/wS8nLjT9Eg+v3bX2t/BkA4UOJqeKcQXo4ubggaJfayp;
-        Expires=Tue, 03 May 2022 05:03:53 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=eGc16F+p0GIZkjiOVmqs7cnt6qntxEKMfSEWqmt68SdgxcPan22jukFtMcRlPzQ/VwUU7PLTKj57ENPJHwGh6C+QKW/cw9Pnv4CMYFAGyjXL4vmGNGJXHtwfjWCQ;
+        Expires=Wed, 04 May 2022 06:19:58 GMT; Path=/
+      - AWSALBCORS=eGc16F+p0GIZkjiOVmqs7cnt6qntxEKMfSEWqmt68SdgxcPan22jukFtMcRlPzQ/VwUU7PLTKj57ENPJHwGh6C+QKW/cw9Pnv4CMYFAGyjXL4vmGNGJXHtwfjWCQ;
+        Expires=Wed, 04 May 2022 06:19:58 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd18e2e3235077370d8e39a17613a3ac5
+      - NBd7630f96d4fc88f366089814995a0e0a
       Pragma:
       - no-cache
       Cache-Control:
@@ -39625,11 +40057,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ENfhkrV-HM-TigBfSF_-lMAxPGh1raiacT-vaUIMF7nU4dv1haCYpQ==
+      - uqLnW_XMMwyJ_Q-AwUMMejfudb62LxBSMdgYcDcCrIh1XHiacu9-9Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -39676,7 +40108,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F3",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d69",
           "Name": "",
@@ -39735,7 +40167,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:53 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:58 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d79
@@ -39751,9 +40183,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDy4A1H0lFpEot9dMBDI0FmZl1mDgiafKFuSDkAfovwmQIgfNnCoeqgqPj41VimND4Kx577oqc9SKalgdVPy+yzTHE="
+        host date digest",signature="MEUCIET4yvBD+NILVayCA+4a43B0TGjVt7ImY4OrVzpdNgVNAiEA8A7u+PJ8Hcn482BsIpGePm4HLb8+hrL2Sbn6zWUbfyk="
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:58 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -39766,16 +40198,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:59 GMT
       Set-Cookie:
-      - AWSALB=ARB0tSvPyZ3rEJvqXIFNk7LoCiIRBg0TGZOdS3B82tmqPnsnq6dm3+TirzZwvTySv4ZDS/3g+XWkkOrAuvccyTcO9CRbpmPFZ2pj03Vnpfd1LCBvzN0ijA5VePUV;
-        Expires=Tue, 03 May 2022 05:03:53 GMT; Path=/
-      - AWSALBCORS=ARB0tSvPyZ3rEJvqXIFNk7LoCiIRBg0TGZOdS3B82tmqPnsnq6dm3+TirzZwvTySv4ZDS/3g+XWkkOrAuvccyTcO9CRbpmPFZ2pj03Vnpfd1LCBvzN0ijA5VePUV;
-        Expires=Tue, 03 May 2022 05:03:53 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=QDSco+Z33//8H2pQ9a6H8U5bsWhjIOz/qNTB2OIhphiwKX3YVQyygq0f/Y5KKO3U8K5g4w7Hkw3tSAf6FG+XbfMHZHHc1F/ErX+PM1tpwaGhLbdBW/zcNUPhn7vE;
+        Expires=Wed, 04 May 2022 06:19:59 GMT; Path=/
+      - AWSALBCORS=QDSco+Z33//8H2pQ9a6H8U5bsWhjIOz/qNTB2OIhphiwKX3YVQyygq0f/Y5KKO3U8K5g4w7Hkw3tSAf6FG+XbfMHZHHc1F/ErX+PM1tpwaGhLbdBW/zcNUPhn7vE;
+        Expires=Wed, 04 May 2022 06:19:59 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB2e01df805c4143a70b811c961ed2fcda
+      - NB5c2e6bc7e306f22bd315f9c748f03b3f
       Pragma:
       - no-cache
       Cache-Control:
@@ -39805,11 +40237,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - QuL4sQQ9YaSu_BxRaQRq3VO7IDv_35bcFN9c51IYCThZFz8yQ7KUkg==
+      - Z_7i-6-ENfW-CqmOb4DBGva8R3D7NeLRqqKkM_UVSWr8_vwPavKvZg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -39856,7 +40288,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CD",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d79",
           "Name": "",
@@ -39915,7 +40347,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:53 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:59 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7d
@@ -39931,9 +40363,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIFBUtU3CE5C7UAwZvbhM0fxu+Ghp+Ea9tvz4QbcZzFjgAiEA/hhCiafpxOI9GlxAvyfav4kCKgFSQlDKF5yMkcK4Odo="
+        host date digest",signature="MEUCIAMiRz6BDdF5zTzMGdUot2UImrFySrmJSMqfEibOZM1zAiEAue9wAMFugo0c9KjTiBa66XihIpMSwA3SDffC67TihMk="
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:59 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -39946,16 +40378,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:59 GMT
       Set-Cookie:
-      - AWSALB=Jk3ERX+wzE5Q4Yq3YEcMh9C+kMf0K8E0uWnXEigtDEKlvrDMqAptgr2saaGqkwyL2gWtVzcN9+D2LhLSyhVuJ77UPN+Kl+TzgXunCZ2pYAOAf1KoJFMF8FnARwKD;
-        Expires=Tue, 03 May 2022 05:03:53 GMT; Path=/
-      - AWSALBCORS=Jk3ERX+wzE5Q4Yq3YEcMh9C+kMf0K8E0uWnXEigtDEKlvrDMqAptgr2saaGqkwyL2gWtVzcN9+D2LhLSyhVuJ77UPN+Kl+TzgXunCZ2pYAOAf1KoJFMF8FnARwKD;
-        Expires=Tue, 03 May 2022 05:03:53 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=qMX+GV7zaMr/5wVkW9viJycIult94371rVeZ2WvCvdDy2mUhip0LdisLiqZM0u95ZNaD4xKyVSYI8YLDBbmAT6DRr4kxmpNQDo53eHsAdMQgRbC9jESW0AlAuz8x;
+        Expires=Wed, 04 May 2022 06:19:59 GMT; Path=/
+      - AWSALBCORS=qMX+GV7zaMr/5wVkW9viJycIult94371rVeZ2WvCvdDy2mUhip0LdisLiqZM0u95ZNaD4xKyVSYI8YLDBbmAT6DRr4kxmpNQDo53eHsAdMQgRbC9jESW0AlAuz8x;
+        Expires=Wed, 04 May 2022 06:19:59 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB892118f882ec4c7d386ec1a97c74d3c5
+      - NB3b6ca81bb35a302a80ca3737fa92af77
       Pragma:
       - no-cache
       Cache-Control:
@@ -39985,11 +40417,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - fNawOgfkFOvvFQLr5H7Osiqfa_hQkh5GsxIXh_OWxKewFQvizf_sRg==
+      - Si2Ai-d_a5Gno4G01kZ9xLB6tWOn9ntTNzs_UGxkNctimND88rzTQg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -40036,7 +40468,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D1",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7d",
           "Name": "",
@@ -40095,7 +40527,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:53 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:59 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8c
@@ -40111,9 +40543,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIFhVr4f/MNOiqLalk6SCGbYPFJ+7nRQ/O0Jajj+FETdaAiEArscE79oOoWWLrzSV6C/EYs5DkhJdK1i7nlPXaFmXB08="
+        host date digest",signature="MEYCIQC2BeQscN01F+df3yUvgjp8RZ36crze3Or68PNuxLJrOgIhAKy2Tr+/Ktg9t7zSrqmvryyvwROfCJABF3IF+ZP6TrHT"
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:59 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -40126,16 +40558,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:59 GMT
       Set-Cookie:
-      - AWSALB=XY/2ZaNfBx30ZG76oD8dMA1jGMVrYx4nhOBo4vwisCZmDuV+R/J1+HtxyOqU4PWlaD4qeCS3WrgDs4nSgFVHIUPir3jc9l8nrMKzKhjOoL0HtyLGNGD3PpxYi7VE;
-        Expires=Tue, 03 May 2022 05:03:53 GMT; Path=/
-      - AWSALBCORS=XY/2ZaNfBx30ZG76oD8dMA1jGMVrYx4nhOBo4vwisCZmDuV+R/J1+HtxyOqU4PWlaD4qeCS3WrgDs4nSgFVHIUPir3jc9l8nrMKzKhjOoL0HtyLGNGD3PpxYi7VE;
-        Expires=Tue, 03 May 2022 05:03:53 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=PgGW69s0O1UGYzxwJ1DH2vFoubW+mtoK33xgdVy/SUbcQhIwTWJWAy06WKga0XLLzsNNyXXRQfFIaS9hgua5+m56ghrfy4nWlkuVJDRHcL71CJPDJMKfV6RdI1wj;
+        Expires=Wed, 04 May 2022 06:19:59 GMT; Path=/
+      - AWSALBCORS=PgGW69s0O1UGYzxwJ1DH2vFoubW+mtoK33xgdVy/SUbcQhIwTWJWAy06WKga0XLLzsNNyXXRQfFIaS9hgua5+m56ghrfy4nWlkuVJDRHcL71CJPDJMKfV6RdI1wj;
+        Expires=Wed, 04 May 2022 06:19:59 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4a5333a01321dc6bd88459bebc5104b6
+      - NB9efe2c6deab51ac99e69e0113b171d63
       Pragma:
       - no-cache
       Cache-Control:
@@ -40165,11 +40597,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Rth3C0Lbi9wOJVeGc-MnMCktkkQ0d15x4F4xsXuJB1FTTNv24g4Iiw==
+      - pyLvJ2sm3DHDyeROeh7cmjkX4kpQFB5wWaHAvzqWfpSdWQExoco7hA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -40216,7 +40648,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E0",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8c",
           "Name": "",
@@ -40275,7 +40707,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:53 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:59 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d65
@@ -40291,9 +40723,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIDE6SEY0HBHKUZKRV9M4oixsf4E0dsRTRGbMpiiJf+fZAiBKKajVvbQy0EC+sZoN/csiIx7xYTCxBPo92mAJJGsQ3Q=="
+        host date digest",signature="MEUCIQDk7yuEBwhrxD5qnocFHEUiralfGzQW64tXUn4Px+XDmgIgYqh6dhccl6fVzLUGE7Yp40Z/HiXWMGwZTJ2yPBflWXE="
       Date:
-      - Tue, 26 Apr 2022 05:03:53 GMT
+      - Wed, 27 Apr 2022 06:19:59 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -40306,16 +40738,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:54 GMT
+      - Wed, 27 Apr 2022 06:19:59 GMT
       Set-Cookie:
-      - AWSALB=pTJvSlo4QAwC2jtMB9b3Lt/Wyq4t6V0Es9pl9/hpfJw1Ax8/Gp0kJUaOq/WHZjmzxsgTf+bxUQzNiivOJHVzzpadSs1JuV5GBs4u1Rqj/Z3qqgssegY6c4ioP1qp;
-        Expires=Tue, 03 May 2022 05:03:54 GMT; Path=/
-      - AWSALBCORS=pTJvSlo4QAwC2jtMB9b3Lt/Wyq4t6V0Es9pl9/hpfJw1Ax8/Gp0kJUaOq/WHZjmzxsgTf+bxUQzNiivOJHVzzpadSs1JuV5GBs4u1Rqj/Z3qqgssegY6c4ioP1qp;
-        Expires=Tue, 03 May 2022 05:03:54 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=4U93MFt55uvO1jLNVJrp2mRfpGQ8sW/VVrJiNUxv+wvprxiW4iRdlHNJ0SKFSf2uEGXeVnUOfI2G//OYu8ktTEItkoPtkrsvD+LDJlIX3oykK3SxKCXBu2Jbrwgx;
+        Expires=Wed, 04 May 2022 06:19:59 GMT; Path=/
+      - AWSALBCORS=4U93MFt55uvO1jLNVJrp2mRfpGQ8sW/VVrJiNUxv+wvprxiW4iRdlHNJ0SKFSf2uEGXeVnUOfI2G//OYu8ktTEItkoPtkrsvD+LDJlIX3oykK3SxKCXBu2Jbrwgx;
+        Expires=Wed, 04 May 2022 06:19:59 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf8fb6987d48fc55f1a0e00708ceab16e
+      - NBe5773d1a082f7d2683469e2c2618be2e
       Pragma:
       - no-cache
       Cache-Control:
@@ -40345,11 +40777,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - J39YrkIuDZQPbiyJI706MhQvrWGXfpcxxV2lLooBEDHRc8sMNVTNMw==
+      - qzm0wBqLLknfaiwuqII-oFU0gjqoaPAeZHohMOkRjfgq31Xzkcv22g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -40396,7 +40828,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:EF",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d65",
           "Name": "",
@@ -40455,7 +40887,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:54 GMT
+  recorded_at: Wed, 27 Apr 2022 06:19:59 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d92
@@ -40471,9 +40903,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBj8zx/rN4m7Xc4Op/c05hPJ5OIbdUZAclndDlxKyFcYAiEAiEhkss4SYmczkMzP2wQqDnEmXJzV9c7+e/Xv3okIKnY="
+        host date digest",signature="MEUCICx1BOQcoGyEbbbYWQadWmJayMlwspHXPvDrtZgQUW7XAiEAj4ITicWRlTlyv8Clh0Ek3+xKfNy7TDH2+IJcsCxU9mg="
       Date:
-      - Tue, 26 Apr 2022 05:03:54 GMT
+      - Wed, 27 Apr 2022 06:19:59 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -40486,16 +40918,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:54 GMT
+      - Wed, 27 Apr 2022 06:20:00 GMT
       Set-Cookie:
-      - AWSALB=RRkkD0VBrMo7lCNLDhsUPJrOSDnQLKY5laP6qNbJK/q1n2iEccs30p7GMTVOWNXrQ1c8BWaFauBvVxmUH+Li24Yoqd1JhjkkbQ6FFEXr/H6k7aL0Q2GPod5IKsm6;
-        Expires=Tue, 03 May 2022 05:03:54 GMT; Path=/
-      - AWSALBCORS=RRkkD0VBrMo7lCNLDhsUPJrOSDnQLKY5laP6qNbJK/q1n2iEccs30p7GMTVOWNXrQ1c8BWaFauBvVxmUH+Li24Yoqd1JhjkkbQ6FFEXr/H6k7aL0Q2GPod5IKsm6;
-        Expires=Tue, 03 May 2022 05:03:54 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=x2Nli3MbaJo/nmRnl4mz5vk6m/BNKQFcJzwQUw1lBbs9xBOt8fQLUTmieE9jIuGo/h+pCXhOgo5svDRbFEo3Gff9TWpIssWvFknSKZaTSiyFwUtERJbqATPu3KEO;
+        Expires=Wed, 04 May 2022 06:20:00 GMT; Path=/
+      - AWSALBCORS=x2Nli3MbaJo/nmRnl4mz5vk6m/BNKQFcJzwQUw1lBbs9xBOt8fQLUTmieE9jIuGo/h+pCXhOgo5svDRbFEo3Gff9TWpIssWvFknSKZaTSiyFwUtERJbqATPu3KEO;
+        Expires=Wed, 04 May 2022 06:20:00 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6d4e7e2f4f2f9f8f1969299361da37f7
+      - NBd29e92ba7b508521fd1b5046a8beb94c
       Pragma:
       - no-cache
       Cache-Control:
@@ -40525,11 +40957,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - DuJ73nvGT997IkCwJWPP7hHTlzVqIMF1pcb0QokperBA-2VMMSMScQ==
+      - EoL3jG2ulVqJe9IMOaf9oyS84jUP2jdbGLzXE5zFqWxwvgKKYHr-6Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -40576,7 +41008,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E6",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d92",
           "Name": "",
@@ -40635,7 +41067,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:54 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:00 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d60
@@ -40651,9 +41083,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCIOd2KrJyzmPSckm5f84/LE10oUL8/ZviprU2FYX1obQIhAL+fPuRX46MlqCVeZrVeGCxPvJrX5bET/HPqG7qb9m+j"
+        host date digest",signature="MEYCIQCG8BPcyPHxeiTIva2B0i/M4DGwAo6SNZ7gn0kSVvitugIhAKb8ed/PQiBdBkx/QSjuyfLPgs5VeNVMQd68XFayTasL"
       Date:
-      - Tue, 26 Apr 2022 05:03:54 GMT
+      - Wed, 27 Apr 2022 06:20:00 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -40666,16 +41098,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:54 GMT
+      - Wed, 27 Apr 2022 06:20:00 GMT
       Set-Cookie:
-      - AWSALB=ZjkMXQ5HUYnjwmPjxE4mmhf+6GtnbJ0tc6/Sv2c+efZzLf9qkKt+gYDqIv4M/Qf0Q7kFLUSaQyNZOQs7ycVifZc1CGI1HtFzj75Z0hTQxjBD8GPqODHslbrpgyRy;
-        Expires=Tue, 03 May 2022 05:03:54 GMT; Path=/
-      - AWSALBCORS=ZjkMXQ5HUYnjwmPjxE4mmhf+6GtnbJ0tc6/Sv2c+efZzLf9qkKt+gYDqIv4M/Qf0Q7kFLUSaQyNZOQs7ycVifZc1CGI1HtFzj75Z0hTQxjBD8GPqODHslbrpgyRy;
-        Expires=Tue, 03 May 2022 05:03:54 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=/ARPJ38JqWT2OICOjrpmkIgPn7o41T6Jx2oO/KolkAl/FTl4/L3ptjftc4iwZZDYeXGQPf3dYobXpIZEEpbCXoBjyLbbsXzT1PqlkoARxosxuENdQfiUur4chfgL;
+        Expires=Wed, 04 May 2022 06:20:00 GMT; Path=/
+      - AWSALBCORS=/ARPJ38JqWT2OICOjrpmkIgPn7o41T6Jx2oO/KolkAl/FTl4/L3ptjftc4iwZZDYeXGQPf3dYobXpIZEEpbCXoBjyLbbsXzT1PqlkoARxosxuENdQfiUur4chfgL;
+        Expires=Wed, 04 May 2022 06:20:00 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0e88406afcb3600fbb78395c368a8fd3
+      - NB9e96443803bd42b8fd48e29c3f9860a9
       Pragma:
       - no-cache
       Cache-Control:
@@ -40705,11 +41137,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - K3bz0SjrB1gN5jJW_82tLJqSA0s3PhNZ2dkcIvEFT23CIHhgFKDL5g==
+      - qFsgNU2Ho38vovtuI-Lv9WZf11KvpxBYHObIUnD7X9pwV4Pz6Rgt6w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -40756,7 +41188,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:EA",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d60",
           "Name": "",
@@ -40815,7 +41247,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:54 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:00 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6e
@@ -40831,9 +41263,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCGdPhTfnyUhyauxq4FPilletMFVqnyvZNzzQvdKiaJlwIhAJ4d2uvnPdVY2bDl7O6niGPQR1vAMP+KBRs5CQvq6SEs"
+        host date digest",signature="MEQCIHCyh3R+uLbTxf+DNOXtENuZ4azUF/oDbXDLGiCWixu7AiAlSYG56LrzD5xiVw2dD1ya2TwDsE3o0QBzH6/5Gs9mmg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:54 GMT
+      - Wed, 27 Apr 2022 06:20:00 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -40846,16 +41278,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:54 GMT
+      - Wed, 27 Apr 2022 06:20:00 GMT
       Set-Cookie:
-      - AWSALB=z3WrqCt1guKPS8nB2VPjsul0srF3lmbhXzzaeAsQLN/E1ypYUzlFxbcPLIOUo/WfxhA84PJexzWPuR0MaRxmpGe0OnNsA8Z9k5XrQHg36Y7FZwfJMhVd8eGuW1Al;
-        Expires=Tue, 03 May 2022 05:03:54 GMT; Path=/
-      - AWSALBCORS=z3WrqCt1guKPS8nB2VPjsul0srF3lmbhXzzaeAsQLN/E1ypYUzlFxbcPLIOUo/WfxhA84PJexzWPuR0MaRxmpGe0OnNsA8Z9k5XrQHg36Y7FZwfJMhVd8eGuW1Al;
-        Expires=Tue, 03 May 2022 05:03:54 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=l9NTimLW4TyPFkirCAKrzkGoSi+VjjLlIAva3jfiHo3lNLhHA3eMLGfw5IhDTx1b44IJYzlRgofbjW+d9UJGEIgJPPqbvOg00fTPNekxU3r+OWuByS11ZU3kQUSr;
+        Expires=Wed, 04 May 2022 06:20:00 GMT; Path=/
+      - AWSALBCORS=l9NTimLW4TyPFkirCAKrzkGoSi+VjjLlIAva3jfiHo3lNLhHA3eMLGfw5IhDTx1b44IJYzlRgofbjW+d9UJGEIgJPPqbvOg00fTPNekxU3r+OWuByS11ZU3kQUSr;
+        Expires=Wed, 04 May 2022 06:20:00 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB2773eb2910c403ce742b1c2077a7c426
+      - NBd47a4746c97d31133881e017d390a787
       Pragma:
       - no-cache
       Cache-Control:
@@ -40885,11 +41317,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 8O8z0pkId45C2BBhqeLvVF5DmcG63zaNtHehHemFfqEmEUFwPsp6WA==
+      - QpDNLt20NwpjKb-HVXNh8Ouswoa1v59JNlZjbf660PRaoDC6sDWsfw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -40936,7 +41368,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F8",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "trunk",
           "Moid": "614ce25c4630312d42bf1d6e",
           "Name": "",
@@ -40995,7 +41427,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:54 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:00 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d83
@@ -41011,9 +41443,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIF6rYujuFoF1n79MOzizRZ1mbF2z8R+Ry2pmwzzCL/VTAiAnByt0BjAlqU0bEm11k9T2FwyBzUn904kNOSJrvwuLPw=="
+        host date digest",signature="MEUCIQDGpXMr9jW9oIB7BmN5K2YCf7sSuK+umpFovBtQ3KJPLwIgdS7aAuyWj+2EncgL13p1cE/pYI7DvdJYd/RYMWt/pcI="
       Date:
-      - Tue, 26 Apr 2022 05:03:54 GMT
+      - Wed, 27 Apr 2022 06:20:00 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -41026,16 +41458,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:54 GMT
+      - Wed, 27 Apr 2022 06:20:00 GMT
       Set-Cookie:
-      - AWSALB=rRpFoDwz2qIFzC0tG0huYQqNV3fg5oAvpU/B3X5szHwN4pTVAYntd2DqufQZt+Dric73Um21efcdvs4CXIfyeKuT9HCa0gYGmDy4Qr7hiXDkNp/JwRFGOx0EjNRs;
-        Expires=Tue, 03 May 2022 05:03:54 GMT; Path=/
-      - AWSALBCORS=rRpFoDwz2qIFzC0tG0huYQqNV3fg5oAvpU/B3X5szHwN4pTVAYntd2DqufQZt+Dric73Um21efcdvs4CXIfyeKuT9HCa0gYGmDy4Qr7hiXDkNp/JwRFGOx0EjNRs;
-        Expires=Tue, 03 May 2022 05:03:54 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=TTMlMTkeMUVOMvYmjjKW62T4s9kHR/NdNzs2cVI+SJGTewdunWwlYSju5kNKbtrATtH1lH5tGiCs2a9QWN2bydt6pZS1SuBHDDBdc186PlEtGNysU5KPxFG642tx;
+        Expires=Wed, 04 May 2022 06:20:00 GMT; Path=/
+      - AWSALBCORS=TTMlMTkeMUVOMvYmjjKW62T4s9kHR/NdNzs2cVI+SJGTewdunWwlYSju5kNKbtrATtH1lH5tGiCs2a9QWN2bydt6pZS1SuBHDDBdc186PlEtGNysU5KPxFG642tx;
+        Expires=Wed, 04 May 2022 06:20:00 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB87c421fdd52ed9acf901271db8df47c6
+      - NB0cbf3e30bc4eb989ddb1e746f78db4f4
       Pragma:
       - no-cache
       Cache-Control:
@@ -41065,11 +41497,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 1XK0952q5pXHTx2jvMgnRvpf6SrtYvTi26H3AbkD8KTV6tPShdkdag==
+      - 1LBLIAROQHX7Rjq3dJmfU9FeybfSkXN1xUCSrihA5k_7cy_pGoavkw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -41116,7 +41548,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D7",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d83",
           "Name": "",
@@ -41175,7 +41607,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:54 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:00 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d87
@@ -41191,9 +41623,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCQhqgfmqRC2qv5T0xsJ2Y88zE3R9SKIraSvAOIO3nBTAIgWprGhK4JMl5MgBJ1IFyCA4ND+H3dyMDtKrYYXL5paSw="
+        host date digest",signature="MEUCIQDWG/mjFafHgZ5KZ+ArzI1IJIV4LzSsUiKRKZOg71w62wIgeyZDE0fk8w9RyLauOhxcDtQkoNuYaOhcWMFKuOkZuEA="
       Date:
-      - Tue, 26 Apr 2022 05:03:55 GMT
+      - Wed, 27 Apr 2022 06:20:00 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -41206,16 +41638,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:55 GMT
+      - Wed, 27 Apr 2022 06:20:00 GMT
       Set-Cookie:
-      - AWSALB=VsF45zU0XrQ67/6Nlq6gO1flRkZ2UnZwK4eVL7LI/UdT46pt45/QWJ3jFl3g0rGUciMKeSPD/bXV3BN+JuKky1DcvPHnLh4zWFXElxxktK2bl8/k/20oLeCXz2Zx;
-        Expires=Tue, 03 May 2022 05:03:55 GMT; Path=/
-      - AWSALBCORS=VsF45zU0XrQ67/6Nlq6gO1flRkZ2UnZwK4eVL7LI/UdT46pt45/QWJ3jFl3g0rGUciMKeSPD/bXV3BN+JuKky1DcvPHnLh4zWFXElxxktK2bl8/k/20oLeCXz2Zx;
-        Expires=Tue, 03 May 2022 05:03:55 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ir59d1Yr9Euxp1ZZKHBOHsci+hLYOzOyBplozitVFhLOfdO5oc4NHRqtzCaN/IbNT6JgL/+la/jyHumfOdmZOiFr6SMooi1zJFMdRSbUQgds3Nk16Usem/hIXnBY;
+        Expires=Wed, 04 May 2022 06:20:00 GMT; Path=/
+      - AWSALBCORS=ir59d1Yr9Euxp1ZZKHBOHsci+hLYOzOyBplozitVFhLOfdO5oc4NHRqtzCaN/IbNT6JgL/+la/jyHumfOdmZOiFr6SMooi1zJFMdRSbUQgds3Nk16Usem/hIXnBY;
+        Expires=Wed, 04 May 2022 06:20:00 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc36b5fc04b9f5effd29a02a9a6b40f28
+      - NBbcf1ae5f73053c0e04c923476d62a154
       Pragma:
       - no-cache
       Cache-Control:
@@ -41245,11 +41677,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 0aSoJO9lrbKlI3p9yTzOQ8wfZPZRWOCedwplZo9QIV-FQjFajgYCJg==
+      - l7eY3cEaLnwrMtdr7pqoc75VVLqa96k_40GvZZ1bBET19Im3m_bFLg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -41296,7 +41728,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DB",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25c4630312d42bf1d87",
           "Name": "",
@@ -41355,7 +41787,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:55 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:01 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d5e
@@ -41371,9 +41803,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDJpAjzwzzK1uBEzoU84x4JPT5ph1uE8Zxo9HvkRgS34QIhAOtl75wescRVBzot/RVf5NA2Q9vPSq/WAivSfrF4DWCV"
+        host date digest",signature="MEUCIQDtNhuGLIlJ6CSHfv3QMYMMOW/5BHnDnXJ3LSWV6vUnyQIgW2QdwxtvzBrIFwuOZpkbeMnCw3hrgF6AZ6jrjGl0fmQ="
       Date:
-      - Tue, 26 Apr 2022 05:03:55 GMT
+      - Wed, 27 Apr 2022 06:20:01 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -41386,16 +41818,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:55 GMT
+      - Wed, 27 Apr 2022 06:20:01 GMT
       Set-Cookie:
-      - AWSALB=4m5UgPCR59rnyilK0D/3nE3Yz00KDKiRVS6RB55yHmlowHv89UL0NFoRTm6cd6vOHL4ch/S1VVMAbjpRgd8x8Kpfe2R3lfO1G3CZ0Xkrh+NOYXeTDVDtEYT+YFrp;
-        Expires=Tue, 03 May 2022 05:03:55 GMT; Path=/
-      - AWSALBCORS=4m5UgPCR59rnyilK0D/3nE3Yz00KDKiRVS6RB55yHmlowHv89UL0NFoRTm6cd6vOHL4ch/S1VVMAbjpRgd8x8Kpfe2R3lfO1G3CZ0Xkrh+NOYXeTDVDtEYT+YFrp;
-        Expires=Tue, 03 May 2022 05:03:55 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=FZl9isWVA6FfPZQZG/NRlZVK654OBvrcf7FRFRkLu2UqWRoFDusCwUzyTm7HY7dOnbQyzZr/XHOStwuwMgG35fYk6iWzGLx1CJvc61MRmPtg5oxZ3LqfMssEHHJN;
+        Expires=Wed, 04 May 2022 06:20:01 GMT; Path=/
+      - AWSALBCORS=FZl9isWVA6FfPZQZG/NRlZVK654OBvrcf7FRFRkLu2UqWRoFDusCwUzyTm7HY7dOnbQyzZr/XHOStwuwMgG35fYk6iWzGLx1CJvc61MRmPtg5oxZ3LqfMssEHHJN;
+        Expires=Wed, 04 May 2022 06:20:01 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4a27f0aa7d453ada8bfb6796b8783348
+      - NBd9ad646edcde62435743d4ee90f97d87
       Pragma:
       - no-cache
       Cache-Control:
@@ -41425,11 +41857,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - giyHSGuK6Zlrz6GkqWtgGAXJ9ronKoj9JW-6OO0p5xYMHwl2fhiVCg==
+      - irw7597KAGL3UAGMO3oCcogz9So5CG7oxkrlDe8zbhtZr7uawUWTaw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -41476,7 +41908,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E8",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d5e",
           "Name": "",
@@ -41535,7 +41967,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:55 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:01 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6c
@@ -41551,9 +41983,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHIJ6ZIe7YXM2IdSVYxcbunyFqdPr/2ejk5xQ1quqhqlAiEA1AFcy7uNeQInrEhcLhMrNCajS+B2qTELnqC+m5AjLt0="
+        host date digest",signature="MEYCIQCTXe3krDvMIZ6xWOylFdM90KDgnuuk/Aup2UMHIZNduwIhAIaFEy56ooGJt0GAeD6AzwzstuAL4ez6k/vgcx0HSbLk"
       Date:
-      - Tue, 26 Apr 2022 05:03:55 GMT
+      - Wed, 27 Apr 2022 06:20:01 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -41566,16 +41998,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:55 GMT
+      - Wed, 27 Apr 2022 06:20:01 GMT
       Set-Cookie:
-      - AWSALB=DMYODiabHe2f6HpJYNGOOlkGDQrTewnzuTvHgoZV2f7ym2X95J4XXHRZHWKwLC/beOcfx+z3UEO52JN2XuCc9dgbmV2QygPk8P7F6kwuMa1rDI1AUFJvpo4ImXQ+;
-        Expires=Tue, 03 May 2022 05:03:55 GMT; Path=/
-      - AWSALBCORS=DMYODiabHe2f6HpJYNGOOlkGDQrTewnzuTvHgoZV2f7ym2X95J4XXHRZHWKwLC/beOcfx+z3UEO52JN2XuCc9dgbmV2QygPk8P7F6kwuMa1rDI1AUFJvpo4ImXQ+;
-        Expires=Tue, 03 May 2022 05:03:55 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=jefJwn0FFi1dns5hO86ndEoPWwRrx9syLXZX7CWdtc2hvprinIzKEQOtAATL3DdGXBF1SqVB8jFGFm7ovuYvMg/ml656QjRGx/HRdgEGOWvNQ3ptAJ5L36zwpW6s;
+        Expires=Wed, 04 May 2022 06:20:01 GMT; Path=/
+      - AWSALBCORS=jefJwn0FFi1dns5hO86ndEoPWwRrx9syLXZX7CWdtc2hvprinIzKEQOtAATL3DdGXBF1SqVB8jFGFm7ovuYvMg/ml656QjRGx/HRdgEGOWvNQ3ptAJ5L36zwpW6s;
+        Expires=Wed, 04 May 2022 06:20:01 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc320ff630094042977e3d2ea223522d5
+      - NB61f91b8f123d8dfce2645ebcd85a240c
       Pragma:
       - no-cache
       Cache-Control:
@@ -41605,11 +42037,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - GXYwUuSsspeiZHJZF9uLzY4bAwo7_xciUhQ4nBNXIDDZCPoeqhf7yg==
+      - 7uFXxipbWYt2f_11ykZwieSqdVCMPaw01PvoYqqkXYJ8_SbAdOb4qw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -41656,7 +42088,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F6",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d6c",
           "Name": "",
@@ -41715,7 +42147,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:55 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:01 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7e
@@ -41731,9 +42163,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDPc0pph9WaUKxi6PvCZ7nlehadAO1waU8v3kr0h7yjVgIgW7kxL2wrWd2ubSgQXA88jenQg8E2TC49MKI3bD3viEE="
+        host date digest",signature="MEUCIAkd+aUjveTNv65upOorkuAul+N51/cvhaVhzqfa+SVSAiEAmoqAQMaUX+Dv9/y+Q43wMunynmYSapBSfcqT7o9P3ZA="
       Date:
-      - Tue, 26 Apr 2022 05:03:55 GMT
+      - Wed, 27 Apr 2022 06:20:01 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -41746,16 +42178,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:55 GMT
+      - Wed, 27 Apr 2022 06:20:01 GMT
       Set-Cookie:
-      - AWSALB=7ORC9RzHAcm3mSEfNJbsLDKyRynb6+3KlI56yWT1pFmEqRRgPYzXXh0DZJ+4Wa1sk2pHO8SF64c8fE17hJhyKWX/ecRJJ8A9tNaFxAE+dbMvi/OUPaS1SBcdjSEy;
-        Expires=Tue, 03 May 2022 05:03:55 GMT; Path=/
-      - AWSALBCORS=7ORC9RzHAcm3mSEfNJbsLDKyRynb6+3KlI56yWT1pFmEqRRgPYzXXh0DZJ+4Wa1sk2pHO8SF64c8fE17hJhyKWX/ecRJJ8A9tNaFxAE+dbMvi/OUPaS1SBcdjSEy;
-        Expires=Tue, 03 May 2022 05:03:55 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=yUExi2pkhAAhFsZFMHsCABLqVdrOsSKrvLTR3XeA/BY+dqBgaw+FoG0FEZ/AqQWs9f43ncKXK45GHDqRTl4lMR52oHRWp42D4qqVOcywX47TP2xlFqOyD8mfYORD;
+        Expires=Wed, 04 May 2022 06:20:01 GMT; Path=/
+      - AWSALBCORS=yUExi2pkhAAhFsZFMHsCABLqVdrOsSKrvLTR3XeA/BY+dqBgaw+FoG0FEZ/AqQWs9f43ncKXK45GHDqRTl4lMR52oHRWp42D4qqVOcywX47TP2xlFqOyD8mfYORD;
+        Expires=Wed, 04 May 2022 06:20:01 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0be4e6078393652c4049787d93680160
+      - NB05c6aa50f0c7559784ee694f0914de6a
       Pragma:
       - no-cache
       Cache-Control:
@@ -41785,11 +42217,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - zzZGm_TcxRSJNfzytZXAhpEiLss2UZqGEgngGcE0ZnO6uFV-HSmtcA==
+      - I_MnGohzQX0vncttBB4j1joOCT6HsHX9Xv3E4AGtpgnddfUicFYE1Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -41836,7 +42268,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D2",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7e",
           "Name": "",
@@ -41895,7 +42327,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:55 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:01 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6d
@@ -41911,9 +42343,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCjIt+K+jtewwrvHi/ryLAyZlqmXsEmVa5WjrzZhSqULQIgQ5pWHlo3QQdU6DLi35dvNopzdbTY6DvIMaeRyDDEA1o="
+        host date digest",signature="MEYCIQDgM5YUntdw5LO5XphVnLKV24O7Sln9HYa0Pb/swGctDAIhAMKgxJj74VO5OM6Kc1DxqUUqPJZOXk8OVZbhDeMk5IBw"
       Date:
-      - Tue, 26 Apr 2022 05:03:55 GMT
+      - Wed, 27 Apr 2022 06:20:01 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -41926,16 +42358,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:56 GMT
+      - Wed, 27 Apr 2022 06:20:02 GMT
       Set-Cookie:
-      - AWSALB=VkuGdWheohkMR+hVO+aRORHjUSmz4b+msqQlkAEKCoRntPxnr9E499uD6zo2pvRKC+MjVclIEOjdJQ8A8ckqYkskm29yXrOu95EUFZcYt4zO0bJxkkiFd3bWzhVW;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/
-      - AWSALBCORS=VkuGdWheohkMR+hVO+aRORHjUSmz4b+msqQlkAEKCoRntPxnr9E499uD6zo2pvRKC+MjVclIEOjdJQ8A8ckqYkskm29yXrOu95EUFZcYt4zO0bJxkkiFd3bWzhVW;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=WqrOWUhiVdI5OOcOvki8rGD+m3atBlmlwAtoZtXH7PCZ8Lvzq3B/3tJGgABeM85XqnFP+sze7exQ8IZRwVIb83OwaIYyTH7Z1gcpRNkgGk4Vd19ZG2of4mKynNnM;
+        Expires=Wed, 04 May 2022 06:20:02 GMT; Path=/
+      - AWSALBCORS=WqrOWUhiVdI5OOcOvki8rGD+m3atBlmlwAtoZtXH7PCZ8Lvzq3B/3tJGgABeM85XqnFP+sze7exQ8IZRwVIb83OwaIYyTH7Z1gcpRNkgGk4Vd19ZG2of4mKynNnM;
+        Expires=Wed, 04 May 2022 06:20:02 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB2d7d9f5e2bd09c9fb071b10694e88572
+      - NBe6b8a9ca04ac38e3deb814506082dc94
       Pragma:
       - no-cache
       Cache-Control:
@@ -41965,11 +42397,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - VVz8mL-cpWzmn4N3aGL2gKiDW0gVULeQJInPVs2ClAzpW0iNdEL7yA==
+      - bjjayDRE3mYouC-b64FoscBWfMiLdR12ql5WOV-QG5XpP8Zm93723w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -42016,7 +42448,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F7",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d6d",
           "Name": "",
@@ -42075,7 +42507,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:56 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:02 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d82
@@ -42091,9 +42523,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHBIfB/67TOZaRjsSuuppyvPP8hQM07bP3TpmaHoj6nSAiEAzr3W9tdIyKwKH94RjTRa3xQYUhWIQNCzNj9Cop+tkM4="
+        host date digest",signature="MEQCID7kQinVuQJqXRNuacsJaH9Uv/ziRlsrc3N0t5dQGd7rAiAko8W1h/gd9ShlmJ8VQswxITavwiXDKsHBkZkne7O1Pg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:56 GMT
+      - Wed, 27 Apr 2022 06:20:02 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -42106,16 +42538,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:56 GMT
+      - Wed, 27 Apr 2022 06:20:02 GMT
       Set-Cookie:
-      - AWSALB=JgSdOa5VvIhm1cmmhj5RcPlU9mN2SxZ/xUm7M2myT4hr9GVh9sCyi0HzpIi4KaAQ7a34MlYmwpEVt3gU3Dc/239xvJODKA+Rwi/w2KJyI4xHREBX3MhC8Mb3HSEp;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/
-      - AWSALBCORS=JgSdOa5VvIhm1cmmhj5RcPlU9mN2SxZ/xUm7M2myT4hr9GVh9sCyi0HzpIi4KaAQ7a34MlYmwpEVt3gU3Dc/239xvJODKA+Rwi/w2KJyI4xHREBX3MhC8Mb3HSEp;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=mgb7wd2ZYDaUmf7/s5HbQriGfuUth1h8Gp+2d1JXps9V72h9RVFhdU0/Y/6tFJKGWgVR4IRxGv/O2zaiSRYsuwXKJ1zQnXpptkAZc1/TEIzuTaH9roIPwoUFAh46;
+        Expires=Wed, 04 May 2022 06:20:02 GMT; Path=/
+      - AWSALBCORS=mgb7wd2ZYDaUmf7/s5HbQriGfuUth1h8Gp+2d1JXps9V72h9RVFhdU0/Y/6tFJKGWgVR4IRxGv/O2zaiSRYsuwXKJ1zQnXpptkAZc1/TEIzuTaH9roIPwoUFAh46;
+        Expires=Wed, 04 May 2022 06:20:02 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB57017557c5966bf0556a7a279ee89add
+      - NBcefd71ccf00d60f9519b0c82948cb05a
       Pragma:
       - no-cache
       Cache-Control:
@@ -42145,11 +42577,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - uTryLu7PpKGCINx6PnJ84mgz8MWfmRugY_65lajZGIIH2iOfZIPvmQ==
+      - DTi_7qS19HjdbqxPxgRmy8bLo5QneOHRAvR0EIogO6pLeGmN6Tu-fQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -42196,7 +42628,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D6",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d82",
           "Name": "",
@@ -42255,7 +42687,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:56 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:02 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d81
@@ -42271,9 +42703,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIEyq4r6Jg22vFKHGEIlgGwKe506NFFWvGP3qFzO8B+boAiA6kA7LROOzS49K9DBuIZjnZUIugNjFtNt+PCCJBTSeHA=="
+        host date digest",signature="MEUCIQC0MCJ+7Tehx9qZih9kwsvUcRz3QG9xDQUfqD7Gyg6xFAIgXUBbXXXG/29ZOVgV8HdVycry3JnZh4xe6YzS1jPPiM8="
       Date:
-      - Tue, 26 Apr 2022 05:03:56 GMT
+      - Wed, 27 Apr 2022 06:20:02 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -42286,16 +42718,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:56 GMT
+      - Wed, 27 Apr 2022 06:20:02 GMT
       Set-Cookie:
-      - AWSALB=9BQHyNXJzIDq/r1MlHQXM8s+kVE7AvOGvKb6WI6GcudJgdVDy/vLc347Zk2vSe4b3iIK+YZJeDQ+8KTNVKNWrZQEGR5QMx/tyxL5yMX2515V+UKjgS5SbMUh2IYp;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/
-      - AWSALBCORS=9BQHyNXJzIDq/r1MlHQXM8s+kVE7AvOGvKb6WI6GcudJgdVDy/vLc347Zk2vSe4b3iIK+YZJeDQ+8KTNVKNWrZQEGR5QMx/tyxL5yMX2515V+UKjgS5SbMUh2IYp;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=VkjNj7lkmrQ5LGU/P/XXQLvoDsurFOGtVJ/xY0YhL6+NT+SWFgN6nMHi3hrSiTI/UlT21dXAqDobQUwqYF3AcCq5vR2EhvRexmGFEtucrIxOuo2GCR1s3XYe/YG1;
+        Expires=Wed, 04 May 2022 06:20:02 GMT; Path=/
+      - AWSALBCORS=VkjNj7lkmrQ5LGU/P/XXQLvoDsurFOGtVJ/xY0YhL6+NT+SWFgN6nMHi3hrSiTI/UlT21dXAqDobQUwqYF3AcCq5vR2EhvRexmGFEtucrIxOuo2GCR1s3XYe/YG1;
+        Expires=Wed, 04 May 2022 06:20:02 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa73dba97cd6228ac5073185e3fb8940c
+      - NBfdf4b8773daac0c1f14e715c47340ef6
       Pragma:
       - no-cache
       Cache-Control:
@@ -42325,11 +42757,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - NRX1UrRXUt_SSPxiksH-9n2eLmS03Q8sIJ9DF-AukmBQxdWgOYpr5A==
+      - fEKSwlmU8EsHoAjOU_CX-MTrmzK86Ukv5ALrgJFn5My-Q-_TxHy0ag==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -42376,7 +42808,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D5",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d81",
           "Name": "",
@@ -42435,7 +42867,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:56 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:02 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d89
@@ -42451,9 +42883,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCktXWhOA792rflR8TUVtO4NBlT/9F6ET291GJ4sH99UgIhAIncU/V0CpOy2Tx9g99j9w57F+YqLha/N/4FBPhk///B"
+        host date digest",signature="MEQCIATqknzOGSgCraT/y+2wQcN0mAUJj7FNUVnti0zGaYziAiBTK+JIpZ+0I358lZTsBFOiSeptvhcG9GSvrPKFrAUfIA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:56 GMT
+      - Wed, 27 Apr 2022 06:20:02 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -42466,16 +42898,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:56 GMT
+      - Wed, 27 Apr 2022 06:20:02 GMT
       Set-Cookie:
-      - AWSALB=mIzH4W1p8ieszKT+zZuGwKIbddeamf9Xw/Hl6/WXQaRrguf2fS6ey3VMToUw2D1U5N4hfZGy3YlpMNtR5VA5FEFmYnW+9pAcH5FmKWDYTAeqpAxq+oIHGEDzgXAO;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/
-      - AWSALBCORS=mIzH4W1p8ieszKT+zZuGwKIbddeamf9Xw/Hl6/WXQaRrguf2fS6ey3VMToUw2D1U5N4hfZGy3YlpMNtR5VA5FEFmYnW+9pAcH5FmKWDYTAeqpAxq+oIHGEDzgXAO;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=f5dEVgfG5En7FtpJ+7JkaR9E9NH8BlaHuPOm05LMyDNPLr0oyT1BbjVdURj/iwujIlBLgZzZP7B7EI7bZntYQGtR9DD3GJTio6raM9NMrriUs2l+w7rSsZNCXJYK;
+        Expires=Wed, 04 May 2022 06:20:02 GMT; Path=/
+      - AWSALBCORS=f5dEVgfG5En7FtpJ+7JkaR9E9NH8BlaHuPOm05LMyDNPLr0oyT1BbjVdURj/iwujIlBLgZzZP7B7EI7bZntYQGtR9DD3GJTio6raM9NMrriUs2l+w7rSsZNCXJYK;
+        Expires=Wed, 04 May 2022 06:20:02 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd3fc605f6f2837d1a564a13959459f6d
+      - NBe0c04ec89a04f12ceb231b5f6b5c7467
       Pragma:
       - no-cache
       Cache-Control:
@@ -42505,11 +42937,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - r0YIiQ3vcmAPWY_Y1VFB9BLOfgUk8gzCJD2IwafW8Q_w5GRZm-iCeA==
+      - oLCaxlo433erBRIt_TdGvK0v5tMB0T9BjFOCXpyPFvqHzAnwPkSP1g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -42556,7 +42988,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DD",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d89",
           "Name": "",
@@ -42615,7 +43047,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:56 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:02 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d78
@@ -42631,9 +43063,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHj/N2/Ht1WeEp+fHYSws5W3gNbayp4zQNuppvNlbZ75AiEAoB8X/1ABtGsFd6rfUrDC3bAejBI/moF4mtCBtXqkmzw="
+        host date digest",signature="MEQCICZMTnyVV5iTM8hnJawPK26pze8sqoqve9s7YI8folo1AiBlwsMIdOWKj7s8jNZrQ5TH7deDYoDi08wp0v2D5d0S+g=="
       Date:
-      - Tue, 26 Apr 2022 05:03:56 GMT
+      - Wed, 27 Apr 2022 06:20:02 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -42646,16 +43078,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:56 GMT
+      - Wed, 27 Apr 2022 06:20:02 GMT
       Set-Cookie:
-      - AWSALB=Jvd4kZDvwhhD7ex/9hq/OWYm0SqurwMHAXdoUnW/YffH0RwsDSHA8fk4d3yMiJfIBboo9dboG/PpttJqz3qlHH1uPAXXJcmbSIjfftR7+7NGrkmJ24jZn5HGVskh;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/
-      - AWSALBCORS=Jvd4kZDvwhhD7ex/9hq/OWYm0SqurwMHAXdoUnW/YffH0RwsDSHA8fk4d3yMiJfIBboo9dboG/PpttJqz3qlHH1uPAXXJcmbSIjfftR7+7NGrkmJ24jZn5HGVskh;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=nXSawrW0AxQyxS2uMX2r5dLziEWoznyCbak+j1z2ZG+sfe/0rwuyoMvZd5DY09EBcIoN6JBugvj/Cz44QWDL240+sd2arwzO+NaEdlz+CaFs8wZ96jwfT/nL7iT9;
+        Expires=Wed, 04 May 2022 06:20:02 GMT; Path=/
+      - AWSALBCORS=nXSawrW0AxQyxS2uMX2r5dLziEWoznyCbak+j1z2ZG+sfe/0rwuyoMvZd5DY09EBcIoN6JBugvj/Cz44QWDL240+sd2arwzO+NaEdlz+CaFs8wZ96jwfT/nL7iT9;
+        Expires=Wed, 04 May 2022 06:20:02 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBcbf6257b0b32984d015cdd499742ecf4
+      - NB0cbf8f5bbf35bfac40eb83095ea62fc9
       Pragma:
       - no-cache
       Cache-Control:
@@ -42685,11 +43117,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - qDs96sg2EvCovBauDtpR7hCdyn6us7MSBApN7CrSXORjKMe4pkWq_Q==
+      - cgLVPrcG-flV6XF3duEKEUVMgGTcP-8qvl7iQrJBFWGXMcBlkgOaAA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -42736,7 +43168,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CC",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d78",
           "Name": "",
@@ -42795,7 +43227,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:56 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:02 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d5f
@@ -42811,9 +43243,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCID44lBKpGrmAUfFu36XCWW9fwZsrrN4wARSOqKpBdx1/AiEApLQnKGnrIJlW3tX9P0D58HE8iAHAC2fh0OtVG33wu5Y="
+        host date digest",signature="MEUCIAdZgSWNbjTLbXCEx+6LrTJmvpK/9rT657LA3+cTWyOWAiEA2AVt6a5Xa6SDzhJea7L41DCbWGrGp5fyi6OC0xGV4w0="
       Date:
-      - Tue, 26 Apr 2022 05:03:56 GMT
+      - Wed, 27 Apr 2022 06:20:02 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -42826,16 +43258,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:03 GMT
       Set-Cookie:
-      - AWSALB=oxjIGvPhOq5v/bfgqJPmML/1Tp9fq5DDqEzIBrEML7npm/7coHxcZaH0R8X+igsuTGNks9tMTiiD7ITAGAbXPe9I7DTvSH8Mj23+LAcaGXjTWV3f7LvbnT9cmx7n;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/
-      - AWSALBCORS=oxjIGvPhOq5v/bfgqJPmML/1Tp9fq5DDqEzIBrEML7npm/7coHxcZaH0R8X+igsuTGNks9tMTiiD7ITAGAbXPe9I7DTvSH8Mj23+LAcaGXjTWV3f7LvbnT9cmx7n;
-        Expires=Tue, 03 May 2022 05:03:56 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=H4c9IlSqxQ2zzWWUU1TYdtMqSKc3SDwUir8PYGZTxxHGFO663HgnuyM8jxnL1UjuvR2DjyJK1VhOh8nmJc1Gf2ArUGMrjxfgzI6GfUS11kU+JwHts507Ei4b4PDt;
+        Expires=Wed, 04 May 2022 06:20:03 GMT; Path=/
+      - AWSALBCORS=H4c9IlSqxQ2zzWWUU1TYdtMqSKc3SDwUir8PYGZTxxHGFO663HgnuyM8jxnL1UjuvR2DjyJK1VhOh8nmJc1Gf2ArUGMrjxfgzI6GfUS11kU+JwHts507Ei4b4PDt;
+        Expires=Wed, 04 May 2022 06:20:03 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB1b06876cc1e9003e3b1905bda5d34be9
+      - NB33071483382880f479c84042260962f5
       Pragma:
       - no-cache
       Cache-Control:
@@ -42865,11 +43297,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - iF-kWcd0M8cOkjAdAnI89PATU1PWOSQSKFqRtgvRkbIvzVVk3gQ4bg==
+      - ucipCrIB71gyoYAFDBtwcPEgGTAh_zCO2TDbQ5j7EYv2yD9CYsO2gg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -42916,7 +43348,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E9",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d5f",
           "Name": "",
@@ -42975,7 +43407,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:57 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:03 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d61
@@ -42991,9 +43423,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIAajATms5SdM081e5n4EeME5pemi0ug430UPbJyhcsWMAiAM67bsj28W69N8irr+og/sAHOMYohWoNAN61bKL2pclA=="
+        host date digest",signature="MEUCIFz/Ya7FE73NDWcxdpAMAZqRiw6o8F9GU2Zx5dmaF3RxAiEAgaQpNpxoBxT04sBy7pyNztsop2ZHr4db91xrOa5WzoY="
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:03 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -43006,16 +43438,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:03 GMT
       Set-Cookie:
-      - AWSALB=4C/q2B73p3RsIDIHAc3EGqnK6q40Fek1/R/WSXPHhLIELVuWYU55ODZk/CMCGx+oyDImpkt9jBUKQiXXp8X5rW28dOjZgqhkacvwm5ep2vV85QsTPhC7SJ8EY16M;
-        Expires=Tue, 03 May 2022 05:03:57 GMT; Path=/
-      - AWSALBCORS=4C/q2B73p3RsIDIHAc3EGqnK6q40Fek1/R/WSXPHhLIELVuWYU55ODZk/CMCGx+oyDImpkt9jBUKQiXXp8X5rW28dOjZgqhkacvwm5ep2vV85QsTPhC7SJ8EY16M;
-        Expires=Tue, 03 May 2022 05:03:57 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=lASQoVc9QxARl1Bk4+ThoCzx79K3BnVVQtjV75mFlcPeyd409wKdSbKv2OVzVJGPDmYSMo1PuO+n1AXBN0jeGzBRbK/8q2XleR+uG7/USvXdjLGAV8WgLOfvByLF;
+        Expires=Wed, 04 May 2022 06:20:03 GMT; Path=/
+      - AWSALBCORS=lASQoVc9QxARl1Bk4+ThoCzx79K3BnVVQtjV75mFlcPeyd409wKdSbKv2OVzVJGPDmYSMo1PuO+n1AXBN0jeGzBRbK/8q2XleR+uG7/USvXdjLGAV8WgLOfvByLF;
+        Expires=Wed, 04 May 2022 06:20:03 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB1d5ed1c77220c06b6e512fc12576b745
+      - NB3ed9b91d12241c78c9e5a089a9f7053c
       Pragma:
       - no-cache
       Cache-Control:
@@ -43045,11 +43477,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 1dTKxI7nBeN0cjfHR0nMVY500EYyolsV8C78wYzuCX-5kTuZ_CdgHw==
+      - ema3Hw84y6srjdTR42h2icV_yUAC6n08cBQp0rQg2cKQ9HXIFIKD-Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -43096,7 +43528,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:EB",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d61",
           "Name": "",
@@ -43155,7 +43587,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:57 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:03 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d84
@@ -43171,9 +43603,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIGNAQnL//F6SGdLFRRbbBAKk4Psc/6YF2fE57HRYV/T8AiBaRU7cEBVP57SNDETclIoJDuQCRlsdx5edtSsv0Xj5oQ=="
+        host date digest",signature="MEQCIEHX+91Ka997aWbSZ996nNm9Xt5cVHVpaTiHVcXZaebrAiAY06ffRHcYUhX1l+wiZimhtmo02r6XXd3c7UxTO9Bm7A=="
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:03 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -43186,16 +43618,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:03 GMT
       Set-Cookie:
-      - AWSALB=sfWt/Mv+w2GPCwMdYanf1oGrMpLmxyfD29R0PZ7qJ7Xg8t1tch6gX4jHtHli0xjujMLl71rJWqjjFyYGQjQqKIPwtmQmPPT2bGLbGcwm8w/w0WrjbPMMv52YquA9;
-        Expires=Tue, 03 May 2022 05:03:57 GMT; Path=/
-      - AWSALBCORS=sfWt/Mv+w2GPCwMdYanf1oGrMpLmxyfD29R0PZ7qJ7Xg8t1tch6gX4jHtHli0xjujMLl71rJWqjjFyYGQjQqKIPwtmQmPPT2bGLbGcwm8w/w0WrjbPMMv52YquA9;
-        Expires=Tue, 03 May 2022 05:03:57 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=rkc0RG/MPmdxQpYr3cd15nEv92vjRG5Fiww/L3uEiOCcFX/lHyrcq4RMZXoRgMwug5/v/QaS+5VdAHo5uNWpwDdSfUftXbv2ugZTSrj3TMaa3Db88WoE70jTwmJY;
+        Expires=Wed, 04 May 2022 06:20:03 GMT; Path=/
+      - AWSALBCORS=rkc0RG/MPmdxQpYr3cd15nEv92vjRG5Fiww/L3uEiOCcFX/lHyrcq4RMZXoRgMwug5/v/QaS+5VdAHo5uNWpwDdSfUftXbv2ugZTSrj3TMaa3Db88WoE70jTwmJY;
+        Expires=Wed, 04 May 2022 06:20:03 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB780c108213699e08cfc877bf60ecba5e
+      - NBd717b8033b799a267f42abc2182edd13
       Pragma:
       - no-cache
       Cache-Control:
@@ -43225,11 +43657,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - gO5PjwE2RSiHlgnYtfclUAFIrTZLKqkgsIk5C1kx6JMnv2lJuYA-Vg==
+      - 9Hh_7ethntOIbAOmtvOJLPxBykWaJmYwbo2DyaE7qZCpZ8t-j7CqOg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -43276,7 +43708,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D8",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25c4630312d42bf1d84",
           "Name": "",
@@ -43335,7 +43767,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:57 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:03 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d90
@@ -43351,9 +43783,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQChASrplIuy8TzCbCltCWg20RGcd1tC6VeQYRuBowKQ2gIgL9DJ4i59sBIEa8F/je/eDEc2kKtRMdwlgg+qXFr6+/M="
+        host date digest",signature="MEQCIELhVUFtF0rwcEA1Nmr/5qv+QKuuYB58f1s3Sn6pv8y6AiAP+TjJyx92rJZazNjjGj+FWMij6WOF2phIfpD/lnd7mA=="
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:03 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -43366,16 +43798,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:03 GMT
       Set-Cookie:
-      - AWSALB=avcm2CBxBj7yT1M65AhPOJcpS9NO5MT3U9TTB2IFfLreJr6nDRFAKkGOUcoWL704jw21qTvyb92G5VDneBAufdXGcYRDTNzon60BhxIEYHD7zhwt7VdvYfe28EPf;
-        Expires=Tue, 03 May 2022 05:03:57 GMT; Path=/
-      - AWSALBCORS=avcm2CBxBj7yT1M65AhPOJcpS9NO5MT3U9TTB2IFfLreJr6nDRFAKkGOUcoWL704jw21qTvyb92G5VDneBAufdXGcYRDTNzon60BhxIEYHD7zhwt7VdvYfe28EPf;
-        Expires=Tue, 03 May 2022 05:03:57 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=G2Ntv37CNIytaF/x72xxyN6juiSJFeZuONOu0XCUVDsJOzYubEJtIAVqbI5CIlOB1nMMHYIzTSIh7aaIqb/OeWRrs6vWYRPdLycb5+1iBPqsDbA94Zrx2/SN8E06;
+        Expires=Wed, 04 May 2022 06:20:03 GMT; Path=/
+      - AWSALBCORS=G2Ntv37CNIytaF/x72xxyN6juiSJFeZuONOu0XCUVDsJOzYubEJtIAVqbI5CIlOB1nMMHYIzTSIh7aaIqb/OeWRrs6vWYRPdLycb5+1iBPqsDbA94Zrx2/SN8E06;
+        Expires=Wed, 04 May 2022 06:20:03 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB32467e5b24887d2f0d25356fe12b224a
+      - NB68de0182bcbe99c39ef61a2d37cb3d9d
       Pragma:
       - no-cache
       Cache-Control:
@@ -43405,11 +43837,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - zzobt6MHtdhstrV9QMO6k0SrCv5MZSlLg3MvniDiDWLcim7-yRMKtA==
+      - QWH8d41deOzcb7GYJ_mzn-z-tcY4mBuTFYVVz-dxoOHuH7BTFL48Eg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -43456,7 +43888,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E4",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d90",
           "Name": "",
@@ -43515,7 +43947,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:57 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:03 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d85
@@ -43531,9 +43963,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIDJOEWu5g9XrtXqT3au/3wmVU8N8/Hf1mbGePz5/Dw+PAiBMVoAVPuZelwCNdJTfBFwIo1CWxUWQNdZ3uD2pllSX8g=="
+        host date digest",signature="MEQCIGnNqXAmUjocBz8JD0HGusnK0Lw9vJBogdsWmDs/yEO1AiACXa0MY0mUpmtalCYfnGvma7YFCS39r/eMWCbato75wg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:03 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -43546,16 +43978,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:03 GMT
       Set-Cookie:
-      - AWSALB=JruOWArw/YTsK4YzrViC8P9gU8lfodGH0qtm7vi1++E/8YUiqxAsLYN2WZgCoJLh98N3XRUTdAWUdWmFyxpIdiHn28BwIEj8QhGP37hBiIVIwAupHdjQUTfVw6Uo;
-        Expires=Tue, 03 May 2022 05:03:57 GMT; Path=/
-      - AWSALBCORS=JruOWArw/YTsK4YzrViC8P9gU8lfodGH0qtm7vi1++E/8YUiqxAsLYN2WZgCoJLh98N3XRUTdAWUdWmFyxpIdiHn28BwIEj8QhGP37hBiIVIwAupHdjQUTfVw6Uo;
-        Expires=Tue, 03 May 2022 05:03:57 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=yPFSGl/vl5T6qX+cgzwi7Ac1uvvOUXL27eP+FP86UbnsvO7jZih1gPlJwdjJjTqKjfTTuaQe6O+FTQRqW4h9zhF5j1LCa/Ux+dn+5UXGFOEFmAAq9dM2iPNXE3Gl;
+        Expires=Wed, 04 May 2022 06:20:03 GMT; Path=/
+      - AWSALBCORS=yPFSGl/vl5T6qX+cgzwi7Ac1uvvOUXL27eP+FP86UbnsvO7jZih1gPlJwdjJjTqKjfTTuaQe6O+FTQRqW4h9zhF5j1LCa/Ux+dn+5UXGFOEFmAAq9dM2iPNXE3Gl;
+        Expires=Wed, 04 May 2022 06:20:03 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB1e803447db7e3efda4e4371936529635
+      - NBbb09a24a1acd53af38f0cfe8f6427b31
       Pragma:
       - no-cache
       Cache-Control:
@@ -43585,11 +44017,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - TL_gLX0EVH3vOjtabA-GyH15EiKKjTi7OMGZaXkgBsMxvuI48rnfJA==
+      - 2n3xJLMP4qkw1G783WRUZcMmaVNq3mX1k3Xi4HCpqMofwp-mzaL8bg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -43636,7 +44068,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D9",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25c4630312d42bf1d85",
           "Name": "",
@@ -43695,7 +44127,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:57 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:03 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6b
@@ -43711,9 +44143,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIH5/x50lOx4imF8SSjwJdivYo2be36iY0x4Eirm31F6wAiEA62jlgbNK1zLv0EPKLsbtVfB0ouFL+MYrUZlYeQDrp7c="
+        host date digest",signature="MEUCIQDGNnPLqfBvMTgzzwMkoVd4VXapEBckVh0kwcKFieBIKgIgKe1+D80kHAKswbKLRazP6HJEVLhdR9P/rxPbPtLxWsc="
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:03 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -43726,16 +44158,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:04 GMT
       Set-Cookie:
-      - AWSALB=E6ysBtVXvDLjrpgJuML6Nu/PgKsVp9yY4lxoYYWMFUIRl1a5jB4OYcE9fcmlpHyUsRR4y3b6aIIRKnCTI92yeyxxie0IzjNkzLtw5AX5s79TdHQN69e9gJGPUPRH;
-        Expires=Tue, 03 May 2022 05:03:57 GMT; Path=/
-      - AWSALBCORS=E6ysBtVXvDLjrpgJuML6Nu/PgKsVp9yY4lxoYYWMFUIRl1a5jB4OYcE9fcmlpHyUsRR4y3b6aIIRKnCTI92yeyxxie0IzjNkzLtw5AX5s79TdHQN69e9gJGPUPRH;
-        Expires=Tue, 03 May 2022 05:03:57 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=lcNGrHqEboWiv9+rnFpObx7UfVdgH2eoLRwQtIb6fb+GBs+ljod8Yz7H5hSCC+ZGxkpb/yIE1yjTjs4Myr/k7jqc9eK9ky40qPreJJHr4A5778Y0k4sflqz8syS3;
+        Expires=Wed, 04 May 2022 06:20:04 GMT; Path=/
+      - AWSALBCORS=lcNGrHqEboWiv9+rnFpObx7UfVdgH2eoLRwQtIb6fb+GBs+ljod8Yz7H5hSCC+ZGxkpb/yIE1yjTjs4Myr/k7jqc9eK9ky40qPreJJHr4A5778Y0k4sflqz8syS3;
+        Expires=Wed, 04 May 2022 06:20:04 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0c50fe23b0c2417ec6acdc2f5708f0c4
+      - NB98ae2e8e87c139b8dba9e443933a7c43
       Pragma:
       - no-cache
       Cache-Control:
@@ -43765,11 +44197,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - h0Nr7y1R93oH6o2byxF8kdxEISenrb0Kph9KaNgdw_AOcy9dGKakFQ==
+      - aoyuR79FX25_n3hFgAe6710FO5aX07R-IM9Gz-1kQ-z-U6KX3Rzbkw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -43816,7 +44248,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F5",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d6b",
           "Name": "",
@@ -43875,7 +44307,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:57 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:04 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d70
@@ -43891,9 +44323,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIESb2lKvA19Nfo6T9kvpUnBbVVYZkDLWkcVNuAbBuz7rAiBE9mqT2PCjDMnjhuFZc/0V3ELZR6oBtsCsLvK3q8BhUA=="
+        host date digest",signature="MEQCICf79wCxfR3kast2LsdapZJaJ5KAoIFNopxoTJVafy2VAiB+HJPdYxnGAFaBLbXCZ9Ww7CEzvcv0UOcTh99CMV4MJw=="
       Date:
-      - Tue, 26 Apr 2022 05:03:57 GMT
+      - Wed, 27 Apr 2022 06:20:04 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -43906,16 +44338,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:58 GMT
+      - Wed, 27 Apr 2022 06:20:04 GMT
       Set-Cookie:
-      - AWSALB=vPvPGdQeH6iH4POzfSVmpgj4RfTG5uqLmDMDgNVL38bYOnni7Ui2pc1koqY0Bu+biRqWv9tcnILAQRUEFEuge315e2STIvhXB22+6k+fIelN9CI1tXwNOuYpZiu/;
-        Expires=Tue, 03 May 2022 05:03:58 GMT; Path=/
-      - AWSALBCORS=vPvPGdQeH6iH4POzfSVmpgj4RfTG5uqLmDMDgNVL38bYOnni7Ui2pc1koqY0Bu+biRqWv9tcnILAQRUEFEuge315e2STIvhXB22+6k+fIelN9CI1tXwNOuYpZiu/;
-        Expires=Tue, 03 May 2022 05:03:58 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ymEdN1Mgnhm6UbyIFByOCH1wXGUxv5hiq0FTO6MBBRBYYkFbUm2YGTCHaeBDavWTMd4evO/nyaLO3yQyMIO9Lq6GUA3et2xlWVJZIRUyx2tDbS5dfwe8u+iuYn4L;
+        Expires=Wed, 04 May 2022 06:20:04 GMT; Path=/
+      - AWSALBCORS=ymEdN1Mgnhm6UbyIFByOCH1wXGUxv5hiq0FTO6MBBRBYYkFbUm2YGTCHaeBDavWTMd4evO/nyaLO3yQyMIO9Lq6GUA3et2xlWVJZIRUyx2tDbS5dfwe8u+iuYn4L;
+        Expires=Wed, 04 May 2022 06:20:04 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBcfd5f92831461a167b9afbcf2ff223d5
+      - NBf8c8f1c01af674d29fad91ed97bcb239
       Pragma:
       - no-cache
       Cache-Control:
@@ -43945,11 +44377,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - wDiFG2hVz18pK0MQSRD5LTcOdDnKXuYL8gvjQ8TmwV42tiXngBIUMw==
+      - ydZYUAFeZOv3vjwo9_6VCCuZAj5p2M3JPhESOtn49X-FljKNYBs3zQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -43996,7 +44428,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:79:00",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d70",
           "Name": "",
@@ -44055,7 +44487,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:58 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:04 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d73
@@ -44071,9 +44503,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIB4bAh6JKgs0GM4IHa0OD6EXgLfOGHbPsFlPCEkLxqlgAiAo2uTwQL5lWDY8VAXykEv3SQX09/gH8Jc1FthUPjUp6A=="
+        host date digest",signature="MEYCIQCoVwlSdpI5LnjPzPCWdjmSL6VQnihqdaiwx5aj9qTMEAIhANftRAfF0qPTxzWblUxLdfj0nOHhDnjvoeKVzbU6ZxsO"
       Date:
-      - Tue, 26 Apr 2022 05:03:58 GMT
+      - Wed, 27 Apr 2022 06:20:04 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -44086,16 +44518,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:58 GMT
+      - Wed, 27 Apr 2022 06:20:04 GMT
       Set-Cookie:
-      - AWSALB=WQIGampgzs8Yx3xB5SaSa5FpD5uybLjw7Q0tTyxzdDj44CdeiKKyGKrE9aLj8fvcp0ZOtH6ZA7V0Wqfx7aX19TIHRgJFVyrFrwcQr1zycagEIL9DeQhkIKGD/hfC;
-        Expires=Tue, 03 May 2022 05:03:58 GMT; Path=/
-      - AWSALBCORS=WQIGampgzs8Yx3xB5SaSa5FpD5uybLjw7Q0tTyxzdDj44CdeiKKyGKrE9aLj8fvcp0ZOtH6ZA7V0Wqfx7aX19TIHRgJFVyrFrwcQr1zycagEIL9DeQhkIKGD/hfC;
-        Expires=Tue, 03 May 2022 05:03:58 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=96IkUEkhTPAHNZjcRs51yZ8MUjKIjDZI8hM2IBajWmCC9eNeNGWNIYiIxKTHCh48PoR73rj2//+EULuHLUqNK7h0kJVLMqX+pnSsgY2eNL/qgJ6xyESTM9KfsmQL;
+        Expires=Wed, 04 May 2022 06:20:04 GMT; Path=/
+      - AWSALBCORS=96IkUEkhTPAHNZjcRs51yZ8MUjKIjDZI8hM2IBajWmCC9eNeNGWNIYiIxKTHCh48PoR73rj2//+EULuHLUqNK7h0kJVLMqX+pnSsgY2eNL/qgJ6xyESTM9KfsmQL;
+        Expires=Wed, 04 May 2022 06:20:04 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa1da8faeca08b178b76253dca47098bc
+      - NB3178eb78bc95a86878056adbd91a948b
       Pragma:
       - no-cache
       Cache-Control:
@@ -44125,11 +44557,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - m0eFrnFWGSy_kGo-zl1u3otjP4gzveYeZerPBmZQ6VEykhw7vYHTWg==
+      - "-Ygv54gYStNh1R_N_hs8PiwiUDAMLZQ7uNdruzg3H0eSRaDHAduiiA=="
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -44176,7 +44608,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:79:0C",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d73",
           "Name": "",
@@ -44235,7 +44667,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:58 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:04 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8f
@@ -44251,9 +44683,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCICugO7B6GDLLPteDaeejHLwx8EJKRUbCsSud3SXf8ufZAiEAsUf1gj6kxj+Q/mQ1YaI1ahY4MJArSWcx8PIgyFXT1bQ="
+        host date digest",signature="MEYCIQCM8zDRJDy0if/v0hrtqWtVWs43H8z6epC4NyBc3gHAkQIhAN+mp/VKsvHhTetfQZCOoHluSHvwcmjAxgJF1d8lWTvR"
       Date:
-      - Tue, 26 Apr 2022 05:03:58 GMT
+      - Wed, 27 Apr 2022 06:20:04 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -44266,16 +44698,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:58 GMT
+      - Wed, 27 Apr 2022 06:20:04 GMT
       Set-Cookie:
-      - AWSALB=S3wraIOSEukrRnm6x5tJGD3CbaL905CtDYVEfZdk2a8NGfmX9UzryS1IRatZrO8RT9YwU6LA+VvAnVLqwDOiKjwLhEkxkezGjk6uiO5YiiLWY7yvONCK2v7Tqhiv;
-        Expires=Tue, 03 May 2022 05:03:58 GMT; Path=/
-      - AWSALBCORS=S3wraIOSEukrRnm6x5tJGD3CbaL905CtDYVEfZdk2a8NGfmX9UzryS1IRatZrO8RT9YwU6LA+VvAnVLqwDOiKjwLhEkxkezGjk6uiO5YiiLWY7yvONCK2v7Tqhiv;
-        Expires=Tue, 03 May 2022 05:03:58 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=H61Frtq+u84oBgLzQMp5GgY9pGfIDoNPGAqfRFmPQsawLQLhFG/E0sOj4FhtY0wCea4lA5nr8HYwp3SXi3P+0XZFh4CBc/3v4tHtoxG0VPai63EnT1sMqLmaW1OQ;
+        Expires=Wed, 04 May 2022 06:20:04 GMT; Path=/
+      - AWSALBCORS=H61Frtq+u84oBgLzQMp5GgY9pGfIDoNPGAqfRFmPQsawLQLhFG/E0sOj4FhtY0wCea4lA5nr8HYwp3SXi3P+0XZFh4CBc/3v4tHtoxG0VPai63EnT1sMqLmaW1OQ;
+        Expires=Wed, 04 May 2022 06:20:04 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe29a348e3d8dc6d5e1bc6962604d2993
+      - NBf0a0f0979beecbbfbdf44d9064f8e768
       Pragma:
       - no-cache
       Cache-Control:
@@ -44305,11 +44737,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - rRzvA2T6aAO7Y-CP7kEBJOiIg15qyEdzgqR_cMtAITWH7bxs5PWn3g==
+      - 4N75I8oJjuqenJDGnI5g_KsLgxsoDBL__Mno96Lhi9kXkALPk1k51w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -44356,7 +44788,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:E3",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8f",
           "Name": "",
@@ -44415,7 +44847,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:58 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:04 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d86
@@ -44431,9 +44863,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIG8GF2dUUABzxvg4+VT5AzEya9MYFFr4Pb1/1n5ycEV1AiA1q6cSKwdawpJ2DBpCKm6HcQTsFb50MBN7gfAkDm2D3A=="
+        host date digest",signature="MEQCICYkppCSmhYvwlYRW7AWrk1RTcAYzLqx4ejJ5wsAmvOdAiALxLQdmIWG4Z1Q8Anxxorud/TEICHILqduTsYUwM1Pfg=="
       Date:
-      - Tue, 26 Apr 2022 05:03:58 GMT
+      - Wed, 27 Apr 2022 06:20:04 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -44446,16 +44878,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:58 GMT
+      - Wed, 27 Apr 2022 06:20:05 GMT
       Set-Cookie:
-      - AWSALB=VHmamdynEeDPb1wcM2iv7ZQu5e6ByneezSpLF6sKrNlnf6ZvRfBqLZeqN20qms4ZKigK0NN1zaXB2GRXifxDDLvwvzkgk1l7KHkjbt2QYDK3ta7E37BZ+IMwLS1f;
-        Expires=Tue, 03 May 2022 05:03:58 GMT; Path=/
-      - AWSALBCORS=VHmamdynEeDPb1wcM2iv7ZQu5e6ByneezSpLF6sKrNlnf6ZvRfBqLZeqN20qms4ZKigK0NN1zaXB2GRXifxDDLvwvzkgk1l7KHkjbt2QYDK3ta7E37BZ+IMwLS1f;
-        Expires=Tue, 03 May 2022 05:03:58 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ls3XdumT8nLZ4a1F1m4lPk+0eZPhgbXSIC2kyEgJlI/jGkq+noEHnwu4jVOBDmtbz655pSUsnqgyd51kM6JRoMVhwPL+T8ZS7KrwLQknGNDkDo4vat6WDLjN/rQh;
+        Expires=Wed, 04 May 2022 06:20:04 GMT; Path=/
+      - AWSALBCORS=ls3XdumT8nLZ4a1F1m4lPk+0eZPhgbXSIC2kyEgJlI/jGkq+noEHnwu4jVOBDmtbz655pSUsnqgyd51kM6JRoMVhwPL+T8ZS7KrwLQknGNDkDo4vat6WDLjN/rQh;
+        Expires=Wed, 04 May 2022 06:20:04 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0e56d05d9a65d7fe141e99820930cea2
+      - NB197f263581448c894f481ec49598347a
       Pragma:
       - no-cache
       Cache-Control:
@@ -44485,11 +44917,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - shNdWMXMAhl7JWPopqeaRiJjqnhm44eOpnrLa4E5IfC83mMVXOmBKw==
+      - "-QUJgyEG8yqo2X-Z1ZzwqGPLC183SmS0tr0cHtOUyarS51TyOO32Bw=="
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -44536,7 +44968,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DA",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25c4630312d42bf1d86",
           "Name": "",
@@ -44595,7 +45027,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:58 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:05 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d88
@@ -44611,9 +45043,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCcS6FyygZGN9sBCBQHYYv0ow6vw6ihp7SgXWa8RcQSKwIhANE7+qxSopAsnyuCCuOkiRop1VzQ9Cn7UtitlGgh4Djb"
+        host date digest",signature="MEYCIQDN0fwVMhXjlDxEaJJ7W6QpiMCrZFEf/FNtYJ87H4eq3AIhAP1YaUAASz2DbRJ68vWzbCE02LRzecaQ5Tje6TAx1j0p"
       Date:
-      - Tue, 26 Apr 2022 05:03:58 GMT
+      - Wed, 27 Apr 2022 06:20:05 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -44626,16 +45058,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:59 GMT
+      - Wed, 27 Apr 2022 06:20:05 GMT
       Set-Cookie:
-      - AWSALB=wbK0Kd03mG0sWWBQbCTDGZckRlsXw8Dq9qOentOYjOzj1oUrfWP57SG6sgJr8S440v1zH2V/2W4BMjjhil26hhcgp6cepcSXl5phe5qpNWejfcNf8lXRwKRSO4Lv;
-        Expires=Tue, 03 May 2022 05:03:59 GMT; Path=/
-      - AWSALBCORS=wbK0Kd03mG0sWWBQbCTDGZckRlsXw8Dq9qOentOYjOzj1oUrfWP57SG6sgJr8S440v1zH2V/2W4BMjjhil26hhcgp6cepcSXl5phe5qpNWejfcNf8lXRwKRSO4Lv;
-        Expires=Tue, 03 May 2022 05:03:59 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=4ICJQ/+YWpXdQ+5cUBbCn2evr3Hm1/6IG0jxYMQUcU67Vq/jZpo5gVY56113nZ7VU17oyBbca6kCDxSjWE8rEh9Nqrei/iAc5xxSRFeD+z07gdkeMVoH27vgqoY/;
+        Expires=Wed, 04 May 2022 06:20:05 GMT; Path=/
+      - AWSALBCORS=4ICJQ/+YWpXdQ+5cUBbCn2evr3Hm1/6IG0jxYMQUcU67Vq/jZpo5gVY56113nZ7VU17oyBbca6kCDxSjWE8rEh9Nqrei/iAc5xxSRFeD+z07gdkeMVoH27vgqoY/;
+        Expires=Wed, 04 May 2022 06:20:05 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3ed6bb07ad0d2018e89ac968ffd3ca8c
+      - NBe9320708f39c983f8e9dad175fb28dcf
       Pragma:
       - no-cache
       Cache-Control:
@@ -44665,11 +45097,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - "-gfNtrEaSakmQHHArRdD8flVAo8RPRdcLi5AK46Zu2aFRQGv0A_-_Q=="
+      - wRYmpylugxYqd9gGFseC3OzxQ1SBYnfP9rzQH56j-U6eKXw5e23aKQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -44716,7 +45148,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DC",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d88",
           "Name": "",
@@ -44775,7 +45207,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:59 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:05 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d6f
@@ -44791,9 +45223,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQC9lYMsHj8Jy9wLE4v2kma+V2rbVop+T7tF+V9OwKMzawIhANJoF+iqba70LmaHFxcTmrDxie/BLeuwQJTw7nNc/U5X"
+        host date digest",signature="MEUCIC1zYjCbXk8sFBPqbf9m4JrROOXRNywwK94ZmkKF8564AiEA4L4jTbDcJAKfLSPUkaUdwotJ19Ky/ciAPrjJsO9nojs="
       Date:
-      - Tue, 26 Apr 2022 05:03:59 GMT
+      - Wed, 27 Apr 2022 06:20:05 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -44806,16 +45238,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:59 GMT
+      - Wed, 27 Apr 2022 06:20:05 GMT
       Set-Cookie:
-      - AWSALB=/dmTChg6qqdksfrbYElrz7UQYJDVyQioYzt9Z/7rBGrkvnTGVr9c1jlXulZ/B0RFo6RZcilNEpxKct4AHeK5XaBU6hyKJv3Zt+R0Y/op4zMyjSyfZsKxnYIz7uzT;
-        Expires=Tue, 03 May 2022 05:03:59 GMT; Path=/
-      - AWSALBCORS=/dmTChg6qqdksfrbYElrz7UQYJDVyQioYzt9Z/7rBGrkvnTGVr9c1jlXulZ/B0RFo6RZcilNEpxKct4AHeK5XaBU6hyKJv3Zt+R0Y/op4zMyjSyfZsKxnYIz7uzT;
-        Expires=Tue, 03 May 2022 05:03:59 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=SNFqra9Yb0KTC4xDIcz423wzBh7PKrR/sn0GENzMAkSGrFPE2ge/914Mjb0T8po58Uktjo4BUSTkWiV8xr+Fgxu/97MdlcbPooK9goKeeSmvl39NQDtnp4tu1tDG;
+        Expires=Wed, 04 May 2022 06:20:05 GMT; Path=/
+      - AWSALBCORS=SNFqra9Yb0KTC4xDIcz423wzBh7PKrR/sn0GENzMAkSGrFPE2ge/914Mjb0T8po58Uktjo4BUSTkWiV8xr+Fgxu/97MdlcbPooK9goKeeSmvl39NQDtnp4tu1tDG;
+        Expires=Wed, 04 May 2022 06:20:05 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc5375ee589dcb107a2e72d8d34f051fb
+      - NB714d9191fb9b5b83c118d818e26696f7
       Pragma:
       - no-cache
       Cache-Control:
@@ -44845,11 +45277,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - epWtjD4mHVU0yWEC6P75_9FpAqFI-UWS3WG6rh_v3OGztcfAwcc48A==
+      - wHU2NDD4lekmpcJLzHIezK-lwm_lguxw9KunkordPKjW_0v8lbq9DQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -44896,7 +45328,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:FC",
-          "ModTime": "2022-04-26T04:32:29.504Z",
+          "ModTime": "2022-04-27T06:18:30.698Z",
           "Mode": "trunk",
           "Moid": "614ce25c4630312d42bf1d6f",
           "Name": "",
@@ -44955,7 +45387,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:59 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:05 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d72
@@ -44971,9 +45403,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIFBlL4/TxxQ5yrChxyrqf2OH+WZrSClu8ad6QSyLKmkKAiEAhHx1no9uRcBwT1UHMKdYrT0xbjFYmdDgInu2iDqYs1w="
+        host date digest",signature="MEUCIARLcZ9qG5Qa2fsDSsn0jzu+KW/eJZA/plKY/wU6Qho9AiEA5xXQtu8Zb/vqoz9821FH7A4nWb8hjpOSyxkeA0nrWDk="
       Date:
-      - Tue, 26 Apr 2022 05:03:59 GMT
+      - Wed, 27 Apr 2022 06:20:05 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -44986,16 +45418,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:59 GMT
+      - Wed, 27 Apr 2022 06:20:05 GMT
       Set-Cookie:
-      - AWSALB=kIk/prM4BVqDVXz3yr64iR5aIEbDbk3uqmAKBfcGi5eW7LHXBjggvjWSrN1Q1x1q+oEoT3s6598mP0YypJb7nJ6lt5KRw5G1bYwK6AvYov3XrLk+B2kWQF571Kjj;
-        Expires=Tue, 03 May 2022 05:03:59 GMT; Path=/
-      - AWSALBCORS=kIk/prM4BVqDVXz3yr64iR5aIEbDbk3uqmAKBfcGi5eW7LHXBjggvjWSrN1Q1x1q+oEoT3s6598mP0YypJb7nJ6lt5KRw5G1bYwK6AvYov3XrLk+B2kWQF571Kjj;
-        Expires=Tue, 03 May 2022 05:03:59 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=fD2BUgnWNcKum25+QTIUMD4D2QpioSnXzHOwGUV/+9xbEj93u1XZmbOFYciXVZ/Ld+BUKMq49/UjMvgZacnyhExaqMxWptNkej3kzdpcztFb+1ZwGzj3lyTNclDv;
+        Expires=Wed, 04 May 2022 06:20:05 GMT; Path=/
+      - AWSALBCORS=fD2BUgnWNcKum25+QTIUMD4D2QpioSnXzHOwGUV/+9xbEj93u1XZmbOFYciXVZ/Ld+BUKMq49/UjMvgZacnyhExaqMxWptNkej3kzdpcztFb+1ZwGzj3lyTNclDv;
+        Expires=Wed, 04 May 2022 06:20:05 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB5cc1aa4fd3fbc3fef4922a75ba5cfa47
+      - NB9c3771e69c538215d79d0bbd437ccb77
       Pragma:
       - no-cache
       Cache-Control:
@@ -45025,11 +45457,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Bb-H41HB9OjzNdAT9fkW4_c_DHihNxbbFJUJnj5Ps4PeEzjzm9A3Qg==
+      - MnK6jVVDwUqE2blPgq6NFSmImMehBbPs-pfbBJCx1CawhJiRueAcqQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -45076,7 +45508,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:79:08",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d72",
           "Name": "",
@@ -45135,7 +45567,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:59 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:05 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d7f
@@ -45151,9 +45583,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCByDYbLoLXKvEU8kyj6jjG1G+w/ABHt9KC7zykgbORIAIhANqvSzjPXhZnoi7VYVvJHSLp30H+ah/LJnd/3Nb/7pOt"
+        host date digest",signature="MEUCIQCGjXsB1JODVQUlVxPQpWiVq9hj2QL1uAZ7cDeTjSlt7AIgf2QIjOjrbdVJfedD3bR3kHlQl3UyJpYo9Aa0BHq4ZNo="
       Date:
-      - Tue, 26 Apr 2022 05:03:59 GMT
+      - Wed, 27 Apr 2022 06:20:05 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -45166,16 +45598,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:03:59 GMT
+      - Wed, 27 Apr 2022 06:20:05 GMT
       Set-Cookie:
-      - AWSALB=zgCruK7xoKDS1jA8WeUcu5vHqAka6TDXlb66AahwWuEdidMlgHz3nPQzO3DeOWoym4IiqFDjxm8zYsEUCQwyoqrwgo1SMbztI+zPGuHa1XW9MYZM60FKTTMUjKOK;
-        Expires=Tue, 03 May 2022 05:03:59 GMT; Path=/
-      - AWSALBCORS=zgCruK7xoKDS1jA8WeUcu5vHqAka6TDXlb66AahwWuEdidMlgHz3nPQzO3DeOWoym4IiqFDjxm8zYsEUCQwyoqrwgo1SMbztI+zPGuHa1XW9MYZM60FKTTMUjKOK;
-        Expires=Tue, 03 May 2022 05:03:59 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=IH81V21JQ63Y1fOQ6Ygei3lrCWTIFhyp6+8CyruO7hOvw4TEUAajGYc2CzRrJGdSofgC3zm8J2a+9wKeS9SU1mvGaXYWSMn3wEjzt6cu0wkHURW/VDgwJqHHZZ7I;
+        Expires=Wed, 04 May 2022 06:20:05 GMT; Path=/
+      - AWSALBCORS=IH81V21JQ63Y1fOQ6Ygei3lrCWTIFhyp6+8CyruO7hOvw4TEUAajGYc2CzRrJGdSofgC3zm8J2a+9wKeS9SU1mvGaXYWSMn3wEjzt6cu0wkHURW/VDgwJqHHZZ7I;
+        Expires=Wed, 04 May 2022 06:20:05 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB83a79196312a094e214634bc03ca2c80
+      - NB6d6dfb2568d153e4f8f5508e55e594a8
       Pragma:
       - no-cache
       Cache-Control:
@@ -45205,11 +45637,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Ql-YhB-nvg9n8nZe7Me-tw-jg8X09RSk8hzSVuY4PeSn4Fc24lkoUw==
+      - ovFETIkVnC4-aTdT8xAbOwSKdbEk-O9WXMS_DqrtSNlgqpTPgFrMmQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -45256,7 +45688,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D3",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d7f",
           "Name": "",
@@ -45315,7 +45747,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:03:59 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:05 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d80
@@ -45331,9 +45763,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCAPCm/D6EOm++AvVl/jDqdjtS6RZWqsmaRdD0+B7kMPAIhANF3HMpvPFcF+21y5ATM9EJt02k9ZcR5WKNZdleji6PB"
+        host date digest",signature="MEYCIQDkCZqDtSF2gxQQWhPGVzx88Tl7x7EXRdJSOe/0chAU5wIhAIEtKFPasjmraHla5JDv9Su1SqcpOm0ysNgbEHNLfROR"
       Date:
-      - Tue, 26 Apr 2022 05:03:59 GMT
+      - Wed, 27 Apr 2022 06:20:06 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -45346,16 +45778,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:00 GMT
+      - Wed, 27 Apr 2022 06:20:06 GMT
       Set-Cookie:
-      - AWSALB=YJhZj+1rN0pwmTfyvLp76jUPz8d104rhPMMsnllMhT48bIUOClud/bDySol54U8ePSwbxzukCLka2Yqda5xTsdO1/KzgEwrJzX+CZ1Z1uM3CHyyxlgtEyoO98Siq;
-        Expires=Tue, 03 May 2022 05:03:59 GMT; Path=/
-      - AWSALBCORS=YJhZj+1rN0pwmTfyvLp76jUPz8d104rhPMMsnllMhT48bIUOClud/bDySol54U8ePSwbxzukCLka2Yqda5xTsdO1/KzgEwrJzX+CZ1Z1uM3CHyyxlgtEyoO98Siq;
-        Expires=Tue, 03 May 2022 05:03:59 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=v2nLlPGK9U15KOlrxo1hKwd3J5/7dtYAJecTWNpCo07n5o6UVMdS8bijzV6h1w/3meWelPnRbh6/BqC4awxUbgDxgkCpYV+xUOiLCO6n2G3+V+m0+mdYCwqxMmjD;
+        Expires=Wed, 04 May 2022 06:20:06 GMT; Path=/
+      - AWSALBCORS=v2nLlPGK9U15KOlrxo1hKwd3J5/7dtYAJecTWNpCo07n5o6UVMdS8bijzV6h1w/3meWelPnRbh6/BqC4awxUbgDxgkCpYV+xUOiLCO6n2G3+V+m0+mdYCwqxMmjD;
+        Expires=Wed, 04 May 2022 06:20:06 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBfbcdee4a20d147a398463f5d1ecadb68
+      - NB471bb6e6a82ce20c54e992914fce933c
       Pragma:
       - no-cache
       Cache-Control:
@@ -45385,11 +45817,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - EPzWm4vfesHkzUaeWA-Yv65CetTkTzFW2AEec8o9UMU9SkxNdpLR6Q==
+      - Lodqv7A_v4P0ZSK6oT8AU6qK1Js-JCLR_0laMts0Jd4qGM0zZteFYw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -45436,7 +45868,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:D4",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d80",
           "Name": "",
@@ -45495,7 +45927,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:00 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:06 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d68
@@ -45511,9 +45943,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQC0cucUeI/DvOC0/xdClJlURu3FALOA0XcuzDmfMrufKwIhALXRtbRedakyNNUYJjb0t2pToKjoNfpfAE0OaB1hh7+C"
+        host date digest",signature="MEUCIFS+CT60+sAk4xGAKbP8RTCgxzd9ijQPlnaI2hmTaXkYAiEA53xD8DCuUl6w3+UskEAmbSKt2q4D+Vc7C3dqrFN3xu0="
       Date:
-      - Tue, 26 Apr 2022 05:04:00 GMT
+      - Wed, 27 Apr 2022 06:20:06 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -45526,16 +45958,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:00 GMT
+      - Wed, 27 Apr 2022 06:20:06 GMT
       Set-Cookie:
-      - AWSALB=TuKA1H1ge9FVlNzCiQZuGRQA26pH9t9ww90nla5wpUf9FUxZITH45V280NGxA6aTbrU1IYaKDuFsz/XZ+ELA6BXJv97CNCXBQOgIzCDCKvGfginbO6tkm+VCKqtq;
-        Expires=Tue, 03 May 2022 05:04:00 GMT; Path=/
-      - AWSALBCORS=TuKA1H1ge9FVlNzCiQZuGRQA26pH9t9ww90nla5wpUf9FUxZITH45V280NGxA6aTbrU1IYaKDuFsz/XZ+ELA6BXJv97CNCXBQOgIzCDCKvGfginbO6tkm+VCKqtq;
-        Expires=Tue, 03 May 2022 05:04:00 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=EOznO47VcWn04Lg9eCZvSZeJcDSXDot91jesnjTqGVceVR0gWlAX7uK3mYzDUvdtLvgiJVO66bDjHe4i449cflLDHYnRUGh71jg3xAUdYYL2i+ErO2jwVh4Tm5zK;
+        Expires=Wed, 04 May 2022 06:20:06 GMT; Path=/
+      - AWSALBCORS=EOznO47VcWn04Lg9eCZvSZeJcDSXDot91jesnjTqGVceVR0gWlAX7uK3mYzDUvdtLvgiJVO66bDjHe4i449cflLDHYnRUGh71jg3xAUdYYL2i+ErO2jwVh4Tm5zK;
+        Expires=Wed, 04 May 2022 06:20:06 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB111b8946391396babaa621c2588e0c07
+      - NB49dbbe0dbd8dc75f74a66102b53f4262
       Pragma:
       - no-cache
       Cache-Control:
@@ -45565,11 +45997,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - u4EL0Tt12Heh0wb4LIttO7K71uUa_D525aBO5lP8ExnUJMa1w0TFbA==
+      - 3aeXyH32c5A-N_2VP4d9G7ZDce5wjsdveccKQcfsh9ZGApqg7taz6A==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -45616,7 +46048,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:F2",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.699Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d68",
           "Name": "",
@@ -45675,7 +46107,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:00 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:06 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25c4630312d42bf1d8a
@@ -45691,9 +46123,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIBEdqbAty7BpHDSqCLP6yCluAy152okqCXtsz447l7NBAiAZF7mQ5pbS0CQkd+phTz6bYzslPPfLAB4rUk5QwM8eSA=="
+        host date digest",signature="MEYCIQDZgMa1JZW3NQ4/kt+NIIUREYKz2DCL+hc//YFUegTzNAIhAIzTFjzhTd7ln0hv4rNdV3LmXu5PNiwgYKSAzgHJmEfc"
       Date:
-      - Tue, 26 Apr 2022 05:04:00 GMT
+      - Wed, 27 Apr 2022 06:20:06 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -45706,16 +46138,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:00 GMT
+      - Wed, 27 Apr 2022 06:20:06 GMT
       Set-Cookie:
-      - AWSALB=UMIH5tHNoU8jcDxwW9IloxVRv4AuZ5ymL7KIlHqYR2uxqFgLrrqODjru7vrDg2lBJvhAc2fMt0aaOzcsFB0n0eaXOV7IkfI3zyayw3DHzSW+MLP8XD2GUoY/nYlD;
-        Expires=Tue, 03 May 2022 05:04:00 GMT; Path=/
-      - AWSALBCORS=UMIH5tHNoU8jcDxwW9IloxVRv4AuZ5ymL7KIlHqYR2uxqFgLrrqODjru7vrDg2lBJvhAc2fMt0aaOzcsFB0n0eaXOV7IkfI3zyayw3DHzSW+MLP8XD2GUoY/nYlD;
-        Expires=Tue, 03 May 2022 05:04:00 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=RilqxJpmChj/PMeDhFRik19l12cFm1XM6jh6odR1VuXz8DHGZf7kNHEqbMLycXl/6blpBUTUce1aOpNrLKpTcNVMratI/o3+/P9XBxSPTp2W/RhofBA0Q0wRUCF/;
+        Expires=Wed, 04 May 2022 06:20:06 GMT; Path=/
+      - AWSALBCORS=RilqxJpmChj/PMeDhFRik19l12cFm1XM6jh6odR1VuXz8DHGZf7kNHEqbMLycXl/6blpBUTUce1aOpNrLKpTcNVMratI/o3+/P9XBxSPTp2W/RhofBA0Q0wRUCF/;
+        Expires=Wed, 04 May 2022 06:20:06 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3a9db1a0c061492f4c50c585e67e1223
+      - NBb799f25e936bfb3feae5ee63bfaa2528
       Pragma:
       - no-cache
       Cache-Control:
@@ -45745,11 +46177,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - uOn1vC2Aa3NOLnrH9dN89sTmXNDEOLhRn0SLndWO2FlYqGWAyhlBMA==
+      - peD3W6P1oreA9eLfhOvUv2pncp9-fIaf9WL44qgPA8FKrEvF2x78IQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -45796,7 +46228,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:DE",
-          "ModTime": "2022-04-26T04:32:29.505Z",
+          "ModTime": "2022-04-27T06:18:30.7Z",
           "Mode": "access",
           "Moid": "614ce25c4630312d42bf1d8a",
           "Name": "",
@@ -45855,7 +46287,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:00 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:06 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/620449094630312d425f65e6
@@ -45871,9 +46303,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDp9EZ4j4DOwI0oRQyK2m71ncYNOt+u1kReVxak8K9JZAIhAJwG7PxdtQRKfDZ/i5A1Oj8urewDSXc9K9heCtZ6dsCD"
+        host date digest",signature="MEUCIQCxlpsw8CAQsmqeSYqNZ+IlzcYbdVJa/wzOsj2fVd08qgIgfcoa/vVejqYQCY+uAq9pyN/wB05xG7c/rr7uod+gfq8="
       Date:
-      - Tue, 26 Apr 2022 05:04:00 GMT
+      - Wed, 27 Apr 2022 06:20:06 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -45886,16 +46318,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:00 GMT
+      - Wed, 27 Apr 2022 06:20:06 GMT
       Set-Cookie:
-      - AWSALB=yWzqp536gptUyqMvkUHMrpvPyiVKRvEH2sH+bX7ykATL/UcqmOGxWmIXBlkcxVenuF/e3GfAk2S1zUllhyEU9DsePceB0jPuqtg9uVbLBgHxeWCs3cKAYHCzJrhh;
-        Expires=Tue, 03 May 2022 05:04:00 GMT; Path=/
-      - AWSALBCORS=yWzqp536gptUyqMvkUHMrpvPyiVKRvEH2sH+bX7ykATL/UcqmOGxWmIXBlkcxVenuF/e3GfAk2S1zUllhyEU9DsePceB0jPuqtg9uVbLBgHxeWCs3cKAYHCzJrhh;
-        Expires=Tue, 03 May 2022 05:04:00 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=cpn8gCYdEiMX801qz51+ljovVPe7JGG3vmFr+JxVN3giBVVQeUvSC/QaMZyS2lGo8exG1ztnOeIeTKcUrkL+krf2bOLcvoflMxZDATKYljVqVAuJM3cpO+PSIFBj;
+        Expires=Wed, 04 May 2022 06:20:06 GMT; Path=/
+      - AWSALBCORS=cpn8gCYdEiMX801qz51+ljovVPe7JGG3vmFr+JxVN3giBVVQeUvSC/QaMZyS2lGo8exG1ztnOeIeTKcUrkL+krf2bOLcvoflMxZDATKYljVqVAuJM3cpO+PSIFBj;
+        Expires=Wed, 04 May 2022 06:20:06 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa16f777bf57848e5a17942c4b250660d
+      - NBc859c5ea83db7ce9b6dc082153178599
       Pragma:
       - no-cache
       Cache-Control:
@@ -45925,11 +46357,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - UEpFfBLkhcKyj38YDE8XUOjm-wTc0k3D8oeIu6hDtkEY2S2CspsbLQ==
+      - urJsc2DusNv_1xwvP0wzTEWtP5YDzkWeUOyDcCx1ZrRhEd6OdmPXAw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -45976,7 +46408,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:C9",
-          "ModTime": "2022-04-26T04:32:29.506Z",
+          "ModTime": "2022-04-27T06:18:30.7Z",
           "Mode": "access",
           "Moid": "620449094630312d425f65e6",
           "Name": "",
@@ -46035,7 +46467,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:00 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:07 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/620449094630312d425f65e7
@@ -46051,9 +46483,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIAkpCnAq0Kf8V07qPG8T67SfsnejCUB6s3iVZCXOqB+cAiEA+G7SeMOSUJb9RlXAZqekWUwkQ6ykNgOGBuQOkS7pPzI="
+        host date digest",signature="MEQCIB5JuzI+ycqyZ3VI6Z7kLEKOfhJOxSLZ6fVVZxueoN8LAiAzZhQXXQgbQz8/T6MEsaXO7hE2u7HW4cd8zelbsHwUbw=="
       Date:
-      - Tue, 26 Apr 2022 05:04:00 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -46066,16 +46498,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:00 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Set-Cookie:
-      - AWSALB=iUEqaVqKceVhVKu+BCPBC9xyb7B0S9n19rBe5b8rZzVV02nWIXcOxA1A4GDn9O4lkIt3l7zY2KBq6qYQmVmCTJ7h6vX+sjWFVG6wf9qCUgRAGGdLeJkwe7ultiSq;
-        Expires=Tue, 03 May 2022 05:04:00 GMT; Path=/
-      - AWSALBCORS=iUEqaVqKceVhVKu+BCPBC9xyb7B0S9n19rBe5b8rZzVV02nWIXcOxA1A4GDn9O4lkIt3l7zY2KBq6qYQmVmCTJ7h6vX+sjWFVG6wf9qCUgRAGGdLeJkwe7ultiSq;
-        Expires=Tue, 03 May 2022 05:04:00 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=4ok0+ORBQ6/QgyCUp3Clt/DT4Th2ZPa+E3kyKKzCgQGlwk6I87sedP9IcJYpjpxJBkq6jzX1LwZYOOJKuayIgSSTjp4feHT/kk6Tv2i838iUXAuONEgXtLjFEEYG;
+        Expires=Wed, 04 May 2022 06:20:07 GMT; Path=/
+      - AWSALBCORS=4ok0+ORBQ6/QgyCUp3Clt/DT4Th2ZPa+E3kyKKzCgQGlwk6I87sedP9IcJYpjpxJBkq6jzX1LwZYOOJKuayIgSSTjp4feHT/kk6Tv2i838iUXAuONEgXtLjFEEYG;
+        Expires=Wed, 04 May 2022 06:20:07 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa1510f5f497f06979361e2e8a6063752
+      - NBfdf5a81fee45716650c05d8dea0ca61c
       Pragma:
       - no-cache
       Cache-Control:
@@ -46105,11 +46537,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - JiQCR0af5wxR20qpl9iG7Vb0_NCE7dnJY21dMmdh57P8c0xersO_Ew==
+      - EOQs-3ZXLb7upOCsyTqosrAb_y1kwLfVHAjZPi-TI9u7-ytj_ZibJg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -46156,7 +46588,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CA",
-          "ModTime": "2022-04-26T04:32:29.506Z",
+          "ModTime": "2022-04-27T06:18:30.7Z",
           "Mode": "access",
           "Moid": "620449094630312d425f65e7",
           "Name": "",
@@ -46215,7 +46647,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:00 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:07 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/620449094630312d425f65e5
@@ -46231,9 +46663,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCICesgW+YWB5zEG9FuUYbTY4hgdfttMWFBtN8p8Tg4Pd3AiBEhrUrdxwfxb6nOgBbSv2l2ijM57x+ZnMqB4tGH2pJkA=="
+        host date digest",signature="MEYCIQDw62GKuytwXX1xCmXtxPgKKFHnUvM4iKeoXRG4YziaGAIhAKNyl7M3jxiBMuipMxnt3D3p9RbcFHYZkitvkwKXNlfJ"
       Date:
-      - Tue, 26 Apr 2022 05:04:00 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -46246,16 +46678,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:01 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Set-Cookie:
-      - AWSALB=b4e5wGz4pDqaZxBlWN9NRbC67AN+IX+wcbUh4oQgInqce81eygtJNqIqIIXcyjvDHEnvO/9LQemFoBYK1AUhM+pBCBrEXmyj7X6yMXsY8Rqv+Jo+UflqG78uW2YU;
-        Expires=Tue, 03 May 2022 05:04:01 GMT; Path=/
-      - AWSALBCORS=b4e5wGz4pDqaZxBlWN9NRbC67AN+IX+wcbUh4oQgInqce81eygtJNqIqIIXcyjvDHEnvO/9LQemFoBYK1AUhM+pBCBrEXmyj7X6yMXsY8Rqv+Jo+UflqG78uW2YU;
-        Expires=Tue, 03 May 2022 05:04:01 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=9Q88r+HBKaFXya9DQwBYDdeWS+jhL7P9IVh3VNrYYrigxhDzwTbUSh/fbdkvrjBpXoKC3gn+K/s9wjf01CfY9ObZ565K5etjJ5bww56rDlbdRNalimRiCcfTrRBj;
+        Expires=Wed, 04 May 2022 06:20:07 GMT; Path=/
+      - AWSALBCORS=9Q88r+HBKaFXya9DQwBYDdeWS+jhL7P9IVh3VNrYYrigxhDzwTbUSh/fbdkvrjBpXoKC3gn+K/s9wjf01CfY9ObZ565K5etjJ5bww56rDlbdRNalimRiCcfTrRBj;
+        Expires=Wed, 04 May 2022 06:20:07 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa6d7764a044a98210eebd1c57dd6aad4
+      - NBb4ecad8354a40d557da73a2e8f3b5fb1
       Pragma:
       - no-cache
       Cache-Control:
@@ -46285,11 +46717,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 7TARWbiHOntAM3M6EwfRzjM6Q48Ga8CM22V2ioyejj2f6A-6yPzpSQ==
+      - lhgqfxuPM2lyNX7333fEzwYXJ0HOPqPKrzVwFneghVHfvhpN65eUNA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -46336,7 +46768,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:C8",
-          "ModTime": "2022-04-26T04:32:29.506Z",
+          "ModTime": "2022-04-27T06:18:30.7Z",
           "Mode": "access",
           "Moid": "620449094630312d425f65e5",
           "Name": "",
@@ -46395,7 +46827,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:01 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:07 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/620449094630312d425f65e8
@@ -46411,9 +46843,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIEtxgXCWC0ciQSXBTGJMGpMqfeSIE1G1wGREB5yrqwWsAiEAx37H1vdyiK0ZP5gJomgmouy2TIhudPJBrMcwZGJJ+Xw="
+        host date digest",signature="MEUCIQCms2viSCoOjktNS76OQ6WDCYIlnMVHP0cNJMfv2qemSwIgUSAoy1HSJSieNLaCIzbK0mjRJp1Fp7RhAN6DZc5ouA8="
       Date:
-      - Tue, 26 Apr 2022 05:04:01 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -46426,16 +46858,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:01 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Set-Cookie:
-      - AWSALB=hcb4kpxh/Ri1pzyFFYoGSLJAA1OCGI6sPK1Xp8/zmT8QnqojNeEqg4jvW/QCLDEqimKO9a0TpBNv1k4Lq6j/t3q/Sew/KCPGbRih470zK9TOGSfT+RfaUbG598dK;
-        Expires=Tue, 03 May 2022 05:04:01 GMT; Path=/
-      - AWSALBCORS=hcb4kpxh/Ri1pzyFFYoGSLJAA1OCGI6sPK1Xp8/zmT8QnqojNeEqg4jvW/QCLDEqimKO9a0TpBNv1k4Lq6j/t3q/Sew/KCPGbRih470zK9TOGSfT+RfaUbG598dK;
-        Expires=Tue, 03 May 2022 05:04:01 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=VhmrNvO/H2EO73xjhOLlTi+qtJPrp1zXxUIQ03c7ZH/0RLLh7f6dlbfOMmw04BfFl6HBDj2Kuc0eEyXmbOTn/mB71rfbAia9hGw1VLVQpossnXLqk3t94Qnd5oHM;
+        Expires=Wed, 04 May 2022 06:20:07 GMT; Path=/
+      - AWSALBCORS=VhmrNvO/H2EO73xjhOLlTi+qtJPrp1zXxUIQ03c7ZH/0RLLh7f6dlbfOMmw04BfFl6HBDj2Kuc0eEyXmbOTn/mB71rfbAia9hGw1VLVQpossnXLqk3t94Qnd5oHM;
+        Expires=Wed, 04 May 2022 06:20:07 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB92dcb77971ec48dd91dc44deb08cce8b
+      - NB241f8023ab7265f72b656b3f87bcbaa0
       Pragma:
       - no-cache
       Cache-Control:
@@ -46465,11 +46897,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - mPKY-_38qwlFFDpWy6ynOhoIfc_zu5xA9zb9dhtXdH2Oh4dWWYDmCA==
+      - PQyZBS9OQpk8ftvt9SMH3AIvCoRiYayO0JQ8-CrecMorUQNCW277Zg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -46516,7 +46948,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:78:CB",
-          "ModTime": "2022-04-26T04:32:29.506Z",
+          "ModTime": "2022-04-27T06:18:30.7Z",
           "Mode": "access",
           "Moid": "620449094630312d425f65e8",
           "Name": "",
@@ -46575,7 +47007,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:01 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:07 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/port/Groups/614ce2a36176752d35a7edd5
@@ -46591,9 +47023,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCivvu50HdYb2NHZ5KOvmV8YPlPD9Pi+LHk7Gj/3zpBIAIgKACVWljs2xLhSrEfJIKrWnc/jgZinDZErHrpiAB4cv8="
+        host date digest",signature="MEUCIQDpomq0QLObeJk3Yz39DSUqiv+d5VOCVaUG+gjrB3MYIQIgDo6dqjx6zgKuqyRr+wJQGgRf5yM7nFgEyf+i2OGxcyc="
       Date:
-      - Tue, 26 Apr 2022 05:04:01 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -46606,16 +47038,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:01 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Set-Cookie:
-      - AWSALB=glfn4VCoYP2wQDkSQasuaHoXlJ53LPAht6tNw6JhXIfftUBujKuVIjQpSOuk/0C/FbGHYXeCclc3g0493MkzASyEQfrXq5WHO5AQ8Cb/bend4wVhLBuiV2pJ2oAt;
-        Expires=Tue, 03 May 2022 05:04:01 GMT; Path=/
-      - AWSALBCORS=glfn4VCoYP2wQDkSQasuaHoXlJ53LPAht6tNw6JhXIfftUBujKuVIjQpSOuk/0C/FbGHYXeCclc3g0493MkzASyEQfrXq5WHO5AQ8Cb/bend4wVhLBuiV2pJ2oAt;
-        Expires=Tue, 03 May 2022 05:04:01 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=OzoB5AfE1Oyy3MH/lqm5kY4nNvMhlCq3lvDTBGCpthNuAVk0JGZqjysR8RDgqcNyS9yz9HijvxTWGw63b/OplLox79bKldBIoicVpRjukY1Y4VDeBJwpDqw239Wm;
+        Expires=Wed, 04 May 2022 06:20:07 GMT; Path=/
+      - AWSALBCORS=OzoB5AfE1Oyy3MH/lqm5kY4nNvMhlCq3lvDTBGCpthNuAVk0JGZqjysR8RDgqcNyS9yz9HijvxTWGw63b/OplLox79bKldBIoicVpRjukY1Y4VDeBJwpDqw239Wm;
+        Expires=Wed, 04 May 2022 06:20:07 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa0e0ff0de51e69d8ef33423b2b5da093
+      - NBd7ca9439e86cbf3908a6110556ebf805
       Pragma:
       - no-cache
       Cache-Control:
@@ -46645,11 +47077,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - OweKjEnMdUJ8xI5FmViJwITbZ5aUdpmrGIKparuwIpjM71ZbJh-MZA==
+      - _ZNEzRiGzOdQqx-9DjYAdvlVFNnLPGFAlv0yo2jx423Qi6FYmF1lkw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -46724,7 +47156,7 @@ http_interactions:
           "Transport": "fc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:01 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:07 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/firmware/RunningFirmwares/614ce25c4630312d42bf1d9c
@@ -46740,9 +47172,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDd5XRzy8XnLF0zGpDb6roX7iklo/eOpjHdJjIHfVTJEgIhANtoOaIvyWLRv8jAC1D5Ma5ZJUqfWYTuayTfptlW/3cx"
+        host date digest",signature="MEYCIQCyO7P+CAvGoGzxa7qBp3ZA8s43pIJyFyp+0isFuBfU5wIhAJcjlBJW9Qg1fIRLWNmPHByOPxWLgTapNOG5Z66I7//j"
       Date:
-      - Tue, 26 Apr 2022 05:04:01 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -46755,16 +47187,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:01 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Set-Cookie:
-      - AWSALB=IQYkQ+n/vsypc0BOJwqrR3KYOfi4k/VhXDl8hTL0bAcIq6d9c4HqxhJg9M8XbZKgPm61gnvhIolmaiKmff3xmK01FCmA8P0kA+pxs/Hg7XASjNNm07R8M26XNmXV;
-        Expires=Tue, 03 May 2022 05:04:01 GMT; Path=/
-      - AWSALBCORS=IQYkQ+n/vsypc0BOJwqrR3KYOfi4k/VhXDl8hTL0bAcIq6d9c4HqxhJg9M8XbZKgPm61gnvhIolmaiKmff3xmK01FCmA8P0kA+pxs/Hg7XASjNNm07R8M26XNmXV;
-        Expires=Tue, 03 May 2022 05:04:01 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=BlI7gXDvbk9v5GiUG66T1coofQqxuFFO2LRESyVL7twnLTt2RhYpee8detXG08Qs5KzNlZHshe4LBC3USy2yRr1M8hdQ6B5/Lw/3k2qypxxIOaFenFbLnk2G9lEs;
+        Expires=Wed, 04 May 2022 06:20:07 GMT; Path=/
+      - AWSALBCORS=BlI7gXDvbk9v5GiUG66T1coofQqxuFFO2LRESyVL7twnLTt2RhYpee8detXG08Qs5KzNlZHshe4LBC3USy2yRr1M8hdQ6B5/Lw/3k2qypxxIOaFenFbLnk2G9lEs;
+        Expires=Wed, 04 May 2022 06:20:07 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBeaf25c98649652967c67313f22f9aedb
+      - NB797d8a745e01b8c165c8e02c398fbf16
       Pragma:
       - no-cache
       Cache-Control:
@@ -46794,11 +47226,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - WrRy8A8AsNqvlNvDZdmd0_U0pU_FAAACnSgx-XXtu5OgjQpd_hYEmw==
+      - JeKIFgA3iMqfialG2FweQjvXW3zfGRQf-y5CD7VKEB1qW90pDfM15g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -46833,7 +47265,7 @@ http_interactions:
             "ObjectType": "management.Controller",
             "link": "https://www.intersight.com/api/v1/management/Controllers/614ce2a36176752d35a7edc8"
           },
-          "ModTime": "2022-04-26T05:02:29.565Z",
+          "ModTime": "2022-04-27T06:14:30.363Z",
           "Moid": "614ce25c4630312d42bf1d9c",
           "NetworkElements": [
             {
@@ -46886,10 +47318,10 @@ http_interactions:
           "Version": "9.3(5)I42(1f)"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:01 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:07 GMT
 - request:
     method: get
-    uri: https://intersight.com/api/v1/equipment/SwitchCards/614ce25c4630312d416698e7
+    uri: https://intersight.com/api/v1/network/ElementSummaries/614ce2a36176752d35a7edbd
     body:
       encoding: US-ASCII
       string: ''
@@ -46902,9 +47334,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCT5FRwguICJS6MsvvR69vbLcwkCsh06E9EWz8NRVWbZQIgSKWg7PY4kYT5NDD/U30/V/A/SFo/sZIqj1YNjsqMie8="
+        host date digest",signature="MEYCIQCZayoh8eqnnKitOWcawhimVENjtMMoKPu4jd768gnRZwIhAIhH9m8aWs5wRK43VD5pnXXEWovYsVQm9uxkZrUUvvuK"
       Date:
-      - Tue, 26 Apr 2022 05:04:01 GMT
+      - Wed, 27 Apr 2022 06:20:07 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -46917,16 +47349,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:02 GMT
+      - Wed, 27 Apr 2022 06:20:08 GMT
       Set-Cookie:
-      - AWSALB=XZ+oiDvg4UmEbcq2m5mauF5AZgZ2w5D5IzVqXDwdXOnibU4/OSZ/LjKIikaGTYTVltJtRfltvtR+syHDg3011yM5ptkLdDU+/+fCbh7HaOJbRfyN83c5hxuQC4jc;
-        Expires=Tue, 03 May 2022 05:04:02 GMT; Path=/
-      - AWSALBCORS=XZ+oiDvg4UmEbcq2m5mauF5AZgZ2w5D5IzVqXDwdXOnibU4/OSZ/LjKIikaGTYTVltJtRfltvtR+syHDg3011yM5ptkLdDU+/+fCbh7HaOJbRfyN83c5hxuQC4jc;
-        Expires=Tue, 03 May 2022 05:04:02 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=l40RjByG+eSjxXVbFpBxsbTNRdQMmerLQ0YIuLWCBrLGaPuipkKEA4NolV11pm5xOd9GTn+9AJXV9X3VBSySEl4IwopaF2I+Pu7W00K4PzLmhQJWPL8Amm8YrAbm;
+        Expires=Wed, 04 May 2022 06:20:08 GMT; Path=/
+      - AWSALBCORS=l40RjByG+eSjxXVbFpBxsbTNRdQMmerLQ0YIuLWCBrLGaPuipkKEA4NolV11pm5xOd9GTn+9AJXV9X3VBSySEl4IwopaF2I+Pu7W00K4PzLmhQJWPL8Amm8YrAbm;
+        Expires=Wed, 04 May 2022 06:20:08 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBeaa2e9d4c223395755176340a2ab46e9
+      - NB83896cfa9aeb6eb7081343d21855aa51
       Pragma:
       - no-cache
       Cache-Control:
@@ -46956,11 +47388,187 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - j3pmcn5Tuo4K9yFXu2T10Ii0AV-ehC5yUMTnMP9wDFRwH0eSgcHFlw==
+      - XCDI6CstwCe0GMmt1TRgSL_Mt3ladfWkGufz7gkJJW28WDh1G6vJMA==
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "AccountMoid": "5ed10e437564612d3352cc2d",
+          "AdminEvacState": "disabled",
+          "AdminInbandInterfaceState": "disabled",
+          "AlarmSummary": {
+            "ClassId": "compute.AlarmSummary",
+            "Critical": 0,
+            "ObjectType": "compute.AlarmSummary",
+            "Warning": 1
+          },
+          "Ancestors": [],
+          "AvailableMemory": "",
+          "Chassis": "",
+          "ClassId": "network.ElementSummary",
+          "ConfModTs": "",
+          "ConfModTsBackup": "",
+          "CreateTime": "2021-09-23T20:25:07.335Z",
+          "DeviceMoId": "614ce29f6f72612d307f5ed4",
+          "Dn": "switch-FDO2441072Q",
+          "DomainGroupMoid": "5ed10e437564612d3352cc37",
+          "EthernetMode": "",
+          "EthernetSwitchingMode": "end-host",
+          "FaultSummary": 0,
+          "FcMode": "",
+          "FcSwitchingMode": "end-host",
+          "Firmware": "",
+          "InbandIpAddress": "0.0.0.0",
+          "InbandIpGateway": "0.0.0.0",
+          "InbandIpMask": "255.255.255.0",
+          "InbandVlan": 0,
+          "Ipv4Address": "",
+          "ManagementMode": "Intersight",
+          "ModTime": "2022-04-27T06:19:06.675Z",
+          "Model": "UCS-FI-6454",
+          "Moid": "614ce2a36176752d35a7edbd",
+          "Name": "LAB02D02F01 FI-A",
+          "NumEtherPorts": 54,
+          "NumEtherPortsConfigured": 6,
+          "NumEtherPortsLinkUp": 4,
+          "NumExpansionModules": 0,
+          "NumFcPorts": 0,
+          "NumFcPortsConfigured": 0,
+          "NumFcPortsLinkUp": 0,
+          "ObjectType": "network.ElementSummary",
+          "OperEvacState": "disabled",
+          "Operability": "online",
+          "OutOfBandIpAddress": "100.66.11.141",
+          "OutOfBandIpGateway": "100.66.11.129",
+          "OutOfBandIpMask": "255.255.255.192",
+          "OutOfBandIpv4Address": "",
+          "OutOfBandIpv4Gateway": "",
+          "OutOfBandIpv4Mask": "",
+          "OutOfBandIpv6Address": "",
+          "OutOfBandIpv6Gateway": "",
+          "OutOfBandIpv6Prefix": "",
+          "OutOfBandMac": "00:3A:9C:DA:93:C0",
+          "Owners": [
+            "5ed10e437564612d3352cc2d",
+            "614ce29f6f72612d307f5ed4"
+          ],
+          "PartNumber": "",
+          "PermissionResources": [
+            {
+              "ClassId": "mo.MoRef",
+              "Moid": "5ed10e456972652d30b39b49",
+              "ObjectType": "organization.Organization",
+              "link": "https://www.intersight.com/api/v1/organization/Organizations/5ed10e456972652d30b39b49"
+            },
+            {
+              "ClassId": "mo.MoRef",
+              "Moid": "614caf8f6972652d30d65a53",
+              "ObjectType": "organization.Organization",
+              "link": "https://www.intersight.com/api/v1/organization/Organizations/614caf8f6972652d30d65a53"
+            }
+          ],
+          "Presence": "",
+          "RegisteredDevice": {
+            "ClassId": "mo.MoRef",
+            "Moid": "614ce29f6f72612d307f5ed4",
+            "ObjectType": "asset.DeviceRegistration",
+            "link": "https://www.intersight.com/api/v1/asset/DeviceRegistrations/614ce29f6f72612d307f5ed4"
+          },
+          "Revision": "0",
+          "Rn": "",
+          "Serial": "FDO2441072Q",
+          "SharedScope": "",
+          "SourceObjectType": "network.Element",
+          "Status": "",
+          "SwitchId": "A",
+          "SwitchType": "FabricInterconnect",
+          "SystemUpTime": "",
+          "Tags": [],
+          "Thermal": "ok",
+          "TotalMemory": 64265,
+          "Vendor": "Cisco Systems, Inc.",
+          "Version": "9.3(5)I42(1f)"
+        }
+    http_version:
+  recorded_at: Wed, 27 Apr 2022 06:20:08 GMT
+- request:
+    method: get
+    uri: https://intersight.com/api/v1/equipment/SwitchCards/614ce25c4630312d416698e7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - OpenAPI-Generator/0.1.3/ruby
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      Authorization:
+      - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
+        host date digest",signature="MEYCIQCSkgR6mNuosbQnQ17y6gEZWr3x/3v2pk9kqbEy4AgBUgIhAKzQGIVF/icluJmK0Q2s/BHQOOovV0iNva5x3hUnMmMZ"
+      Date:
+      - Wed, 27 Apr 2022 06:20:08 GMT
+      Digest:
+      - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
+      Expect:
+      - ''
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 27 Apr 2022 06:20:08 GMT
+      Set-Cookie:
+      - AWSALB=N+C1vrpsuHYbRNIzIQwjD7IJkRyjBeVFhB4UIDHbAhwzDBsPZLwY24viVoRX+pOFWG3psNz99TFSgYrNthHdwdlZyKxG9KX/ttrefoxw7mQyI1Q3owT39FraGrgg;
+        Expires=Wed, 04 May 2022 06:20:08 GMT; Path=/
+      - AWSALBCORS=N+C1vrpsuHYbRNIzIQwjD7IJkRyjBeVFhB4UIDHbAhwzDBsPZLwY24viVoRX+pOFWG3psNz99TFSgYrNthHdwdlZyKxG9KX/ttrefoxw7mQyI1Q3owT39FraGrgg;
+        Expires=Wed, 04 May 2022 06:20:08 GMT; Path=/; SameSite=None; Secure
+      Server:
+      - nginx
+      X-Starship-Traceid:
+      - NBe121abf38b5fca03b33a76e1b25664d4
+      Pragma:
+      - no-cache
+      Cache-Control:
+      - no-cache, no-store, must-revalidate
+      Content-Security-Policy:
+      - 'base-uri ''self'' https://cdn.intersight.com/; child-src ''self'' https://www.intersight.com/
+        https://cdn.intersight.com/  https://cloudsso.cisco.com https://www.cisco.com/
+        https://id.cisco.com; default-src ''self'' https://cdn.intersight.com/; font-src
+        ''self'' data: https://cdn.intersight.com/; frame-ancestors ''self''; img-src
+        ''self'' data: https://cdn.intersight.com/; style-src ''self'' ''unsafe-inline''
+        https://cdn.intersight.com/; object-src ''none''; form-action ''self'' https://www.intersight.com/
+        https://cloudsso.cisco.com https://www.cisco.com/ https://id.cisco.com; script-src
+        ''self'' https://cdn.intersight.com/; sandbox allow-modals allow-scripts allow-same-origin
+        allow-popups allow-forms allow-downloads; connect-src ''self'' https://cdn.intersight.com/
+        https://status.intersight.com https://download.intersight.com/ wss://socket.intersight.com
+        wss://intersight.com; frame-src ''self'' blob: https://www.intersight.com/
+        https://cdn.intersight.com/  https://cloudsso.cisco.com https://www.cisco.com/
+        https://id.cisco.com;'
+      X-Xss-Protection:
+      - 1; mode=block;
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Cache:
+      - Miss from cloudfront
+      Via:
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
+      X-Amz-Cf-Pop:
+      - ZAG50-C1
+      X-Amz-Cf-Id:
+      - la_Q_ho8pVyN3RQXlSJYd3L-OgvrUQnCgSYwPPve5du0ErtoKfpJvA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -46996,7 +47604,7 @@ http_interactions:
           "FcSwitchingMode": "end-host",
           "HwVersion": "",
           "InventoryDeviceInfo": null,
-          "ModTime": "2022-04-26T04:31:05.432Z",
+          "ModTime": "2022-04-27T06:19:06.133Z",
           "Model": "UCS-FI-6454",
           "Moid": "614ce25c4630312d416698e7",
           "Name": "",
@@ -47106,7 +47714,7 @@ http_interactions:
           "Vendor": "Cisco Systems, Inc."
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:02 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:08 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/port/Groups/614ce2a36176752d35a7ee2a
@@ -47122,9 +47730,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQC4OPXfM7/AK6DOPNlNI6tGdtAD0jS4ooryAgp7VJ2TNwIgZOUc18NWe5I/EITT6IW1s1g1yW0PlwcKI/SzRi20RMI="
+        host date digest",signature="MEYCIQD69M63vei3iZfkO+fgku6V38X69UBWM4B+q2q2lymCCgIhAMBeZeodGrBgaJl9b5uyGhCUbs5Ije+pp2WfGSORKhXZ"
       Date:
-      - Tue, 26 Apr 2022 05:04:02 GMT
+      - Wed, 27 Apr 2022 06:20:08 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -47137,16 +47745,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:02 GMT
+      - Wed, 27 Apr 2022 06:20:08 GMT
       Set-Cookie:
-      - AWSALB=WKyE/3XN9INuDvH/DT1WuoiCFy3OWCj0jDl+ST6kDbCXs5rzJRR8Atbc0X1AwIozYmdkNxw0rgLD8tPmA5/y0HWaOV0oFfNSvvmBZJIEY/7o0xz3HJfrjpPIKRuw;
-        Expires=Tue, 03 May 2022 05:04:02 GMT; Path=/
-      - AWSALBCORS=WKyE/3XN9INuDvH/DT1WuoiCFy3OWCj0jDl+ST6kDbCXs5rzJRR8Atbc0X1AwIozYmdkNxw0rgLD8tPmA5/y0HWaOV0oFfNSvvmBZJIEY/7o0xz3HJfrjpPIKRuw;
-        Expires=Tue, 03 May 2022 05:04:02 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=bDHEqYx3evZdAEU6/fwe13iI+O8Q0IDHu6quiqEdtnwMQAW+6v+2Qxi6xVhGFA6PRfdgqhi7RwvpvNWGDMgg+fNV3QyJ9++lglvht6987ezOEOSEPQPJwmuOFqhW;
+        Expires=Wed, 04 May 2022 06:20:08 GMT; Path=/
+      - AWSALBCORS=bDHEqYx3evZdAEU6/fwe13iI+O8Q0IDHu6quiqEdtnwMQAW+6v+2Qxi6xVhGFA6PRfdgqhi7RwvpvNWGDMgg+fNV3QyJ9++lglvht6987ezOEOSEPQPJwmuOFqhW;
+        Expires=Wed, 04 May 2022 06:20:08 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB8ca8620db55cbe3b763c2d7878d5a7e2
+      - NBd6f5c52601f037643574239db57c3b0c
       Pragma:
       - no-cache
       Cache-Control:
@@ -47176,11 +47784,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 6yoaExmIOYnz-1NQJ10os46nFj7ijMklNiz_ELnfaTXe_dWdDdE61A==
+      - OCT6syc0MyHUT6fpYoob3ZM7gAsgXI6b3qRIWQuPYcbN3dFFmULuqg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -47580,7 +48188,7 @@ http_interactions:
           "Transport": "ether"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:02 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:08 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991d
@@ -47596,9 +48204,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIEPKgDZOxp4kV6xNC1D2IX6CUgKRMIlvEHQ9iYlmDTwzAiEAygXlzypP6woI/NXPQ08ZzS/PfR3Q6ovSWTP2p4zaQK0="
+        host date digest",signature="MEUCIHUue0UEvVvI8wtisbsGf22VIlXMN4YHsiIMdZjHmiPOAiEAimcNIW6uN02xRz7GbZdX8oj6GheNlONj9roWGjHFF4A="
       Date:
-      - Tue, 26 Apr 2022 05:04:02 GMT
+      - Wed, 27 Apr 2022 06:20:08 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -47611,16 +48219,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:02 GMT
+      - Wed, 27 Apr 2022 06:20:09 GMT
       Set-Cookie:
-      - AWSALB=RPH/Bh+e0wNAZDDoNO4B7rHGN/ihzbOqEB9uNOQ+liHR2EmYGtIRQ86a7CgXLRdn4PSsFAKJWICDsAwSkJmy2RKGpPd6O5LBTZugG7DdzbQ8ybXU605cwbEpT+qf;
-        Expires=Tue, 03 May 2022 05:04:02 GMT; Path=/
-      - AWSALBCORS=RPH/Bh+e0wNAZDDoNO4B7rHGN/ihzbOqEB9uNOQ+liHR2EmYGtIRQ86a7CgXLRdn4PSsFAKJWICDsAwSkJmy2RKGpPd6O5LBTZugG7DdzbQ8ybXU605cwbEpT+qf;
-        Expires=Tue, 03 May 2022 05:04:02 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=rSWojjQzqlBN8OhSHPZHVte5qkTHROI2iWxaaQlIaA9IyL7A0oBsT5kduwtxLZMh5uPg6u3KSfXa9WiY2OtZuypNFyQH8T74+NekglIu7GKvrfKOBsPTNwBf+Zjb;
+        Expires=Wed, 04 May 2022 06:20:08 GMT; Path=/
+      - AWSALBCORS=rSWojjQzqlBN8OhSHPZHVte5qkTHROI2iWxaaQlIaA9IyL7A0oBsT5kduwtxLZMh5uPg6u3KSfXa9WiY2OtZuypNFyQH8T74+NekglIu7GKvrfKOBsPTNwBf+Zjb;
+        Expires=Wed, 04 May 2022 06:20:08 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB627367bb5666c7f488bcfddefcf15c1c
+      - NBd0d28d92a58cc700528f1cc43d072156
       Pragma:
       - no-cache
       Cache-Control:
@@ -47650,11 +48258,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 6nnqBS8cKZY_GGygfd0kjYkGAN274DqPcaNOfAsbiYz4RUffqZDRCw==
+      - Md-OePDKnamkzahStsPXcaXRS3bUFn08pIVADk97ykjSq8zLQ0IXMg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -47701,7 +48309,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E5",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991d",
           "Name": "",
@@ -47760,7 +48368,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:02 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:09 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669906
@@ -47776,9 +48384,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDksbCd7+TpOlUpyp54+4RyFcBnHd6b9lrIVjbB/gZo2AIhAMTUJARgNkOwSSG1LZ4bAf1Z7ri56kOLmVKIQhqAIkwe"
+        host date digest",signature="MEYCIQDkM1Ial0O09+aqeJ+YTAQKZtnZPSnr1+T3qBMbFLxrQgIhALLVOa9p0luLkmgw8HyhUf1HEokqgDhpqr2kHOml7uNG"
       Date:
-      - Tue, 26 Apr 2022 05:04:02 GMT
+      - Wed, 27 Apr 2022 06:20:09 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -47791,16 +48399,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:02 GMT
+      - Wed, 27 Apr 2022 06:20:09 GMT
       Set-Cookie:
-      - AWSALB=U03uHg08jM40Zqvj18ex3aO88qlWBdzxaZF38qU3XzA+qTu7GlAhoTqFc3Psc/ZWQLr1tHDPRQLq5wt45eImNR61TQQI06NyVLcBn0zQ8sFZCO3o9MGp4q1W8UKB;
-        Expires=Tue, 03 May 2022 05:04:02 GMT; Path=/
-      - AWSALBCORS=U03uHg08jM40Zqvj18ex3aO88qlWBdzxaZF38qU3XzA+qTu7GlAhoTqFc3Psc/ZWQLr1tHDPRQLq5wt45eImNR61TQQI06NyVLcBn0zQ8sFZCO3o9MGp4q1W8UKB;
-        Expires=Tue, 03 May 2022 05:04:02 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=km8lq8CFQ9PjcU8G6ipfj7eCF74wHtp2d4mY/W7cO788WC6d3zt5xovBXG1kxkAdH2qJZupv1U6lCxBdMT1kVI+ll7riH//p0t6UB10P81CPh9Sn7fllOos2sTPT;
+        Expires=Wed, 04 May 2022 06:20:09 GMT; Path=/
+      - AWSALBCORS=km8lq8CFQ9PjcU8G6ipfj7eCF74wHtp2d4mY/W7cO788WC6d3zt5xovBXG1kxkAdH2qJZupv1U6lCxBdMT1kVI+ll7riH//p0t6UB10P81CPh9Sn7fllOos2sTPT;
+        Expires=Wed, 04 May 2022 06:20:09 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd36421599609aea2e8ed4ad51f2609ce
+      - NBddb84941a70b85bc0e4ded4a07eab7e5
       Pragma:
       - no-cache
       Cache-Control:
@@ -47830,11 +48438,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - hxBmjmOPdvxTEez8zlMM7ocdquS4DkLfy5ENg0Oi4QpZ7szfyUQCHw==
+      - 7CQ20dXfyAU6R9E0L8B6R8XbgeusC0LIegeyZwS0c2Hy3-sRAl7AuA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -47881,7 +48489,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CE",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669906",
           "Name": "",
@@ -47940,7 +48548,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:02 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:09 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669916
@@ -47956,9 +48564,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCXRNLJhf8IlB04gZO+heLIuT1fas4E+iCkt9AjQWtZjwIgGns/SH6y5CRPXFNq9a1C8wKAExmlr1gefJL5Z9auRQo="
+        host date digest",signature="MEUCIQDu/J4cEdEli1qMUrKXXgV1D6P9i2xfWZV14GJFU9ppkgIgK/0LKkb02K7rafcMyv+gh8Z3fKo52wcROX6lD/pOmu8="
       Date:
-      - Tue, 26 Apr 2022 05:04:02 GMT
+      - Wed, 27 Apr 2022 06:20:09 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -47971,16 +48579,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:03 GMT
+      - Wed, 27 Apr 2022 06:20:09 GMT
       Set-Cookie:
-      - AWSALB=Oq4s23YV2cFw/WrkqH2xW0hFiuCHM2PqwzeMTNuwNZEKzmoGfGITPLcjbznoDgE5BMhZyoXwDqr2zhW8JsLX58LsY89GxpNknEB4kmzwiOi8rw/UASNVvs5cL4hg;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/
-      - AWSALBCORS=Oq4s23YV2cFw/WrkqH2xW0hFiuCHM2PqwzeMTNuwNZEKzmoGfGITPLcjbznoDgE5BMhZyoXwDqr2zhW8JsLX58LsY89GxpNknEB4kmzwiOi8rw/UASNVvs5cL4hg;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=5oPQ32rcfBbQprAWb35mAIYpLl5qp0+JcqidW0D7EDrx377EeSkVtSNuew2rTSR9BTfqoDIAkkDH3NDlQ/LkrOWOZL8KrVAxPf5FiuZtmoY/IQDnkgvRcYL4f/px;
+        Expires=Wed, 04 May 2022 06:20:09 GMT; Path=/
+      - AWSALBCORS=5oPQ32rcfBbQprAWb35mAIYpLl5qp0+JcqidW0D7EDrx377EeSkVtSNuew2rTSR9BTfqoDIAkkDH3NDlQ/LkrOWOZL8KrVAxPf5FiuZtmoY/IQDnkgvRcYL4f/px;
+        Expires=Wed, 04 May 2022 06:20:09 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB1b79be27a5b81e1b2c0e6c0ce8c8dba3
+      - NB1be8a91225a291a5c4447e391fe657c7
       Pragma:
       - no-cache
       Cache-Control:
@@ -48010,11 +48618,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - aUWifDHZ4NZH4Vv3JQ_7ol8kPb40MySg8-LeDZHvCFg1fvylnbTxAQ==
+      - sRSuIfUeG5sakz7YHIA_AlDcohFJ2wDp8fl7uOljEIWWyEYBVE3dzw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -48061,7 +48669,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DE",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669916",
           "Name": "",
@@ -48120,7 +48728,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:03 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:09 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669904
@@ -48136,9 +48744,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIE0wGmJnubbFB32F1XZ5fMXuD6RrFlqVT9WOJfb8A4GpAiEA6SYHI/HxokcMGEF56qR3lgD7PHAI3YZ1vV+kh/ZbAk8="
+        host date digest",signature="MEQCIAuhvgyQEqYUGObW15yOy8EwtYzHb6DU+VnBdN57kidRAiBKD40UZH/1sTRxhH7jpUawpp5+ckTAbEv+HOsNW1c89A=="
       Date:
-      - Tue, 26 Apr 2022 05:04:03 GMT
+      - Wed, 27 Apr 2022 06:20:09 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -48151,16 +48759,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:03 GMT
+      - Wed, 27 Apr 2022 06:20:09 GMT
       Set-Cookie:
-      - AWSALB=4gh0OCFXFIO0kB/Mp1f4SugI9p2pqv21qj4c1HDM6H7yxRVbYDleWThUXCuARMYa678KOKcnJSrcEDWbXhEI4G1myTQAOir57sZ0grhfT/3K7/x4hjTTehp3fit8;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/
-      - AWSALBCORS=4gh0OCFXFIO0kB/Mp1f4SugI9p2pqv21qj4c1HDM6H7yxRVbYDleWThUXCuARMYa678KOKcnJSrcEDWbXhEI4G1myTQAOir57sZ0grhfT/3K7/x4hjTTehp3fit8;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=tuKdR84kb1YE6649u5flyq0gATErmRNt/8NiG4WYGOtHl+aHeBSvtbtNJ2L2yUN/ReU1Ujdp3JTVLFIBiMuBIIHsGW54EF92Mgr3YQgv0smwOE1ISETPwGbUAg95;
+        Expires=Wed, 04 May 2022 06:20:09 GMT; Path=/
+      - AWSALBCORS=tuKdR84kb1YE6649u5flyq0gATErmRNt/8NiG4WYGOtHl+aHeBSvtbtNJ2L2yUN/ReU1Ujdp3JTVLFIBiMuBIIHsGW54EF92Mgr3YQgv0smwOE1ISETPwGbUAg95;
+        Expires=Wed, 04 May 2022 06:20:09 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB75be4324e46de6947487cb9a1b77c391
+      - NB40700e90e24e8d3886eeede2103bad54
       Pragma:
       - no-cache
       Cache-Control:
@@ -48190,11 +48798,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - x7oaHBj_FAQR0Z906ESftLz6KSzgQKvZbqc0BHfqugPRpwP4u2rECQ==
+      - ud29RVYBXPEKB_2AIPN0wXZcKMNgjRZMR3OWoaG1FGNJ3Kpbc1Rsow==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -48241,7 +48849,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CC",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669904",
           "Name": "",
@@ -48300,7 +48908,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:03 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:09 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ea
@@ -48316,9 +48924,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDsZI7V15yLbR2ByMcUyhTGVZAF1towAQGBMYkZxN7RjQIhAO+hs3w7/dSerrXhtP7M2DEIpaNVjISEyzLYHb0T5bJr"
+        host date digest",signature="MEQCIF4mjOV8E4d5b2ZnsvrS8eHaZyP4gtSRMmRm/egcq7/mAiByrkNw4hbOd33nuiAL+y9R3EfWNrQzbuSxrcxKnGRbTw=="
       Date:
-      - Tue, 26 Apr 2022 05:04:03 GMT
+      - Wed, 27 Apr 2022 06:20:09 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -48331,16 +48939,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:03 GMT
+      - Wed, 27 Apr 2022 06:20:09 GMT
       Set-Cookie:
-      - AWSALB=BXMHnbPPX38ae5Ac1nI9ZE+vfDqu5QMMrt2l0rj6epyt6K/SpQTFoW4ZwdRQxhNcKllB7+tJz1vJZrhM021JIkCrSTs3aRR/X3g23h8khspmGnEEfjnu9u8mUpFe;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/
-      - AWSALBCORS=BXMHnbPPX38ae5Ac1nI9ZE+vfDqu5QMMrt2l0rj6epyt6K/SpQTFoW4ZwdRQxhNcKllB7+tJz1vJZrhM021JIkCrSTs3aRR/X3g23h8khspmGnEEfjnu9u8mUpFe;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=0TzWyBhIV4+N1JZwp842ho1K0Rd3V89NqaJ/++wvQI/nCHmiNpyK/V72HQusbpKkLmJ/znamhO3YnUFSygv9hdQqQRDpZQfwLcGIBiMXWybKvYINgvK07TBNTxiX;
+        Expires=Wed, 04 May 2022 06:20:09 GMT; Path=/
+      - AWSALBCORS=0TzWyBhIV4+N1JZwp842ho1K0Rd3V89NqaJ/++wvQI/nCHmiNpyK/V72HQusbpKkLmJ/znamhO3YnUFSygv9hdQqQRDpZQfwLcGIBiMXWybKvYINgvK07TBNTxiX;
+        Expires=Wed, 04 May 2022 06:20:09 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBcbd754c326f7b16650ca2df240496c18
+      - NBb5b890a1e62933cf1653528e21a3d426
       Pragma:
       - no-cache
       Cache-Control:
@@ -48370,11 +48978,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Yf1uXbHQfroQcvMh-BhNaSIBcjtdlUVhktB_uPWy47TXJP-anFkRIA==
+      - SCJrgndpXsR-drs-SQm5b7jmjnuVZJkeJeMJlZEkiR8Syt9jQvl7ag==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -48421,7 +49029,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E8",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ea",
           "Name": "",
@@ -48480,7 +49088,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:03 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:09 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698fa
@@ -48496,9 +49104,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIGqFlEUR2thIdBJ+MGVVD3NSmT6kp9om9oHhDWBZXxX2AiEA5Gw6XbyucytJRzmitzL6HB14Pm3Wazx0xk59TBIvuqE="
+        host date digest",signature="MEUCIQDSRVbi3O53su4R8oDMir/PJ4xuIJ/bSHYN2kOKBUWt3wIgGPYjTMPKDCBiSoB7adQYoijHUAeNPnFOfg0ANFSiFMI="
       Date:
-      - Tue, 26 Apr 2022 05:04:03 GMT
+      - Wed, 27 Apr 2022 06:20:09 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -48511,16 +49119,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:03 GMT
+      - Wed, 27 Apr 2022 06:20:10 GMT
       Set-Cookie:
-      - AWSALB=KtzmpgIFdPKTaEuh+gbQQVEDSAq6Dxo2L5hHtu2zMwmPiSoT1DW6Yv3D7UaLDoIxtrNTxquF34m9UI3fOTmFrPC35IQZC8VIWJlgFToAVEE+f1XmT4RW3DjLgnae;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/
-      - AWSALBCORS=KtzmpgIFdPKTaEuh+gbQQVEDSAq6Dxo2L5hHtu2zMwmPiSoT1DW6Yv3D7UaLDoIxtrNTxquF34m9UI3fOTmFrPC35IQZC8VIWJlgFToAVEE+f1XmT4RW3DjLgnae;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ykP8NME86QIT8OWUEySOLRlhVLH4TImEViSsb8zXCg4eJELX7sVRq2gK/bmrf4y41++ojwilMGKMNO2aJVGaExoLlrUfSyRlnfYOOgjTD/d6GrB1jua7OZxcrC5x;
+        Expires=Wed, 04 May 2022 06:20:10 GMT; Path=/
+      - AWSALBCORS=ykP8NME86QIT8OWUEySOLRlhVLH4TImEViSsb8zXCg4eJELX7sVRq2gK/bmrf4y41++ojwilMGKMNO2aJVGaExoLlrUfSyRlnfYOOgjTD/d6GrB1jua7OZxcrC5x;
+        Expires=Wed, 04 May 2022 06:20:10 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4c5233279677e7633e9d7c38c48db21c
+      - NBc4317ebb0a5c8a101cafd3b85a21a9f9
       Pragma:
       - no-cache
       Cache-Control:
@@ -48550,11 +49158,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - sol87UiAfkD0Qxj6tBG0D-YBEhASAcjiIWK4bryVwwmdxkWu-20Lfw==
+      - 4snORsKVsLJgPCTBi80iDcMOTfOmZC2QxVx4pj8xVQlHWM9u6lM23A==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -48601,7 +49209,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F8",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "trunk",
           "Moid": "614ce25d4630312d416698fa",
           "Name": "",
@@ -48660,7 +49268,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:03 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:10 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669914
@@ -48676,9 +49284,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIGReSwYXjWDBtMjYJJkd6ald1OYzLpVshzComftAUAOGAiAdAZ3gpvI9w+ZyCdUSlZ8MTy4FKo0kRfeJI7yk+m9asg=="
+        host date digest",signature="MEUCIQD96R9s6NARD1qXiaR/5aldk2iDDeAEDAZV6rIrYhdxFAIgZ1jBNbK0TJScbGnDRBgD2G6O9oakiR23YbFrQvnLQ8A="
       Date:
-      - Tue, 26 Apr 2022 05:04:03 GMT
+      - Wed, 27 Apr 2022 06:20:10 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -48691,16 +49299,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:03 GMT
+      - Wed, 27 Apr 2022 06:20:10 GMT
       Set-Cookie:
-      - AWSALB=Cea0Qq2HU/Dj16zJy7Cz14dA7t+/DRqzcBjRRGlpVle4fAdzC6yeYzPQ/C6+tNRn6hyYKaGN5EFfTWACYgXsc6Fy7Z6GNgd2J7/nAcAZPRbgfEl0dAWXvGkJ9w7J;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/
-      - AWSALBCORS=Cea0Qq2HU/Dj16zJy7Cz14dA7t+/DRqzcBjRRGlpVle4fAdzC6yeYzPQ/C6+tNRn6hyYKaGN5EFfTWACYgXsc6Fy7Z6GNgd2J7/nAcAZPRbgfEl0dAWXvGkJ9w7J;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=GH2laCP+e47XsTnkQtcX2GGNT4eP22bBX4TlQ5VD028VexXcfRnazNUJiRXNZGy0B0OsVDSf+SoqSKP3k7esHZYWFYrC8qePQivulpgYvkteXqBHg2/xy7pNIuN9;
+        Expires=Wed, 04 May 2022 06:20:10 GMT; Path=/
+      - AWSALBCORS=GH2laCP+e47XsTnkQtcX2GGNT4eP22bBX4TlQ5VD028VexXcfRnazNUJiRXNZGy0B0OsVDSf+SoqSKP3k7esHZYWFYrC8qePQivulpgYvkteXqBHg2/xy7pNIuN9;
+        Expires=Wed, 04 May 2022 06:20:10 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB3454a8fa339136886926e185346eaf84
+      - NB0d74b503a30b3ed5e38a22fd4aa9652b
       Pragma:
       - no-cache
       Cache-Control:
@@ -48730,11 +49338,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - bElwNmrqTH8TAeYqwu5oKli53a57ng2IhWUc13rP8outqY0nerxTTQ==
+      - 12zHWMfHWgXBnaSpcGt1wljG6uZUc5KbyYjedMiRTzo06vjAS9KuzQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -48781,7 +49389,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DC",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669914",
           "Name": "",
@@ -48840,7 +49448,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:03 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:10 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698fd
@@ -48856,9 +49464,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDwamI90zUtSm2r8dZLb4zFwJmvSAxsBw9ATSXKnOhTawIgaiHMk1yykOQhdCVEQdGKGNt9fiVcUY0pISFS2slTxis="
+        host date digest",signature="MEUCIQDFHftRIPKr0W/KCCBkcDCQ4+wKmahDfFiQo9XPLk600AIgDwBAbFDBMJ2b1GM++an4OBPeYPHdDLRsflJ9V1fYT+8="
       Date:
-      - Tue, 26 Apr 2022 05:04:03 GMT
+      - Wed, 27 Apr 2022 06:20:10 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -48871,16 +49479,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:04 GMT
+      - Wed, 27 Apr 2022 06:20:10 GMT
       Set-Cookie:
-      - AWSALB=sa68dO2JoYNGRuNNb4MsJVX1UMnQFSCWF1pxmarX96dCyRamYboDO2nmLzbiY3Kz4b9CfLmvmLNykvWv3YSmpH6XEnhaoihOciY3InsK9EuLbhE/Vrp/XZzSDllj;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/
-      - AWSALBCORS=sa68dO2JoYNGRuNNb4MsJVX1UMnQFSCWF1pxmarX96dCyRamYboDO2nmLzbiY3Kz4b9CfLmvmLNykvWv3YSmpH6XEnhaoihOciY3InsK9EuLbhE/Vrp/XZzSDllj;
-        Expires=Tue, 03 May 2022 05:04:03 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=6xkwXUTGMFIKSuM6lrX81KEEwgKB1NmhLfylXpLVzaNi7guqdE6bZbhM9PabMer03jSeRMddOi4Nzone3Ub2iQCm/FLci5/zoz0GXg4cOPh0BZ8mnEE1LEmKe5ZP;
+        Expires=Wed, 04 May 2022 06:20:10 GMT; Path=/
+      - AWSALBCORS=6xkwXUTGMFIKSuM6lrX81KEEwgKB1NmhLfylXpLVzaNi7guqdE6bZbhM9PabMer03jSeRMddOi4Nzone3Ub2iQCm/FLci5/zoz0GXg4cOPh0BZ8mnEE1LEmKe5ZP;
+        Expires=Wed, 04 May 2022 06:20:10 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd9e727ef461758369d14564c32d4d94e
+      - NB873d6c2ad6a5f908ceaff8f05e142fd6
       Pragma:
       - no-cache
       Cache-Control:
@@ -48910,11 +49518,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 9KkrycB3aKfe8apiI_E9llBk9UHwqczzhvq81sLsAaJKejh6bV-9AA==
+      - j4t8g91UM5Yypg0dvmNStxcXs7Wtt2ieEUmfA0nmQ3D3tmI3n4LMuw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -48961,7 +49569,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:94:04",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698fd",
           "Name": "",
@@ -49020,7 +49628,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:04 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:10 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669905
@@ -49036,9 +49644,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCllsKmICI+gU0YebRF9XVYZnEdUMyXVoxtDvPwQbkx6wIgLr7BbM01lfgq6fTRQELsUjzseE476CgRAjLeMKGMjy4="
+        host date digest",signature="MEQCICKQSSfN2lvG179Uas0skGllGiQwQheuXkMxMgeXS3sGAiAR1aFcoY4g1hf202o5+rSlWXAQlIGQy2O+80NhabjtUg=="
       Date:
-      - Tue, 26 Apr 2022 05:04:04 GMT
+      - Wed, 27 Apr 2022 06:20:10 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -49051,16 +49659,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:04 GMT
+      - Wed, 27 Apr 2022 06:20:10 GMT
       Set-Cookie:
-      - AWSALB=1S9hLIL9MfWjYHV+713r6v0ojiq82tjlxwKr+W932jT0zrr41wUVQLXNQjgxfMLLdAurXr3hyR81lZeL1lTHvHo7HWMr8JhRU+uw1/8CrabJ/NI/+y7F74r/Ajex;
-        Expires=Tue, 03 May 2022 05:04:04 GMT; Path=/
-      - AWSALBCORS=1S9hLIL9MfWjYHV+713r6v0ojiq82tjlxwKr+W932jT0zrr41wUVQLXNQjgxfMLLdAurXr3hyR81lZeL1lTHvHo7HWMr8JhRU+uw1/8CrabJ/NI/+y7F74r/Ajex;
-        Expires=Tue, 03 May 2022 05:04:04 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=vAdiTOd3ecgnTDa17UuElIv0oYSPh/JMgBTMNRTeuTLZeDqoN7VF1xBVS0I6Cfx9IYpTNhRBf7hf4IexmOtAG+BJ/e+G3lvjvWrU5KG6PMBV21D3nN6Q3oqpCMfg;
+        Expires=Wed, 04 May 2022 06:20:10 GMT; Path=/
+      - AWSALBCORS=vAdiTOd3ecgnTDa17UuElIv0oYSPh/JMgBTMNRTeuTLZeDqoN7VF1xBVS0I6Cfx9IYpTNhRBf7hf4IexmOtAG+BJ/e+G3lvjvWrU5KG6PMBV21D3nN6Q3oqpCMfg;
+        Expires=Wed, 04 May 2022 06:20:10 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf22a3f579a86ce041b9e73600274a47e
+      - NBfa94302414ef523615a145e6e0fc9b59
       Pragma:
       - no-cache
       Cache-Control:
@@ -49090,11 +49698,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - iXIjvi-cU7V_GajeSKJlo9cryWBYSjLDpsCnWwV90vYYEOwUKCTiCg==
+      - p3ueK07A-QsdtlYTlTcX1Q6y7x2PFnILDT3bDghz2b9kymhuxGh_nA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -49141,7 +49749,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CD",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669905",
           "Name": "",
@@ -49200,7 +49808,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:04 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:10 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669911
@@ -49216,9 +49824,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCk1fGv6PJed2d+7B+fHjCKux5c17wz3X34ofFOVqX/4gIhAPROMogFIHwwrz1mU50iKLSZAAZIrJKIzHmKGqp9DJ0G"
+        host date digest",signature="MEYCIQCKZ/zh4rujHRK+BJbCMQ8nNEntR5JU5QAiVvR9+s498wIhAK7LsycabEerIs01+IpQxisJQYHy/KBVLKpxwklyvhIG"
       Date:
-      - Tue, 26 Apr 2022 05:04:04 GMT
+      - Wed, 27 Apr 2022 06:20:10 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -49231,16 +49839,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:04 GMT
+      - Wed, 27 Apr 2022 06:20:11 GMT
       Set-Cookie:
-      - AWSALB=xNIt0D9hRxAIhMMihCnCPzCdvr4IIbLqR/w66cB/ulxon+7YAgho0Ja96zvAGTmspJht3bCWFD89o/EgN5BSLAiVyacTu+PNCvDCVDVK8vra/aZoDcyGj5YWi/GP;
-        Expires=Tue, 03 May 2022 05:04:04 GMT; Path=/
-      - AWSALBCORS=xNIt0D9hRxAIhMMihCnCPzCdvr4IIbLqR/w66cB/ulxon+7YAgho0Ja96zvAGTmspJht3bCWFD89o/EgN5BSLAiVyacTu+PNCvDCVDVK8vra/aZoDcyGj5YWi/GP;
-        Expires=Tue, 03 May 2022 05:04:04 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=WVQyE/QwA0KnzVyA51jApqAwHIqEXAAtU2+07m/WrajKg5jjFpVF+DQNYSPpjnKzg12X2OOE0ekLc/Ju7ePPFsua3i4hShyX7pYX1UTf055ixhsMQ6nMP01dzeyw;
+        Expires=Wed, 04 May 2022 06:20:10 GMT; Path=/
+      - AWSALBCORS=WVQyE/QwA0KnzVyA51jApqAwHIqEXAAtU2+07m/WrajKg5jjFpVF+DQNYSPpjnKzg12X2OOE0ekLc/Ju7ePPFsua3i4hShyX7pYX1UTf055ixhsMQ6nMP01dzeyw;
+        Expires=Wed, 04 May 2022 06:20:10 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB05922e767722d3a119311e92aac884e5
+      - NB0160994ce30b690f562fc39840736a38
       Pragma:
       - no-cache
       Cache-Control:
@@ -49270,11 +49878,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ApLDRx6EA24HJctovl8xwZgkQTeMOd3-u0YMN1ku6BEd3RJ6KDLM2Q==
+      - mjH74c5SSH-BXYoZL5pvH5QXRjN_YIGpCLmkcyZvXp5T8jNmxVnwpA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -49321,7 +49929,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D9",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.585Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25d4630312d41669911",
           "Name": "",
@@ -49380,7 +49988,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:04 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:11 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991a
@@ -49396,9 +50004,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIFXxZTx5hbHnXD5FHEq0sDnruiXIBA2PEKr2IbZpaCrZAiEA3U2IvQb7Xt82hUKFXwVSG/88fpwDt/XpWRvJzzEdPL0="
+        host date digest",signature="MEUCIQDKu8klCAbfC1qLiBjv/uVCEWTmvQRZyINXhJ33Ps/1MgIgGavhEFCSvSvgA9RUruSBg8MIZ5JAqnuzDhd03THoleU="
       Date:
-      - Tue, 26 Apr 2022 05:04:04 GMT
+      - Wed, 27 Apr 2022 06:20:11 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -49411,16 +50019,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:04 GMT
+      - Wed, 27 Apr 2022 06:20:11 GMT
       Set-Cookie:
-      - AWSALB=Pgh/OBHuivkDvpxUKrhsFta9sG4GJJ8LlskdHGC2hxjpkPhAiSIGji+BgicSDy/kFuQ84/jeqkXOJt7bQ/9k8ELjvFP+XihJgY/FT1KnObTjrh2fwlWeobEwBvdG;
-        Expires=Tue, 03 May 2022 05:04:04 GMT; Path=/
-      - AWSALBCORS=Pgh/OBHuivkDvpxUKrhsFta9sG4GJJ8LlskdHGC2hxjpkPhAiSIGji+BgicSDy/kFuQ84/jeqkXOJt7bQ/9k8ELjvFP+XihJgY/FT1KnObTjrh2fwlWeobEwBvdG;
-        Expires=Tue, 03 May 2022 05:04:04 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=4qZPiA7gqo6YOp35+ZwYq2G9I27BnrnnpXacqNUSJwHwNNbVPzaoXn5lSmfxHQRnmUQDT3SPGiVvgZpINP8np6MPl56jUsjgXk/2QIuJ7F94YpM5oTjGa9Og6Bom;
+        Expires=Wed, 04 May 2022 06:20:11 GMT; Path=/
+      - AWSALBCORS=4qZPiA7gqo6YOp35+ZwYq2G9I27BnrnnpXacqNUSJwHwNNbVPzaoXn5lSmfxHQRnmUQDT3SPGiVvgZpINP8np6MPl56jUsjgXk/2QIuJ7F94YpM5oTjGa9Og6Bom;
+        Expires=Wed, 04 May 2022 06:20:11 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0f2c9fbdcf2e1f70f038b4b3f698fc63
+      - NB4f4985243193ffdaf700dcb6b858ac32
       Pragma:
       - no-cache
       Cache-Control:
@@ -49450,11 +50058,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - oh00O85EyoINaeOmX7BngHZzWxY8QauCytYFzxW614pqexI72bvMlQ==
+      - jPXTVrvajSdv6clbGXjnXrmIiOJdVQHg0D99nIO2gL1styJn-YDSKQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -49501,7 +50109,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E2",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991a",
           "Name": "",
@@ -49560,7 +50168,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:04 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:11 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ec
@@ -49576,9 +50184,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBKunIA+Znt/CGYZV1WYECLNLgM+tIQJE/FiQMKIgsR3AiEAvRjrZTMr9DB2AbnMR01lEuaEOX3aaaMjHLz2jkRewxQ="
+        host date digest",signature="MEUCIQD2QmW9sArgr4my+Cl8FNg8H6ceaDQut2k6qjyxXjA+dAIgHG9faqs1mtF/lpMpYjEM4bL/6KmStsMpjO8NhqL5G7Q="
       Date:
-      - Tue, 26 Apr 2022 05:04:04 GMT
+      - Wed, 27 Apr 2022 06:20:11 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -49591,16 +50199,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:04 GMT
+      - Wed, 27 Apr 2022 06:20:11 GMT
       Set-Cookie:
-      - AWSALB=eJ6Zoa5bjQncGcICpPr6mEFt5KoEIFry4fND1zJEvOx3N4EHKE7AiOe3KjX+XI0tJGJ2u8dkqOdk9oQbqFI61IbTV3EVnn14aTcEu2ZlOAnxujr/EOMIeRxvzmAs;
-        Expires=Tue, 03 May 2022 05:04:04 GMT; Path=/
-      - AWSALBCORS=eJ6Zoa5bjQncGcICpPr6mEFt5KoEIFry4fND1zJEvOx3N4EHKE7AiOe3KjX+XI0tJGJ2u8dkqOdk9oQbqFI61IbTV3EVnn14aTcEu2ZlOAnxujr/EOMIeRxvzmAs;
-        Expires=Tue, 03 May 2022 05:04:04 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=DkCKEqa6HqOhhlyknFEcjXAQCu4Bc2Ampg2pngAprTUhIvqEaoYoVE3wSezE63AvD2kQJcbSSYuBt2gvavrC/qWI2uADbmaXjk/21gykJhLqhhcnHdfd2jHmNqCL;
+        Expires=Wed, 04 May 2022 06:20:11 GMT; Path=/
+      - AWSALBCORS=DkCKEqa6HqOhhlyknFEcjXAQCu4Bc2Ampg2pngAprTUhIvqEaoYoVE3wSezE63AvD2kQJcbSSYuBt2gvavrC/qWI2uADbmaXjk/21gykJhLqhhcnHdfd2jHmNqCL;
+        Expires=Wed, 04 May 2022 06:20:11 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB4148dc0c065203563675f9615f0dc93b
+      - NB65be56a04d286beb6189b3a3d2b90105
       Pragma:
       - no-cache
       Cache-Control:
@@ -49630,11 +50238,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - vI4C4NkleScoZH8gLjxXrLvKNtmbbNECSgMzbedGVwlSGO6IVHZ2uw==
+      - YMki4yUnftSPtJVrAYkqHxLbD0UaQGgNZ2wel12FFiqeHWbLvpRrGw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -49681,7 +50289,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:EA",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ec",
           "Name": "",
@@ -49740,7 +50348,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:05 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:11 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f6
@@ -49756,9 +50364,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCzfb3jw7PUt/7Zu6JqMTT6RByXUgsq5Uw6WMq+Qb06oAIgP2mxOu0P47TFLpgV0vQ7FSkGZmkgU2DLGp55EIQUskY="
+        host date digest",signature="MEUCICzceWi1OSM4862ekzSm/iCmXnyNOygR1scE1PL/kIbgAiEAg7dvFdwv806+NdnCb0zMrQjxj+evoSYC3bHnOYMuP+0="
       Date:
-      - Tue, 26 Apr 2022 05:04:05 GMT
+      - Wed, 27 Apr 2022 06:20:11 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -49771,16 +50379,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:05 GMT
+      - Wed, 27 Apr 2022 06:20:11 GMT
       Set-Cookie:
-      - AWSALB=9T5FowL5WFUGOZjtmnI88ZVwpqDVuJ8YsEVLXGgj7l2xzL7jYUsZssQ4FvWs9oVX98HNiNGrnIyNWd3R30b6Yb3ZbPPN029CIERlrxvNjBcjTEqreppS5JTEjIpM;
-        Expires=Tue, 03 May 2022 05:04:05 GMT; Path=/
-      - AWSALBCORS=9T5FowL5WFUGOZjtmnI88ZVwpqDVuJ8YsEVLXGgj7l2xzL7jYUsZssQ4FvWs9oVX98HNiNGrnIyNWd3R30b6Yb3ZbPPN029CIERlrxvNjBcjTEqreppS5JTEjIpM;
-        Expires=Tue, 03 May 2022 05:04:05 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=v99xQ3VQeh1P8olR/8pPsBICdHtMfi5dBgAN1klL65VarygyvjwJKGBkZX3+7bbH6j1hph5AZEpRoH8nB3R0wTF+vpQTONAQ/S3YWYQ62BIwPPBgULLo09bmxkpO;
+        Expires=Wed, 04 May 2022 06:20:11 GMT; Path=/
+      - AWSALBCORS=v99xQ3VQeh1P8olR/8pPsBICdHtMfi5dBgAN1klL65VarygyvjwJKGBkZX3+7bbH6j1hph5AZEpRoH8nB3R0wTF+vpQTONAQ/S3YWYQ62BIwPPBgULLo09bmxkpO;
+        Expires=Wed, 04 May 2022 06:20:11 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe1f21cd067fdb6839c651d82b7ead824
+      - NB605174044540146047a33a07989d9548
       Pragma:
       - no-cache
       Cache-Control:
@@ -49810,11 +50418,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 4HVu2RKbt30l4KTb08ZSi33_ffJFsvXGA2WQgsA6jUXtCu1bnLXz1Q==
+      - eFqrD5sUcYGTgN1k1EqusdEzTfKUZWHC8fCx_Y3yX9HeVTzKoSBS3g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -49861,7 +50469,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F4",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f6",
           "Name": "",
@@ -49920,7 +50528,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:05 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:11 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f8
@@ -49936,9 +50544,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDGexZeEIIi1Dp5mg+n9lbyrvmTMLm+zZqibXdUsfinBQIhAI4fTs4NTXcnwZWySmIObd/9puJ/cigvh5b6lzYuyD5r"
+        host date digest",signature="MEYCIQCdxNauLRnYcBd20SWKA94yCWuiuSoyT6LtAEZSXFsdXwIhALZsteHnSNY30YSbvMLkcC10BnU6x7Uer/FSmSl9TArE"
       Date:
-      - Tue, 26 Apr 2022 05:04:05 GMT
+      - Wed, 27 Apr 2022 06:20:11 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -49951,16 +50559,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:05 GMT
+      - Wed, 27 Apr 2022 06:20:11 GMT
       Set-Cookie:
-      - AWSALB=K7p507UXwGj2i4RnBfGf7ahTwRD171+NT1NTx5a/9e5MIBwep14oX48RIsFh4PwOlQX9nCq1nT9CPc/JXgzUTuX0W3glKUlELLVAbJDLWO2MI3jb4+6Qt3kveeiK;
-        Expires=Tue, 03 May 2022 05:04:05 GMT; Path=/
-      - AWSALBCORS=K7p507UXwGj2i4RnBfGf7ahTwRD171+NT1NTx5a/9e5MIBwep14oX48RIsFh4PwOlQX9nCq1nT9CPc/JXgzUTuX0W3glKUlELLVAbJDLWO2MI3jb4+6Qt3kveeiK;
-        Expires=Tue, 03 May 2022 05:04:05 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=rnHXxiVznMEDz6mFRINHG/r0Lt8KSx1Y04ZOM1aELxXd67I8ds7S+TfUv16lgdpfYMs+mndherBVfV6kpsE3bcdqQyzBX4kLHF8XrMfM7Q0rE9DM7xRsVtgOJo+g;
+        Expires=Wed, 04 May 2022 06:20:11 GMT; Path=/
+      - AWSALBCORS=rnHXxiVznMEDz6mFRINHG/r0Lt8KSx1Y04ZOM1aELxXd67I8ds7S+TfUv16lgdpfYMs+mndherBVfV6kpsE3bcdqQyzBX4kLHF8XrMfM7Q0rE9DM7xRsVtgOJo+g;
+        Expires=Wed, 04 May 2022 06:20:11 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB9da4544b90e73b5d9b23f2285d5fbda1
+      - NB3c9fc223c81b9671e384227176e378cd
       Pragma:
       - no-cache
       Cache-Control:
@@ -49990,11 +50598,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 75W-wjaRW5QZmUltJ87GldHSw9zK1buzqe3sLwhBvOoVl5OU_GM9kQ==
+      - lxBUiYVpNN6lE786dyMU7HS3hL9AGGTWUVVXDtmHDNy5alfN8-HmUw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -50041,7 +50649,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F6",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f8",
           "Name": "",
@@ -50100,7 +50708,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:05 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:12 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991f
@@ -50116,9 +50724,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDRBKxHcAVbfYTSu6qkvoluqwTKGBhYRj0Z9aQ4+59KsAIhAO6qNQ9exgITAkPe8dAZ0x7mHD5MVIyi+gAWSHvCRIiX"
+        host date digest",signature="MEUCIGMWlsEw5c1wfFAtlPhCYyCkAzUaAvuR3koh2j6S3n6BAiEApnRwfPPtC6wPGDbwDGJqMnGeOYl69DC46zUFI03kZQw="
       Date:
-      - Tue, 26 Apr 2022 05:04:05 GMT
+      - Wed, 27 Apr 2022 06:20:12 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -50131,16 +50739,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:05 GMT
+      - Wed, 27 Apr 2022 06:20:12 GMT
       Set-Cookie:
-      - AWSALB=O+pphlyVVPn85ADtQZ9gtZb2HS18ukcoOuHXaA37OUgk49LYMZNvkyPTb+k3Eg3mwh+39FopjS7ZdlWBo1mcoR48dGXy+hid8MCxUqGqCKHFYo3HQMDY1pGQP1kj;
-        Expires=Tue, 03 May 2022 05:04:05 GMT; Path=/
-      - AWSALBCORS=O+pphlyVVPn85ADtQZ9gtZb2HS18ukcoOuHXaA37OUgk49LYMZNvkyPTb+k3Eg3mwh+39FopjS7ZdlWBo1mcoR48dGXy+hid8MCxUqGqCKHFYo3HQMDY1pGQP1kj;
-        Expires=Tue, 03 May 2022 05:04:05 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=0JZzVG77tqtUIOZIZ08GwlEbOjFooYYjgoN1UwDI34ujb25J36GStU5bpTX0c3fzxfVLzq+2mxGy977sKjlb6QSAmz+pqm7xHMhJ2twZoOMj6EGB8e64Gxr5TrNe;
+        Expires=Wed, 04 May 2022 06:20:12 GMT; Path=/
+      - AWSALBCORS=0JZzVG77tqtUIOZIZ08GwlEbOjFooYYjgoN1UwDI34ujb25J36GStU5bpTX0c3fzxfVLzq+2mxGy977sKjlb6QSAmz+pqm7xHMhJ2twZoOMj6EGB8e64Gxr5TrNe;
+        Expires=Wed, 04 May 2022 06:20:12 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb4a8a1d63b4c9f8f523557b71cbe184b
+      - NBa12df09fce1d099cac7b8d3bb704996b
       Pragma:
       - no-cache
       Cache-Control:
@@ -50170,11 +50778,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 6zaxcisHPNeTqq8YIPJ4-XcwygDF-CmZjsb3hkWgYGyTW53i84X1yA==
+      - _wKS2_SFv5i3TULkex74kres6V_B3xaHmNvfNWLvm_vMocdfwWKYfw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -50221,7 +50829,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E7",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991f",
           "Name": "",
@@ -50280,7 +50888,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:05 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:12 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f1
@@ -50296,9 +50904,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQDDawWubSKvNbmw49n+viUxab2r1xycp7ODMXE4qYQKUwIgD9rM1rtsyWp4JycDtAO8SPmbwN84Ul9GWXy7j8VJe0A="
+        host date digest",signature="MEUCIQCtmUvYwPKZmGl/tkpCiiKMLW9yo/bDvHghWG1SjnKG/AIgK0DdldnV3NCxZJgwMMP0EKUqI8+VxYWxeNanen+Dl0k="
       Date:
-      - Tue, 26 Apr 2022 05:04:05 GMT
+      - Wed, 27 Apr 2022 06:20:12 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -50311,16 +50919,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:05 GMT
+      - Wed, 27 Apr 2022 06:20:12 GMT
       Set-Cookie:
-      - AWSALB=7tAFAJ+7JqM1Tv2IDgN5rHvqMcvarHeE2h+hJ6+JjqfREMj2xDHjVJU9yAgBmZhA2DuXU4rS5oTRmsTD+jWRwUxmNFuVz+Ut4450S2ERG5wO7TzQUILshTKv/6T0;
-        Expires=Tue, 03 May 2022 05:04:05 GMT; Path=/
-      - AWSALBCORS=7tAFAJ+7JqM1Tv2IDgN5rHvqMcvarHeE2h+hJ6+JjqfREMj2xDHjVJU9yAgBmZhA2DuXU4rS5oTRmsTD+jWRwUxmNFuVz+Ut4450S2ERG5wO7TzQUILshTKv/6T0;
-        Expires=Tue, 03 May 2022 05:04:05 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=xkqL7de2xYcyTaqYPq43zH2QqZw2tSAwWhlTor+Tt5rYaXSjJ8WtRxCaC+k29OoL9wODDkN9IpOc9XAkn4pYhaUAQMXk5pjR55V+fWEip95PUEsoexfNEalcr5iL;
+        Expires=Wed, 04 May 2022 06:20:12 GMT; Path=/
+      - AWSALBCORS=xkqL7de2xYcyTaqYPq43zH2QqZw2tSAwWhlTor+Tt5rYaXSjJ8WtRxCaC+k29OoL9wODDkN9IpOc9XAkn4pYhaUAQMXk5pjR55V+fWEip95PUEsoexfNEalcr5iL;
+        Expires=Wed, 04 May 2022 06:20:12 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf2ef230996b7f3b54d0408e357190bee
+      - NBdc60570fc408d4efd7d0d6833bd872e2
       Pragma:
       - no-cache
       Cache-Control:
@@ -50350,11 +50958,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - O9lO8JYCV9KjH4y9c_Zkn5l-k6rNKZIPPUSFYZYnW0PLggXXz_dsEA==
+      - "-e5SGZ0UmbgXu1em8-23fnd33V35zox8m4OLzgzUTHsOPEI90Tfy7Q=="
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -50401,7 +51009,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:EF",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f1",
           "Name": "",
@@ -50460,7 +51068,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:05 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:12 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ff
@@ -50476,9 +51084,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIGg0eDa7YN2TMNCNuwkLswA5lLwGwmoKgVtNc0nrPhRXAiAZWJkTLX7ggRYI/GA7qwpqOvwQwG6bdcl8aZa7EAqV8w=="
+        host date digest",signature="MEUCIQDST0J4+HUygtgA/W8NxWH8EKrjVVeyNG7FfWliKcVxiAIgJtHAJessKhNGwEL15aTmKLdjdG3z0U72NMIvVJejcfw="
       Date:
-      - Tue, 26 Apr 2022 05:04:05 GMT
+      - Wed, 27 Apr 2022 06:20:12 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -50491,16 +51099,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:06 GMT
+      - Wed, 27 Apr 2022 06:20:12 GMT
       Set-Cookie:
-      - AWSALB=tuQJPq9iZhrQ2/ndf4YMaLnBz/nA5NOuIYwUJlzKX32v1rl3XT/3Tivihmmzk/8oj6V/dUa/qkFktZSUZxR0O2Xukcwj1Dh+/gKgnkkvBshjcLkVrtgtxzXBxTLQ;
-        Expires=Tue, 03 May 2022 05:04:06 GMT; Path=/
-      - AWSALBCORS=tuQJPq9iZhrQ2/ndf4YMaLnBz/nA5NOuIYwUJlzKX32v1rl3XT/3Tivihmmzk/8oj6V/dUa/qkFktZSUZxR0O2Xukcwj1Dh+/gKgnkkvBshjcLkVrtgtxzXBxTLQ;
-        Expires=Tue, 03 May 2022 05:04:06 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=QBgp0cGx40pKhoBS1zkDDsqZ+mx8QyjBphepXtYTT8IWtv3aOHqkTrsdqlHlpgg22p8ryoj8MtJAvqDA+uADt/Es+KlMuLjxVqEwGZc+YyBX/QWqTDaEjAvldYET;
+        Expires=Wed, 04 May 2022 06:20:12 GMT; Path=/
+      - AWSALBCORS=QBgp0cGx40pKhoBS1zkDDsqZ+mx8QyjBphepXtYTT8IWtv3aOHqkTrsdqlHlpgg22p8ryoj8MtJAvqDA+uADt/Es+KlMuLjxVqEwGZc+YyBX/QWqTDaEjAvldYET;
+        Expires=Wed, 04 May 2022 06:20:12 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBbce889d9d1ec86eb088db555644e1dad
+      - NB1bb024b180040f4026d2c5ab4098095d
       Pragma:
       - no-cache
       Cache-Control:
@@ -50530,11 +51138,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - mCzt6WJ3QJt48mXXPze4ZoABoxG3n3I3B6I79OyHLzXESZqllbGejg==
+      - C4526b7TG2PKx8Ni69r4mqZM0yYtLH5SUOC66b285p5DvjYRpqFsmg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -50581,7 +51189,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:94:0C",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ff",
           "Name": "",
@@ -50640,7 +51248,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:06 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:12 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991c
@@ -50656,9 +51264,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIHN0g3zWF5ksn9+se52jh4L65bZR55rsuCuxjKLEiV8FAiAo6ZHK+Y073ufktyqUpyY9wVXGVRMFqYlHdkuuG1z+Xg=="
+        host date digest",signature="MEUCIHMSnduZmkWc7zG3hGVbvLlhTqUYyfk6A296sJ2LrfH8AiEAsAEHjG6DKK5wciBCDTnJd5p1mq4TyCdUsVi+N3FLieE="
       Date:
-      - Tue, 26 Apr 2022 05:04:06 GMT
+      - Wed, 27 Apr 2022 06:20:12 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -50671,16 +51279,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:06 GMT
+      - Wed, 27 Apr 2022 06:20:12 GMT
       Set-Cookie:
-      - AWSALB=td5n0MnUs+SBOrBHLGpTmmkC1OpiOMX96P2iPmQijDsKX9lWnQT0pX8q3cKfRcTLOhX2HoPDYHYX6sFI0DavCtDXy5PyaelCPKqNgtYgwWgg16UF2dxsKHWnv6pW;
-        Expires=Tue, 03 May 2022 05:04:06 GMT; Path=/
-      - AWSALBCORS=td5n0MnUs+SBOrBHLGpTmmkC1OpiOMX96P2iPmQijDsKX9lWnQT0pX8q3cKfRcTLOhX2HoPDYHYX6sFI0DavCtDXy5PyaelCPKqNgtYgwWgg16UF2dxsKHWnv6pW;
-        Expires=Tue, 03 May 2022 05:04:06 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=5uY4Y8elmZcj114gCsUSdfO49cFFl80dmPAtW27RixgZZhEufVuxXWSBRCner2l1Cb9BShGiIeL6pSd/FBFLidpfrqj9ZpCJ4U1Aheit3Vf/bn+aCGriTSvHu1d6;
+        Expires=Wed, 04 May 2022 06:20:12 GMT; Path=/
+      - AWSALBCORS=5uY4Y8elmZcj114gCsUSdfO49cFFl80dmPAtW27RixgZZhEufVuxXWSBRCner2l1Cb9BShGiIeL6pSd/FBFLidpfrqj9ZpCJ4U1Aheit3Vf/bn+aCGriTSvHu1d6;
+        Expires=Wed, 04 May 2022 06:20:12 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBdf85b474ea0b94fe2ea277d4dbe68409
+      - NB7822c3cada52c38960d0b9aabff40038
       Pragma:
       - no-cache
       Cache-Control:
@@ -50710,11 +51318,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - D4T2Ffj_CuUep4M5Vkqi7ZqOaUvaoJGECSqAAfC9lQeNznR6ARKGaw==
+      - biaDFvKq58niwaxiZwvn2NlVGsVp1pFpLhDK72ef-v4timmrntggfQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -50761,7 +51369,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E4",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991c",
           "Name": "",
@@ -50820,7 +51428,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:06 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:12 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669909
@@ -50836,9 +51444,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIBU+ylP+/4Ewu7loaXaNegBxUs6XIQklJQE1Z6xP2rkOAiBeVYoUKWTydzmRprBzB/C8SPfL/vB8h88kBRkOkJGQkQ=="
+        host date digest",signature="MEQCICnXLWQqKoHq65x7O+fkZaHP9CBUUaxRLGKCjARRYsGkAiAZKIqa7u+tgVSoqb7N+zaKZboG+UDOajvhui3nqk1gDg=="
       Date:
-      - Tue, 26 Apr 2022 05:04:06 GMT
+      - Wed, 27 Apr 2022 06:20:12 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -50851,16 +51459,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:06 GMT
+      - Wed, 27 Apr 2022 06:20:13 GMT
       Set-Cookie:
-      - AWSALB=Cc7gEfhr94Ghb+gJBTm7gz2k+NGh0ypoIJ47gWo0mjwpopeqPxgc551hvlEAEXZBV90L8Yvxw2rXSQl5ZN9uIuURVvouEGura2mNF8BpzdOnIwKnEfdoYtM02FAD;
-        Expires=Tue, 03 May 2022 05:04:06 GMT; Path=/
-      - AWSALBCORS=Cc7gEfhr94Ghb+gJBTm7gz2k+NGh0ypoIJ47gWo0mjwpopeqPxgc551hvlEAEXZBV90L8Yvxw2rXSQl5ZN9uIuURVvouEGura2mNF8BpzdOnIwKnEfdoYtM02FAD;
-        Expires=Tue, 03 May 2022 05:04:06 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=TpudjdOFU+22fCzpaRSlKIOAgR8ZmLSXtQ8hCRFrPqUujUAj9cMewpia+DRe56RejsaXvsp7lq6A67YFPqPCoiIxRTZKSk+c5hrw+lhNy2Kej/T2cN/4AIYXXsnU;
+        Expires=Wed, 04 May 2022 06:20:13 GMT; Path=/
+      - AWSALBCORS=TpudjdOFU+22fCzpaRSlKIOAgR8ZmLSXtQ8hCRFrPqUujUAj9cMewpia+DRe56RejsaXvsp7lq6A67YFPqPCoiIxRTZKSk+c5hrw+lhNy2Kej/T2cN/4AIYXXsnU;
+        Expires=Wed, 04 May 2022 06:20:13 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB01b591f603c621e27841e212f204c0b1
+      - NBc6b75e34ad9ab17e1e1fe81be7914f38
       Pragma:
       - no-cache
       Cache-Control:
@@ -50890,11 +51498,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - vdWnXQaUVcKNd1-mFr1N7i7vJW6srucfAvMONM_AZcwH7LPHXvzNNQ==
+      - 2JaLkzxWAthA-vm8_1ErKO6tqQDpepsG9QMgp_jwJWuUgpcDt2fLig==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -50941,7 +51549,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D1",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669909",
           "Name": "",
@@ -51000,7 +51608,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:06 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:13 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990e
@@ -51016,9 +51624,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDms65OURWsfxJ0X+BXT53+4kpx2olisxYbEZHQKPUB+wIhAOxqwXZqE/5Z1RDMYfm6F6joGqjjQAJe7vypogXOPfP5"
+        host date digest",signature="MEQCIElAn5Yh0CsRfmCkdVGv4RXCvwI3ddScNWBTJZDa6SLDAiBj6Ue2Ljhit37Dg9t/i1DhCLrt1Q9puDYcxcV9L3kQbw=="
       Date:
-      - Tue, 26 Apr 2022 05:04:06 GMT
+      - Wed, 27 Apr 2022 06:20:13 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -51031,16 +51639,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:06 GMT
+      - Wed, 27 Apr 2022 06:20:13 GMT
       Set-Cookie:
-      - AWSALB=5ZC17LzPyz6NC/fJDYRRfnivZL+ySWbc80EwZOLTky1qQqQBg5xdNgnPN2vq4TsgS0ZF1YNS7qrPzqYHFQpYBnD6CTb2A1qpE57etaz9aDRTTOdxXXC7Nv1x0xRs;
-        Expires=Tue, 03 May 2022 05:04:06 GMT; Path=/
-      - AWSALBCORS=5ZC17LzPyz6NC/fJDYRRfnivZL+ySWbc80EwZOLTky1qQqQBg5xdNgnPN2vq4TsgS0ZF1YNS7qrPzqYHFQpYBnD6CTb2A1qpE57etaz9aDRTTOdxXXC7Nv1x0xRs;
-        Expires=Tue, 03 May 2022 05:04:06 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=Ts6ZY/5kmEOEFheP7+G9xIleYRXsQwE1iUoVft9YC6zfucCSgbr2L+1SQqQ6tTOFyUAlPwODZnCjCVkY6nw6kP5n6lIyZGG5je+8OpYBZ3qJ3V7MvVlgHXcuNUlJ;
+        Expires=Wed, 04 May 2022 06:20:13 GMT; Path=/
+      - AWSALBCORS=Ts6ZY/5kmEOEFheP7+G9xIleYRXsQwE1iUoVft9YC6zfucCSgbr2L+1SQqQ6tTOFyUAlPwODZnCjCVkY6nw6kP5n6lIyZGG5je+8OpYBZ3qJ3V7MvVlgHXcuNUlJ;
+        Expires=Wed, 04 May 2022 06:20:13 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6e1f6660de4bb10cbb9a2ab71638ace9
+      - NB341c15cd9d5a27080171a44dd9e0d0af
       Pragma:
       - no-cache
       Cache-Control:
@@ -51070,11 +51678,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 1FSLsb4fV6-u1-3OLHWecBPVrMgOFbeosGQLqJkH_J8G3gL_rF31zg==
+      - 1T6ihbTbq_WZ_PXYgveCQlOsUqb-Rx6pWlefQZkbo6mGUHGuDqJF0A==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -51121,7 +51729,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D6",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990e",
           "Name": "",
@@ -51180,7 +51788,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:06 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:13 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f4
@@ -51196,9 +51804,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBBIcndQY4v8bHYKE5IdAyFhUvu648GGQ/rUlKGB1G8hAiEAsIMSZHjg7U2PmgljwHb5p8wkNWy3vIXofZOsXnEnlq4="
+        host date digest",signature="MEUCIQCpFVBtRWI3NWxEZpNkkIu2NNoDujFLjfd7ip0ZYH2rLAIgZ+JLUoEbmMo+g/Q+gGbOiPebuWH7qa/2Eb1ysOJO1l4="
       Date:
-      - Tue, 26 Apr 2022 05:04:06 GMT
+      - Wed, 27 Apr 2022 06:20:13 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -51211,16 +51819,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:06 GMT
+      - Wed, 27 Apr 2022 06:20:13 GMT
       Set-Cookie:
-      - AWSALB=Vz3cSjZ6l9sd8yM0res2WvC8Wbo9FzsGJaeSttBSys6fjm4aI8w8YqCu6surnaqgDB1QiziA9d3YM8YZ7UtAquY8HDoy+K3dAVuU+N5Lz/Lrdp/03NpMi96w48sh;
-        Expires=Tue, 03 May 2022 05:04:06 GMT; Path=/
-      - AWSALBCORS=Vz3cSjZ6l9sd8yM0res2WvC8Wbo9FzsGJaeSttBSys6fjm4aI8w8YqCu6surnaqgDB1QiziA9d3YM8YZ7UtAquY8HDoy+K3dAVuU+N5Lz/Lrdp/03NpMi96w48sh;
-        Expires=Tue, 03 May 2022 05:04:06 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=oZyYASa1PAXof4XnzV3ISVobLqmBWyIryh1LgiZxRx7xvil1eoxh6UBOAg1DByUU9WQCfgG1V6GYm9mHiVSUEojg+U4EApdhTN+pVBT27IvlLpQ4qeycSgGFrhbL;
+        Expires=Wed, 04 May 2022 06:20:13 GMT; Path=/
+      - AWSALBCORS=oZyYASa1PAXof4XnzV3ISVobLqmBWyIryh1LgiZxRx7xvil1eoxh6UBOAg1DByUU9WQCfgG1V6GYm9mHiVSUEojg+U4EApdhTN+pVBT27IvlLpQ4qeycSgGFrhbL;
+        Expires=Wed, 04 May 2022 06:20:13 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe723713aafa0229ae9c7fd978580c1d4
+      - NB06aa4b4872aaff9f3276ec7f280a2835
       Pragma:
       - no-cache
       Cache-Control:
@@ -51250,11 +51858,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 5tsadUf8JYTcmYuj3RfbPhWTmgTNlbYNAWoMHjF18klCUE3-kYK5CQ==
+      - G3vSJHdIoYBPUDFKFzbCtayITJuqTMjaOiR_6lv2cLkrC3aIe4c8Eg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -51301,7 +51909,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F2",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f4",
           "Name": "",
@@ -51360,7 +51968,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:06 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:13 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669917
@@ -51376,9 +51984,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQD7SGp6JpfM5oTf4H0SM32rJzLA+FL1RepcBVtydOOMbwIhAMIUoG4/Oksuqy8FtgoCmeKCzslxuliGKnrG9UO8OknO"
+        host date digest",signature="MEYCIQD3iAPcmO5ddnLF8S0enTFrZ8E0tY5zMRI6occ9M4W8KwIhAL2Vs58ap/rkcvoXs7jYt01HrTvU9DYshAr5EO46oMJ6"
       Date:
-      - Tue, 26 Apr 2022 05:04:06 GMT
+      - Wed, 27 Apr 2022 06:20:13 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -51391,16 +51999,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:07 GMT
+      - Wed, 27 Apr 2022 06:20:13 GMT
       Set-Cookie:
-      - AWSALB=l4SfqmBfYHuHzatE6im7MoBhh5F3D9H0RfcT002AjD1umqhcIaLXw8eY0iG28z4InsMoAM85KlWs9QJWRPtrvbc7nXezncdfXAS6qDfOAuMZFJf+K8sq9W56PY21;
-        Expires=Tue, 03 May 2022 05:04:07 GMT; Path=/
-      - AWSALBCORS=l4SfqmBfYHuHzatE6im7MoBhh5F3D9H0RfcT002AjD1umqhcIaLXw8eY0iG28z4InsMoAM85KlWs9QJWRPtrvbc7nXezncdfXAS6qDfOAuMZFJf+K8sq9W56PY21;
-        Expires=Tue, 03 May 2022 05:04:07 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=y3ZqEt5KUwIfyhtWP0itvrXJDFEtUqwDYDhRAfsduPYdng1Gfjo7oxBz+HdmYbzbqy72ThOZJyERxJypkMIPUh6eXrr5DDGpLYbfhFE8anc10Ow+lnpK3Kglsf40;
+        Expires=Wed, 04 May 2022 06:20:13 GMT; Path=/
+      - AWSALBCORS=y3ZqEt5KUwIfyhtWP0itvrXJDFEtUqwDYDhRAfsduPYdng1Gfjo7oxBz+HdmYbzbqy72ThOZJyERxJypkMIPUh6eXrr5DDGpLYbfhFE8anc10Ow+lnpK3Kglsf40;
+        Expires=Wed, 04 May 2022 06:20:13 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB49c6cf1086cb210aea20baaac4e0a151
+      - NB9ddc2d053be5d75fb401caa55a23a764
       Pragma:
       - no-cache
       Cache-Control:
@@ -51430,11 +52038,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 24QHl5qzhZy2MIZzTrIYLuPNml2k7V57PO1KcJZ2KJFLOAg_2xenfg==
+      - gdryyyQ1gU8XVqCNKD0LXiteRmg-2BGfIqr5q95_gbmsDSVlUfplyQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -51481,7 +52089,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DF",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669917",
           "Name": "",
@@ -51540,7 +52148,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:07 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:13 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990a
@@ -51556,9 +52164,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIGAtJcuZDZ9RaDfNHxJcF24H7Ae+cuudC5B5OoFQ9MaLAiEA+Ob0EYUrxvkWqqZWDATabPxyt8ckQKoTOV2PqSXIaHA="
+        host date digest",signature="MEQCIEoumm/ZYgxQnNNFJSbuEZefAkLFEUu4n3EWN9smVm+UAiBup9rO0m9gVqfNJ34BYTu9y0bWJpEeJ/aDcAkT6FUARw=="
       Date:
-      - Tue, 26 Apr 2022 05:04:07 GMT
+      - Wed, 27 Apr 2022 06:20:13 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -51571,16 +52179,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:07 GMT
+      - Wed, 27 Apr 2022 06:20:14 GMT
       Set-Cookie:
-      - AWSALB=OLXKdHKIZfzqRGJj8bmpRtAUcuPvHWMq87HiRKOhk8Wrb2HdGOKy3lxY4yllciit/h/8qsI/CMm8FOHTZb+F85deFoz0DcAqz3ovTr61uBfzYNW3ciXkNInaNUPg;
-        Expires=Tue, 03 May 2022 05:04:07 GMT; Path=/
-      - AWSALBCORS=OLXKdHKIZfzqRGJj8bmpRtAUcuPvHWMq87HiRKOhk8Wrb2HdGOKy3lxY4yllciit/h/8qsI/CMm8FOHTZb+F85deFoz0DcAqz3ovTr61uBfzYNW3ciXkNInaNUPg;
-        Expires=Tue, 03 May 2022 05:04:07 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ssca/mfVYR6b+qyywWZ3ZQmyjF6oUmUfBxPcgLRtbQy8Uh+ur2/IqHibIK4YYwULw8i+8vKfqWiJRvy+spfsxVOe40WQRCgBjZDO7ta1MXzywl1RzZBFFINn+48K;
+        Expires=Wed, 04 May 2022 06:20:14 GMT; Path=/
+      - AWSALBCORS=ssca/mfVYR6b+qyywWZ3ZQmyjF6oUmUfBxPcgLRtbQy8Uh+ur2/IqHibIK4YYwULw8i+8vKfqWiJRvy+spfsxVOe40WQRCgBjZDO7ta1MXzywl1RzZBFFINn+48K;
+        Expires=Wed, 04 May 2022 06:20:14 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB1c4c097665c979ba84ee703fc5da60a6
+      - NB332831123e0a239cfce8efe5b87ea40c
       Pragma:
       - no-cache
       Cache-Control:
@@ -51610,11 +52218,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - LI5b85_ubU1lExTif6Vc-zuf6jadIvBkvWRtex1eVj5-rmEoWSRnxA==
+      - nbTiFQxyWgIzz10b_FBr3liTrBfqp8gvgDUFGBJOBpg8mTn-I6WE9Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -51661,7 +52269,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D2",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990a",
           "Name": "",
@@ -51720,7 +52328,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:07 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:14 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669918
@@ -51736,9 +52344,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCAdUboZ6MEEg6U4Ew5QQ66WjCOe4BWYXIj29kvZVh1UQIgN5AaReqCBUaE6yEFMmy6rw6NJPlbIl8X3mqERmf/RMY="
+        host date digest",signature="MEUCIH/LedsDTzLA67aqaG6w3dl7p5qY4HFCZdWxkS6DZA9qAiEA14aZr/3xAQ5YbMEaFWeYQsduyGgS6WhE8S/ng3foA3Y="
       Date:
-      - Tue, 26 Apr 2022 05:04:07 GMT
+      - Wed, 27 Apr 2022 06:20:14 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -51751,16 +52359,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:07 GMT
+      - Wed, 27 Apr 2022 06:20:14 GMT
       Set-Cookie:
-      - AWSALB=WPUnZhNMFom6xooCX58fmSING36Mrcq0aupYl0fp6wJ+hwwAf3/0e+19Y3b/TrsQhOp0N4aceqHbGGqQF0sIwOpcNusvwqXeSoWMUQzsCU/k3T8uMzgiXVyOCGsm;
-        Expires=Tue, 03 May 2022 05:04:07 GMT; Path=/
-      - AWSALBCORS=WPUnZhNMFom6xooCX58fmSING36Mrcq0aupYl0fp6wJ+hwwAf3/0e+19Y3b/TrsQhOp0N4aceqHbGGqQF0sIwOpcNusvwqXeSoWMUQzsCU/k3T8uMzgiXVyOCGsm;
-        Expires=Tue, 03 May 2022 05:04:07 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=3i6g7XZKOlLW7+ZAeWfv2EQBVBtCT2h/NX2MSyBK+c/HYMv8oIX5Y6a32L0bVlouGxS84Dyn+kyR0a8xQ9MFswoPx9GHAx1lIqOiNpL7nUl9L6g31+8NRqOqZnOk;
+        Expires=Wed, 04 May 2022 06:20:14 GMT; Path=/
+      - AWSALBCORS=3i6g7XZKOlLW7+ZAeWfv2EQBVBtCT2h/NX2MSyBK+c/HYMv8oIX5Y6a32L0bVlouGxS84Dyn+kyR0a8xQ9MFswoPx9GHAx1lIqOiNpL7nUl9L6g31+8NRqOqZnOk;
+        Expires=Wed, 04 May 2022 06:20:14 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBdfbfed4ec8f9fea530b6e5974e66765b
+      - NB3426f5dd959210cab79b11cf5e5c6064
       Pragma:
       - no-cache
       Cache-Control:
@@ -51790,11 +52398,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - QhceQauDuokH_Zi-rxT94e54sVQWtk3blcGSuwQfaA6kP5c8Gsrl2g==
+      - Z7F7JoHRt2pws7LIEoU5y444QPEQ8VmQNYBk7C6cUqEysBwYGBr4jg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -51841,7 +52449,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E0",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669918",
           "Name": "",
@@ -51900,7 +52508,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:07 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:14 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991b
@@ -51916,9 +52524,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIF9FJAwa127GMDTgPiLJiCmC8G5Y/AAflBeBXiDUqKCcAiAYp4sDUe/zWyv6jLCR5lZ6yj1jyGtbf1MLp0Iqom3dsQ=="
+        host date digest",signature="MEUCIQCW9voz3Es7qtKkhqtCwyXgHjjjdcjHup1UgJFjwcMIWgIgXsDJdClPQ78ZXS43qc+aJ0rvTGnBvlePF6/HAPcVtcs="
       Date:
-      - Tue, 26 Apr 2022 05:04:07 GMT
+      - Wed, 27 Apr 2022 06:20:14 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -51931,16 +52539,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:07 GMT
+      - Wed, 27 Apr 2022 06:20:14 GMT
       Set-Cookie:
-      - AWSALB=qx0HN79+C55TyFQpK1if1hvfAq5DK/sCVPXzzWGTm361g4kvqnUb8Ll4SDcR7+eIhs7/9nzhN8wzbjAxF3DH7OiGAuWWerbu1PipkMST/TI0Ca/5NCnbBjVdTADG;
-        Expires=Tue, 03 May 2022 05:04:07 GMT; Path=/
-      - AWSALBCORS=qx0HN79+C55TyFQpK1if1hvfAq5DK/sCVPXzzWGTm361g4kvqnUb8Ll4SDcR7+eIhs7/9nzhN8wzbjAxF3DH7OiGAuWWerbu1PipkMST/TI0Ca/5NCnbBjVdTADG;
-        Expires=Tue, 03 May 2022 05:04:07 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=nFyLBTKvnXhpZhbDlY3CWsFGEUCMXgfIXqjA4b0i9URUP6RFTNWKvDElqMLpoC/UM2osU/qQ0koz24GjJXwEpbcG9+i/JRTsiIA+vNWP6l646Lb/SkcYQNTHrpSL;
+        Expires=Wed, 04 May 2022 06:20:14 GMT; Path=/
+      - AWSALBCORS=nFyLBTKvnXhpZhbDlY3CWsFGEUCMXgfIXqjA4b0i9URUP6RFTNWKvDElqMLpoC/UM2osU/qQ0koz24GjJXwEpbcG9+i/JRTsiIA+vNWP6l646Lb/SkcYQNTHrpSL;
+        Expires=Wed, 04 May 2022 06:20:14 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBed8a265d5aedcc4d8146909df4c64c86
+      - NBa76cfdcaf40cf9b36143e74d4665f34f
       Pragma:
       - no-cache
       Cache-Control:
@@ -51970,11 +52578,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - MTZV4ugLcsGHQs7ob7hErXWofB1OSR72Bqja72w7HaQS-qeMtRWKqA==
+      - ouYlVpPqz-_Ge29SPNJ7zM77tvhGwa_BmRgCPL3b1ILhtP3HJTnoFg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -52021,7 +52629,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E3",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991b",
           "Name": "",
@@ -52080,7 +52688,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:07 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:14 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f0
@@ -52096,9 +52704,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIC8yQDoVyz32csQKnAgbiJ8QHQtBjWtuL0Ap0vS1lGRKAiEAkVvv5/tyhKc3NByUfxixEcJT6KMSCQtTckqF32/UWAo="
+        host date digest",signature="MEYCIQDaHP316GgM2gJrJCSFdEDxGSEo/77jHZhUBDGWQDwQQgIhAKW+iDEhFg+k+bV5fd7tBuWspYeRyB8zq+cw7XhCwQMf"
       Date:
-      - Tue, 26 Apr 2022 05:04:07 GMT
+      - Wed, 27 Apr 2022 06:20:14 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -52111,16 +52719,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:14 GMT
       Set-Cookie:
-      - AWSALB=mdUv3+jBRI1cvfYiUcbgdf+3dfwirhpNPvHXndUL06IV3H0pg5YsCRNQ9TMxPkZxVA+fcSp3KSkb9SboxqenRMLJLCVEnu9QddSQmsZSzunC7ATVUHWjqDRgHe+K;
-        Expires=Tue, 03 May 2022 05:04:07 GMT; Path=/
-      - AWSALBCORS=mdUv3+jBRI1cvfYiUcbgdf+3dfwirhpNPvHXndUL06IV3H0pg5YsCRNQ9TMxPkZxVA+fcSp3KSkb9SboxqenRMLJLCVEnu9QddSQmsZSzunC7ATVUHWjqDRgHe+K;
-        Expires=Tue, 03 May 2022 05:04:07 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=fzKyHhkbtLgxl7OfbTC8+AWag9eUBfDE7dw3hK6YL/SBK9+j13Gifq3oMKKwsJICEBGoJ0vGV+d5EkYM1elV9T4ATb7XQ3JftdSTYBxTc9aXe+U0vmWroIbI7dDJ;
+        Expires=Wed, 04 May 2022 06:20:14 GMT; Path=/
+      - AWSALBCORS=fzKyHhkbtLgxl7OfbTC8+AWag9eUBfDE7dw3hK6YL/SBK9+j13Gifq3oMKKwsJICEBGoJ0vGV+d5EkYM1elV9T4ATb7XQ3JftdSTYBxTc9aXe+U0vmWroIbI7dDJ;
+        Expires=Wed, 04 May 2022 06:20:14 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0bd2e77ebcb5f8ff9b62643237428a71
+      - NB5b89a6788894361f615f8a86362d21b9
       Pragma:
       - no-cache
       Cache-Control:
@@ -52150,11 +52758,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - v92kyNGpN85Rzq3yJ9XXMKmu4FL8RAxAt4BoHKUks7qf83b0oeIUTQ==
+      - xF3nfv7LF_yfZFyQieN8fHgNuIw5pEoxpaRvHYtWALY6aqtc0vy1IQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -52201,7 +52809,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:EE",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f0",
           "Name": "",
@@ -52260,7 +52868,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:07 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:14 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f2
@@ -52276,9 +52884,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDr5+VGpDVAi+z+N08NYmWZZSV467nOcN6h2T2m68AXvgIhAO1cSqdtrQ9KIE866E1FoZV6OJtCq1j1zgYfQzilamd7"
+        host date digest",signature="MEQCIG9WAMtrxjNqSxNyRtaD6n62oE2eFvVvJV0YmFX5CahRAiAsCnU1q091S2klLZH7qU6CY/nKhLaUv79mSyWVYQiImg=="
       Date:
-      - Tue, 26 Apr 2022 05:04:07 GMT
+      - Wed, 27 Apr 2022 06:20:14 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -52291,16 +52899,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:14 GMT
       Set-Cookie:
-      - AWSALB=p6ILI5CLzQzhIaXIK8XXBWKjheYMWa54lvot/maNFzExGxDiuyvibVI/nXaH0mD8BB2PPyBT+aYJp0DmuL82/is3Q4zb5Nwg1Kt6H1S9cyh0QPweGEbhGKiNOX1X;
-        Expires=Tue, 03 May 2022 05:04:08 GMT; Path=/
-      - AWSALBCORS=p6ILI5CLzQzhIaXIK8XXBWKjheYMWa54lvot/maNFzExGxDiuyvibVI/nXaH0mD8BB2PPyBT+aYJp0DmuL82/is3Q4zb5Nwg1Kt6H1S9cyh0QPweGEbhGKiNOX1X;
-        Expires=Tue, 03 May 2022 05:04:08 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=GtBI2/FF0ThslmNBOc0gy4KIaefNfOZtUvaJxKzROcsW4APRU83qbRjnLOvRiLriMcL+PwR1w4ibL9r3uvmjvPJsfw3G0F1iVkI8ySSbmoQokpTwgbYl9FnATN2d;
+        Expires=Wed, 04 May 2022 06:20:14 GMT; Path=/
+      - AWSALBCORS=GtBI2/FF0ThslmNBOc0gy4KIaefNfOZtUvaJxKzROcsW4APRU83qbRjnLOvRiLriMcL+PwR1w4ibL9r3uvmjvPJsfw3G0F1iVkI8ySSbmoQokpTwgbYl9FnATN2d;
+        Expires=Wed, 04 May 2022 06:20:14 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB1278bcd526c777b560683198e47bddf9
+      - NB31f84b584aeaa5212a902a2c2a64f14f
       Pragma:
       - no-cache
       Cache-Control:
@@ -52330,11 +52938,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - F2RA9L0XcWnl68OjwHuLUmfiUtewwe4uxoOJH_lGGXPousuy2ywkzQ==
+      - "-JZ1uzpWboY0k8jIIrjcm13XPQMtwfR5f6FNe-8RRqpJ-ICkX5-qWQ=="
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -52381,7 +52989,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F0",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f2",
           "Name": "",
@@ -52440,7 +53048,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:08 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:14 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698fc
@@ -52456,9 +53064,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIA0AnEqCMsn6t3uo/L83LSidvps10EsSd1is7c2rRQ5sAiAbqP2gODeJXbTgZ1aDBmJHyfxcrtmLBK05Z3pyC4uUBw=="
+        host date digest",signature="MEUCIQDIbsnNGHdFtON8WDkeP980xiyjfI3CrMzDWTa57VpUCQIgM9t4k0ngfNVi3a6u6BPZrjYCavbKrfzOP6RnTl6QiSk="
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:14 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -52471,16 +53079,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:15 GMT
       Set-Cookie:
-      - AWSALB=jR7MjqYf6AmQtvlOnHMqM7sXXfQdtvjfehWx+frr8GMCIdCr/fNY50f975iVs9GI8SwMeHjyahnOW/Q1Q1mLSfSPDaH/KQC+55uTTyjlJJgZXyGdag8s7tMWnwLS;
-        Expires=Tue, 03 May 2022 05:04:08 GMT; Path=/
-      - AWSALBCORS=jR7MjqYf6AmQtvlOnHMqM7sXXfQdtvjfehWx+frr8GMCIdCr/fNY50f975iVs9GI8SwMeHjyahnOW/Q1Q1mLSfSPDaH/KQC+55uTTyjlJJgZXyGdag8s7tMWnwLS;
-        Expires=Tue, 03 May 2022 05:04:08 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ygYQH1AAvaVP4UP1jXUv+eIvMl/mwW2Wb+vXImB52n0+zmtHUQgr1mJWONWEEpTrXiPJI8bTMqr67SONtdkajNdPfb07G1E/1ZrsATmTGLqBU6XfWG0oun6ZEUL/;
+        Expires=Wed, 04 May 2022 06:20:15 GMT; Path=/
+      - AWSALBCORS=ygYQH1AAvaVP4UP1jXUv+eIvMl/mwW2Wb+vXImB52n0+zmtHUQgr1mJWONWEEpTrXiPJI8bTMqr67SONtdkajNdPfb07G1E/1ZrsATmTGLqBU6XfWG0oun6ZEUL/;
+        Expires=Wed, 04 May 2022 06:20:15 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd6ed946e3741d9b3532422520d94cbb5
+      - NB393c4f892de91d51333b059acc301c69
       Pragma:
       - no-cache
       Cache-Control:
@@ -52510,11 +53118,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Zu5v7PZRVRlsCdh9TYTegfemdE4suMEwuH6gUkMqR3v_XOVdYbNeSg==
+      - A7grrC-h7W5NC7UnwGZDkQMrbsX4lHjdp_CN66O_i5xTsBJOlFPVnQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -52561,7 +53169,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:94:00",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698fc",
           "Name": "",
@@ -52620,7 +53228,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:08 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:15 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990b
@@ -52636,9 +53244,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIGdE4abHP7oZfZcXcF47AlWIRVhornlAlQ3eoWnwlgNhAiEA42UimYCn9x0JY/c6CLLkYjsksYp8bVMV9J5Zdsnd3NY="
+        host date digest",signature="MEYCIQDTwq7bc3lp+YYesbPk9iBx+ovF6s+WQmLc9AdY16CzRQIhAN7bwZH+Iosz3wreEYi7mXxsk36SfBShxJVuOIElrAax"
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:15 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -52651,16 +53259,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:15 GMT
       Set-Cookie:
-      - AWSALB=PkpEz9GPjswMlB246ucz413PamWDln2zJMB7vhFw6qRc5UDiwwRa7+vvMLBo8VqXHQ0MNZTvtriqCEhsLzIjRfhhUIJwtCNdOElMsXNsQp+t1q1LFMjRebJ0uMnM;
-        Expires=Tue, 03 May 2022 05:04:08 GMT; Path=/
-      - AWSALBCORS=PkpEz9GPjswMlB246ucz413PamWDln2zJMB7vhFw6qRc5UDiwwRa7+vvMLBo8VqXHQ0MNZTvtriqCEhsLzIjRfhhUIJwtCNdOElMsXNsQp+t1q1LFMjRebJ0uMnM;
-        Expires=Tue, 03 May 2022 05:04:08 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=97ENSNv6AJWy34Y197D4U+uUoFmmEoxBYNTJQskBU50QB7PfufsrHdLnEcf7W3iSKocCCHfxRedwX3DATfOvb1TxwSAjt/cFcYuwsmm3WYjbwOhIZaxZ09Qeee06;
+        Expires=Wed, 04 May 2022 06:20:15 GMT; Path=/
+      - AWSALBCORS=97ENSNv6AJWy34Y197D4U+uUoFmmEoxBYNTJQskBU50QB7PfufsrHdLnEcf7W3iSKocCCHfxRedwX3DATfOvb1TxwSAjt/cFcYuwsmm3WYjbwOhIZaxZ09Qeee06;
+        Expires=Wed, 04 May 2022 06:20:15 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB1ee38cc414f082afa070c102dcb125d6
+      - NBee94c2410980f8e531188389a1c52992
       Pragma:
       - no-cache
       Cache-Control:
@@ -52690,11 +53298,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - uoqsOi8hlaWkTvQ45FAqCAVmwaSpA5tMRCNDlf_X3sxq6EVRlmGq_g==
+      - 3-KHQECTuygE-Dfc7Jk6Iqv-hAOJDeHIk9WcdECeXuIsIV3NnkUX4Q==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -52741,7 +53349,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D3",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990b",
           "Name": "",
@@ -52800,7 +53408,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:08 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:15 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990f
@@ -52816,9 +53424,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIC6SKaLS+l2FKYMGl7MKnlWv2BPYebdIMopQ51xSmu1TAiEAldGEYmmTv5Cw6ArqJHqZA7+rkvcKwJvIya29vh+9YtY="
+        host date digest",signature="MEQCIFy72Xbi3lt0T2nTf4QuuZf+jgLtdYPgQ63MCVrbV7PdAiAKghEbSnAGJriB6PsyOC/qi9opvToT3jMLUZW4H4IAdg=="
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:15 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -52831,16 +53439,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:15 GMT
       Set-Cookie:
-      - AWSALB=TzUnEiRsQPk13A7Q6VrxAWghlEJK+DHJ4KPQ5wNxd+UIaENVyQWFS4oBpXgTFVHxF0F6qvHtkoF9Ur4UHxGVOdNa3hKeXw3SsBQupbmZf0Y1kZ+Fw87jLwsiebm4;
-        Expires=Tue, 03 May 2022 05:04:08 GMT; Path=/
-      - AWSALBCORS=TzUnEiRsQPk13A7Q6VrxAWghlEJK+DHJ4KPQ5wNxd+UIaENVyQWFS4oBpXgTFVHxF0F6qvHtkoF9Ur4UHxGVOdNa3hKeXw3SsBQupbmZf0Y1kZ+Fw87jLwsiebm4;
-        Expires=Tue, 03 May 2022 05:04:08 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=F8b5eNWKzKCO2XLwvOqqe5IZPaDObu96ZEwJeu0VuXwzAjJ/MKN91njOZZok6gl66XHo28qsFjlBpgM0q3KE3E/1yMdNCXF7UFw8ssHE31ovvExi8PEcLFjKc5Ky;
+        Expires=Wed, 04 May 2022 06:20:15 GMT; Path=/
+      - AWSALBCORS=F8b5eNWKzKCO2XLwvOqqe5IZPaDObu96ZEwJeu0VuXwzAjJ/MKN91njOZZok6gl66XHo28qsFjlBpgM0q3KE3E/1yMdNCXF7UFw8ssHE31ovvExi8PEcLFjKc5Ky;
+        Expires=Wed, 04 May 2022 06:20:15 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB303160b7f75ab17d611a412e17ef29db
+      - NB5b31445e71391cd937cf58f9f4154326
       Pragma:
       - no-cache
       Cache-Control:
@@ -52870,11 +53478,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - mkHdXyHilq-O02gaVKJRfO5Pig3YGxN7SwDMUXaQ2NstiJkG-iVGrQ==
+      - dNVqH2Jaj-0RsQGs35QVQ-1v0OrVauMQkiIhBfYUGZYyRzj663jPwQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -52921,7 +53529,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D7",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990f",
           "Name": "",
@@ -52980,7 +53588,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:08 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:15 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669915
@@ -52996,9 +53604,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQD0lmIzcfyr9Qe/JCTVqQG8NZ+lArMm11zpNVmfz2o5fwIgGWx83mmdfl4efo+4r3u1cvKP4098hHCKfLOmh57u75M="
+        host date digest",signature="MEUCIQCwgwCUyFef52rjxiBts4mw22zBDw0ocDElLaAkcqVzggIgArHtv7lzsJYBlZQgCeK/bewlINcrGCDo7YFYigGGtKg="
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:15 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -53011,16 +53619,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:15 GMT
       Set-Cookie:
-      - AWSALB=QJb8StDO2UFz3yz284+BCe8YbOLhZ+UHtj+waCmVAND3OD5B1LFcdZurmuJ8NvEB5koA9+oVh+N1f6NkVxq2gRx2ur8nRPq6K0jXB1a2fwOKnvWaL/QbxmZUWLSj;
-        Expires=Tue, 03 May 2022 05:04:08 GMT; Path=/
-      - AWSALBCORS=QJb8StDO2UFz3yz284+BCe8YbOLhZ+UHtj+waCmVAND3OD5B1LFcdZurmuJ8NvEB5koA9+oVh+N1f6NkVxq2gRx2ur8nRPq6K0jXB1a2fwOKnvWaL/QbxmZUWLSj;
-        Expires=Tue, 03 May 2022 05:04:08 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=HSTK6Qdr10UFQDZbWkASpNInjPWZeMyEdUbzL64EY9tr0F73g9JsdtWbxn+lRlayMpfPdAYuRDfGHcABYXZ5fv2UUs6TYOTgH51KZaUmMyoMyKwJwMaBpJWpuKAp;
+        Expires=Wed, 04 May 2022 06:20:15 GMT; Path=/
+      - AWSALBCORS=HSTK6Qdr10UFQDZbWkASpNInjPWZeMyEdUbzL64EY9tr0F73g9JsdtWbxn+lRlayMpfPdAYuRDfGHcABYXZ5fv2UUs6TYOTgH51KZaUmMyoMyKwJwMaBpJWpuKAp;
+        Expires=Wed, 04 May 2022 06:20:15 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc0cc5d6c20fce222844937fbebff3761
+      - NB0cb6302ba7745e319ec988b0508c18e7
       Pragma:
       - no-cache
       Cache-Control:
@@ -53050,11 +53658,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - syRlQbqKq7mAnO7_PR_xaARdC30vqleiJuvmoqigHKxS44pKFRI-iA==
+      - "-wkXoDTx8Tvp7Ycc7FhDx31F3o3oq0iQJJRxY3TcNlTaGIM0uKeG6w=="
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -53101,7 +53709,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DD",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669915",
           "Name": "",
@@ -53160,7 +53768,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:08 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:15 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f3
@@ -53176,9 +53784,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQD2D0LzX3wdCPTDIq1rpLZ5xV0uU1kXxT9UPGDLcQe9AQIhAJ+tObV8gIiCj7+eqfDquL2RTvLE/ifzyqJxlldoBKYy"
+        host date digest",signature="MEUCIQClO/s21Bf6sW4/NfXX1EUAYRlCRp5u+73AdzUk8qdiwwIgbU8QACA5teBSPiDrAXF/cf6IiirWMjkWc+R7sMyUCY8="
       Date:
-      - Tue, 26 Apr 2022 05:04:08 GMT
+      - Wed, 27 Apr 2022 06:20:15 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -53191,16 +53799,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:15 GMT
       Set-Cookie:
-      - AWSALB=ykpDIrQqjtu/gJsOScEu8xLO8cxn3aDem43Y34hOp2vSls7EzUbUf6/v1w/jWIq8+Pn41KT+tMvXlWDyOtD9jUqTZ1yVRTcTvUrzM/Qp5Y7Jan/ZAGzf7bSDT2u3;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/
-      - AWSALBCORS=ykpDIrQqjtu/gJsOScEu8xLO8cxn3aDem43Y34hOp2vSls7EzUbUf6/v1w/jWIq8+Pn41KT+tMvXlWDyOtD9jUqTZ1yVRTcTvUrzM/Qp5Y7Jan/ZAGzf7bSDT2u3;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=RKBcFlYq1823AZKrL5ylrxcHXQ8omKCYYbxlOu1YsQ0t/DOCnXeUfAPF3XCSJVKm6l+ugVjIC1q9utcJZICMUT6OB+PJeRuXVVop7KFWcp6sswqzATVjsd/ebp5V;
+        Expires=Wed, 04 May 2022 06:20:15 GMT; Path=/
+      - AWSALBCORS=RKBcFlYq1823AZKrL5ylrxcHXQ8omKCYYbxlOu1YsQ0t/DOCnXeUfAPF3XCSJVKm6l+ugVjIC1q9utcJZICMUT6OB+PJeRuXVVop7KFWcp6sswqzATVjsd/ebp5V;
+        Expires=Wed, 04 May 2022 06:20:15 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB6e16bb880c6b7d67695c08de346586d2
+      - NB0acb03296d8c4e8a33197ee07d70c943
       Pragma:
       - no-cache
       Cache-Control:
@@ -53230,11 +53838,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - rtUTyHXQXQPQZY6PTCGjYtabUiiqZBiRoIj-qQhGxJHN2wYmmsLoDw==
+      - dWjLRbDe_7bOcQLOiPDEjSpYaq89Oix1EvOnVclv0pYCR3Vq2-3TKA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -53281,7 +53889,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F1",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f3",
           "Name": "",
@@ -53340,7 +53948,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:09 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:16 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f7
@@ -53356,9 +53964,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIHdKUQBkp1RKlfRHo0Ik9tF5sqeUsuazZNp005dtZonfAiAxCsqRE49gSJVZ+62AYkpJsDkYVEsiS4bViWOdxQYq7Q=="
+        host date digest",signature="MEQCIAgu9JN+OSyKYdtDHvBh+0RC38ZN5Ri1/cxCbc3mhO6jAiA0ahaKVS7uDxGaVutAQWDsKY4ejrPnhevDJ3A63gH8Lg=="
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -53371,16 +53979,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Set-Cookie:
-      - AWSALB=7ObPRn6qCBI98b4s7wtHATdn4rsgXXls6eUyeZ7Y9L7SHsK4Zljt8hOQO/86ZmAmN2UKM0FTSjq6GK/wlCb4EZyOIAtjy1mkUKriK21zLqkqjRz2ZT2vLPZWLxiv;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/
-      - AWSALBCORS=7ObPRn6qCBI98b4s7wtHATdn4rsgXXls6eUyeZ7Y9L7SHsK4Zljt8hOQO/86ZmAmN2UKM0FTSjq6GK/wlCb4EZyOIAtjy1mkUKriK21zLqkqjRz2ZT2vLPZWLxiv;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=apT1f8ME5UMxW3NLkeOZEf//CwvpLlsTUGz7/i6Kfjc5GEyQOhrumEQVQoQG8/C/gWic7Gr5D9IIEOjBDotk7t5+QDqs5iNBmjp2qHY3EGhqkxrzwQ4H9Mgnv+yT;
+        Expires=Wed, 04 May 2022 06:20:16 GMT; Path=/
+      - AWSALBCORS=apT1f8ME5UMxW3NLkeOZEf//CwvpLlsTUGz7/i6Kfjc5GEyQOhrumEQVQoQG8/C/gWic7Gr5D9IIEOjBDotk7t5+QDqs5iNBmjp2qHY3EGhqkxrzwQ4H9Mgnv+yT;
+        Expires=Wed, 04 May 2022 06:20:16 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb661042016d8170419cda3b85daf6c16
+      - NBfec5ac01efae158a6b281ec45fc4fea5
       Pragma:
       - no-cache
       Cache-Control:
@@ -53410,11 +54018,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Mp-gWsIlNBkgkV3OqjcMPkm5U7fwSF0JYPRGAawp6Z0VWBwEC9yTXA==
+      - 4rsfrNI5GdSer7IW6YUXOCTcoTOi3KIg9aPxuHwUdGKYyWUcO_dE6g==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -53461,7 +54069,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F5",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f7",
           "Name": "",
@@ -53520,7 +54128,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:09 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:16 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669907
@@ -53536,9 +54144,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHMyec/WjZVs6vhBDh3WWC6SfjxzH26otqLvOXIxWxmaAiEAz018zwKzX6mUCwgBaTe2V5BYsjBLQF0u0n31cCgDjXU="
+        host date digest",signature="MEQCIA4XQcRcjR2JW1cFHxtTMkqkx3SfObdjHRb3SDdX9VYlAiA+8xpjs/GUWH0T4ZfGDIgEZK/Y6aip3gubMfNN9TfPKA=="
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -53551,16 +54159,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Set-Cookie:
-      - AWSALB=hI3e4jkTK/ho/QnegqvwEAnq9VthPK9pUS5W/ugsrhZujeDUYJbXBG6qqY9jqsfJp+MJI6TRJppLhwOxbw3LIErRcwPawbLL2i2sbr+Cv+ZWk5pB//RipmGvnfZ2;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/
-      - AWSALBCORS=hI3e4jkTK/ho/QnegqvwEAnq9VthPK9pUS5W/ugsrhZujeDUYJbXBG6qqY9jqsfJp+MJI6TRJppLhwOxbw3LIErRcwPawbLL2i2sbr+Cv+ZWk5pB//RipmGvnfZ2;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=2jB+FGs7C7jTCHhkSolWo769+DED4quhv8Dt10D9Z0eWwibqFCYtOthPBtevWfpVV1ykcXNudPYacZy0xxOtVvpC+iA61X0siwO0cpD8W63fvwxrFGYH/RfhTaWh;
+        Expires=Wed, 04 May 2022 06:20:16 GMT; Path=/
+      - AWSALBCORS=2jB+FGs7C7jTCHhkSolWo769+DED4quhv8Dt10D9Z0eWwibqFCYtOthPBtevWfpVV1ykcXNudPYacZy0xxOtVvpC+iA61X0siwO0cpD8W63fvwxrFGYH/RfhTaWh;
+        Expires=Wed, 04 May 2022 06:20:16 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBf28a7b9e573e5053cf72b97be59695a5
+      - NBe290cce3331297ce8dfc5a2047980330
       Pragma:
       - no-cache
       Cache-Control:
@@ -53590,11 +54198,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - akATXaKEHAc-SJN3uqjnxB_zeDq5VS73BjvoPBCGrDbuwqz42vpOKQ==
+      - mgv8j84UMFN97yoNrONBNB7DtVk8QfcIBmdxTG4J5aBK0gx3nYQMRA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -53641,7 +54249,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CF",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669907",
           "Name": "",
@@ -53700,7 +54308,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:09 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:16 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698fb
@@ -53716,9 +54324,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCfYWoVwvRELtc5O+eREloY8hn2MvJ+GrPstFxoaIYflgIgIgrQ7W6F4huQqn64RlS6A4m3TKlmtNzmnsw/lf5hAxg="
+        host date digest",signature="MEQCIHjF/W904hD4/i8uO2kIW+zZczlftO1DB9ppWkq8hgD+AiAhLfCb1kfPJXtzyz9/fsJGu/6a2/s06uDxZPyIefa/RA=="
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -53731,16 +54339,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Set-Cookie:
-      - AWSALB=s1Kv3DpfugwN+W9KxywCq5b47RhZ5ck46ji63cR+c5UA/eGtXKOjhnB7St+OhpOisfLthZCT0F+llVTFkxTRl4t9aapZ6JtmcLZENrAF8HOfYduYMF4nOIkgBw2a;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/
-      - AWSALBCORS=s1Kv3DpfugwN+W9KxywCq5b47RhZ5ck46ji63cR+c5UA/eGtXKOjhnB7St+OhpOisfLthZCT0F+llVTFkxTRl4t9aapZ6JtmcLZENrAF8HOfYduYMF4nOIkgBw2a;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=WhYjWL2ep3fe5PTK+/eH/J74iaGY4alIcOkBufwqFy26iTel4FnOhxEBz/nK2GKpMpVhKiY1t7mj23BaxTQM1rjvfzaNpnMkjYRjMVJLbWLN6qubWnAKDiODJHjx;
+        Expires=Wed, 04 May 2022 06:20:16 GMT; Path=/
+      - AWSALBCORS=WhYjWL2ep3fe5PTK+/eH/J74iaGY4alIcOkBufwqFy26iTel4FnOhxEBz/nK2GKpMpVhKiY1t7mj23BaxTQM1rjvfzaNpnMkjYRjMVJLbWLN6qubWnAKDiODJHjx;
+        Expires=Wed, 04 May 2022 06:20:16 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB14c4d6c76984e46c1ea4864ff9cce155
+      - NB031711ee0d9d745ef6c9b9722393d13f
       Pragma:
       - no-cache
       Cache-Control:
@@ -53770,11 +54378,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - x3EpIjqc_JyvZVzuBO44pCbHuXOtUt2Q7ABq_VL5ih9BWouqncW4Hw==
+      - pO3Bjo5YDQWyWTz4kgqtw6mOXSkceQIJwt_GCOFDnNdJAJsyKsWEUg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -53821,7 +54429,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:FC",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "trunk",
           "Moid": "614ce25d4630312d416698fb",
           "Name": "",
@@ -53880,7 +54488,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:09 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:16 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669908
@@ -53896,9 +54504,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQDxPEjgPRFQ/yqjUsv2AGIPoHSIPzftDHZ7xb4ZFDmeywIhAIF5uwZObhY8sADBqZd629IYN6ZsAb7pikOoF1ka93PT"
+        host date digest",signature="MEUCIC7fXNsFvGo1mlbPcLil8J8syU0Wvp4BShMAVSkupHQ+AiEAtd2Zttx5Ea/w9BcqDO2lmQbGGpDcqrNGtZhqx8+WqTw="
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -53911,16 +54519,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Set-Cookie:
-      - AWSALB=w5J1yDeawQVo89a9JY++c6ZeKzjO+wWe2zQIDVASuKqEBAKpICreSBzGDZBd0kPYB8VbCiL6i4OiweJ062YMmPRq1M+I/w2zzWiegdVfgtkXJziiD9TnGqUoGnyi;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/
-      - AWSALBCORS=w5J1yDeawQVo89a9JY++c6ZeKzjO+wWe2zQIDVASuKqEBAKpICreSBzGDZBd0kPYB8VbCiL6i4OiweJ062YMmPRq1M+I/w2zzWiegdVfgtkXJziiD9TnGqUoGnyi;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=HFoeeHgJU/p8+SurehA6Mtax4GGpJ/12e9qWbr/ndpGVLlTyILqsrTvsZZip8NJDt7BccU/DeTH6UnYuI4dSX8Fh7QWix8x6mo2Hy/wzt9XYMKI0Y/rjSzujBbdq;
+        Expires=Wed, 04 May 2022 06:20:16 GMT; Path=/
+      - AWSALBCORS=HFoeeHgJU/p8+SurehA6Mtax4GGpJ/12e9qWbr/ndpGVLlTyILqsrTvsZZip8NJDt7BccU/DeTH6UnYuI4dSX8Fh7QWix8x6mo2Hy/wzt9XYMKI0Y/rjSzujBbdq;
+        Expires=Wed, 04 May 2022 06:20:16 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBacea852d5765f307019a2c9b2703c247
+      - NB8f6a101374a9e8207635fd21e471d4b8
       Pragma:
       - no-cache
       Cache-Control:
@@ -53950,11 +54558,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - EzRQoSSB6lGVufedqrLXgEPDNF-95RArf4AVXrAr6M4O-_nBbidRjg==
+      - IvWwgVH1hJjDBab9d1SAb4baVboQI-tairSK5f_bjdwsTlSNiEFeJg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -54001,7 +54609,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D0",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669908",
           "Name": "",
@@ -54060,7 +54668,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:09 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:16 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990d
@@ -54076,9 +54684,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIGJN5pRL7p6EfLoV5m2eEIdErvF+xr+oY5mcPMjfqobjAiEAvglBfedKnF2YWeJO7tK1WbaYQmOoJKGatf5VGhWzJbI="
+        host date digest",signature="MEUCIDBKdbFwEaaHK3pzKqlAhfditog3skdcF25rTsN2sa4bAiEAxxZ7GN9OYRdggLjWO82oqFi6AB63Zm3ypSgg4QAJdjw="
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -54091,16 +54699,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Set-Cookie:
-      - AWSALB=Lkk8AnPmQBM0saq+iqtCflYpH02CmCxkzCb6GUkwlbcBpyA33RkgvEdES+FSfpu/v4EcdWlHhvHwsKqfo2BYbshZxA1hLelPjkRTzHx6QfLYRPqEH0lXhVJtb5vD;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/
-      - AWSALBCORS=Lkk8AnPmQBM0saq+iqtCflYpH02CmCxkzCb6GUkwlbcBpyA33RkgvEdES+FSfpu/v4EcdWlHhvHwsKqfo2BYbshZxA1hLelPjkRTzHx6QfLYRPqEH0lXhVJtb5vD;
-        Expires=Tue, 03 May 2022 05:04:09 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=Gl9q1tOgLZwnOWbH6sL70mEEmzvDaTvcxZRkkppmWXpZ5ohe0kmPYc7v11zE/ifdLrutwmPO42AZSnfAjc4n6KlSRV57beeNnPzSx8uHXsv3H0EygFRlHrqAS92/;
+        Expires=Wed, 04 May 2022 06:20:16 GMT; Path=/
+      - AWSALBCORS=Gl9q1tOgLZwnOWbH6sL70mEEmzvDaTvcxZRkkppmWXpZ5ohe0kmPYc7v11zE/ifdLrutwmPO42AZSnfAjc4n6KlSRV57beeNnPzSx8uHXsv3H0EygFRlHrqAS92/;
+        Expires=Wed, 04 May 2022 06:20:16 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB423f39b6d7a09b468ff2ba8eb4e0d4f5
+      - NBd9cea381e0a954aa66190a4e8f6142d4
       Pragma:
       - no-cache
       Cache-Control:
@@ -54130,11 +54738,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - e0v2o7zqAy_VJvV3MJulQtxCWqgI_S9ucPDdbhkHh70sUmx7egDz7g==
+      - QVRn-uV1Ro0TLkqCPkKMLMdKszV-pTvO9Fx4kK0pVMaK46Ja5pcUTA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -54181,7 +54789,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D5",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990d",
           "Name": "",
@@ -54240,7 +54848,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:09 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:16 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698eb
@@ -54256,9 +54864,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIGsdtz1q7lBZFuk2vQOlMqlYY1HVH+CaTABNHOAKsFWMAiEAvhk/HkPSpNoDa4tb74PyFK09Vi86GPqTzh5dBy9E0to="
+        host date digest",signature="MEUCIDty2KfGNUBaRQ8WE7CB7eCGkKQsrH61T4/KFTiEGR/BAiEAyjHkhjStEpDNLYCn4y8EzOM97XRSqDmUQwPNWrekudA="
       Date:
-      - Tue, 26 Apr 2022 05:04:09 GMT
+      - Wed, 27 Apr 2022 06:20:16 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -54271,16 +54879,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:10 GMT
+      - Wed, 27 Apr 2022 06:20:17 GMT
       Set-Cookie:
-      - AWSALB=oktuorNX7ZJu/9i7ziBmDQcRTcXOdqeUbKu8mRGJUDC6pdrrN3Low2QK8201Q5iJuuMN4lUG0ZWeVcZcT64PVd8RP6wJvxCWq71oz7dV2XvuljjEqhcRUVWdXad/;
-        Expires=Tue, 03 May 2022 05:04:10 GMT; Path=/
-      - AWSALBCORS=oktuorNX7ZJu/9i7ziBmDQcRTcXOdqeUbKu8mRGJUDC6pdrrN3Low2QK8201Q5iJuuMN4lUG0ZWeVcZcT64PVd8RP6wJvxCWq71oz7dV2XvuljjEqhcRUVWdXad/;
-        Expires=Tue, 03 May 2022 05:04:10 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=3h6NQputPJd1507O2twWsBr6MIgGnbpAAF1g2G8GR38I+SY47U6ZGasxN/BX8U7XvTiP5AgW4149LH66U/DJeLQDn+gBMGZwol2QvBQeHq53oemkmlQZRtxnmQlp;
+        Expires=Wed, 04 May 2022 06:20:17 GMT; Path=/
+      - AWSALBCORS=3h6NQputPJd1507O2twWsBr6MIgGnbpAAF1g2G8GR38I+SY47U6ZGasxN/BX8U7XvTiP5AgW4149LH66U/DJeLQDn+gBMGZwol2QvBQeHq53oemkmlQZRtxnmQlp;
+        Expires=Wed, 04 May 2022 06:20:17 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd1cd447d0e11f9d98d32d8684d0d76db
+      - NB6b3b855a4453dc6589496ded385872d9
       Pragma:
       - no-cache
       Cache-Control:
@@ -54310,11 +54918,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - tj9xiSH5VS_2pEr0m1b_TOn14VkLiDOsZ6QAeu0o91dtS3KOvrTwWQ==
+      - idjMB_nXqD66NDmRJ3EQIuoHZapPR8c1F9CODiIkGqVYZSSVIkp5Aw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -54361,7 +54969,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E9",
-          "ModTime": "2022-04-26T04:31:05.88Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698eb",
           "Name": "",
@@ -54420,7 +55028,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:10 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:17 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ee
@@ -54436,9 +55044,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIEYFeIcRHD0xgez+kBCEfEMooHOv+7hMWxwl4O+OnZiZAiASTIZT4v0P1rOlfcDh/Nl/hXg/VsWPR/6HU0k6gSRSqQ=="
+        host date digest",signature="MEQCIGudq1lhvKpl2qzqQA7qlUsHzwTcG7b1vMIYIht/Em+vAiA4ht6tB1vz/Tr6Zl9A8zh7WhQCiXDl51f2nNQaXbiM6w=="
       Date:
-      - Tue, 26 Apr 2022 05:04:10 GMT
+      - Wed, 27 Apr 2022 06:20:17 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -54451,16 +55059,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:10 GMT
+      - Wed, 27 Apr 2022 06:20:17 GMT
       Set-Cookie:
-      - AWSALB=W5AopChCVn6waG8myEnRAyNiKusKPC/DnFmQOd3ARB0DvIn320yfr2U5xqjN/fcwGDIu1C6SCvzhzK7KUyAcygMH7NA4JkkgH8ywha7IbMMBmQfn504E0qg1dET0;
-        Expires=Tue, 03 May 2022 05:04:10 GMT; Path=/
-      - AWSALBCORS=W5AopChCVn6waG8myEnRAyNiKusKPC/DnFmQOd3ARB0DvIn320yfr2U5xqjN/fcwGDIu1C6SCvzhzK7KUyAcygMH7NA4JkkgH8ywha7IbMMBmQfn504E0qg1dET0;
-        Expires=Tue, 03 May 2022 05:04:10 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=yQzsrb+MvZulgr7Ai5OAO/CcR9IQ89w/RVAfHiabFuuXCNDx0mDaYQaBlVWVrU5K68avqbKLcFhS6c1JQUSVle1kUWFJyfZ/PsljSPmscd5Ng0yhkNTXxd8IvNDR;
+        Expires=Wed, 04 May 2022 06:20:17 GMT; Path=/
+      - AWSALBCORS=yQzsrb+MvZulgr7Ai5OAO/CcR9IQ89w/RVAfHiabFuuXCNDx0mDaYQaBlVWVrU5K68avqbKLcFhS6c1JQUSVle1kUWFJyfZ/PsljSPmscd5Ng0yhkNTXxd8IvNDR;
+        Expires=Wed, 04 May 2022 06:20:17 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBc81a15dddda65c0e827b83f546175f67
+      - NB1aa0de5062736145b7e92bf02e99f36e
       Pragma:
       - no-cache
       Cache-Control:
@@ -54490,11 +55098,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 9jaczPX-sOT8GSkyVVce321njo1_ocPbhN03NCpqnuTKTI4UJpzyrA==
+      - zWgSB20GM_kwQNjW8qg_UHg6GupjWG9iLIdR973L8Qj-359zSOgFMQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -54541,7 +55149,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:EC",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ee",
           "Name": "",
@@ -54600,7 +55208,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:10 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:17 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f5
@@ -54616,9 +55224,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIHmq46WD3cLhq2L52eweLFRh4zZ01+IaneZTwD87FHUEAiEAhLvEpXB9O9L1XwBJBEb7CL/IwwY2HKOgFrdjjwcsWZU="
+        host date digest",signature="MEUCIQD7kaqo7ZMXXMMFsIgJ5mf97mq0+r75L/71o3G9TGvxNAIgIO863Xi4HdgTgaU3TxBaUK0Ptf3lxwioLG4yMT5+z0U="
       Date:
-      - Tue, 26 Apr 2022 05:04:10 GMT
+      - Wed, 27 Apr 2022 06:20:17 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -54631,16 +55239,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:10 GMT
+      - Wed, 27 Apr 2022 06:20:17 GMT
       Set-Cookie:
-      - AWSALB=p/agb8WUPjit7dA+YxB9jIcwFIodzAJpUC8h6q7p/UhFLWMUfuzKzhsktSHwTiDp6T0ALvJQGEjIcWDifY3GvAHlkL4rV5jZPbAUtX8e7ndhRraXmXboivpxhP44;
-        Expires=Tue, 03 May 2022 05:04:10 GMT; Path=/
-      - AWSALBCORS=p/agb8WUPjit7dA+YxB9jIcwFIodzAJpUC8h6q7p/UhFLWMUfuzKzhsktSHwTiDp6T0ALvJQGEjIcWDifY3GvAHlkL4rV5jZPbAUtX8e7ndhRraXmXboivpxhP44;
-        Expires=Tue, 03 May 2022 05:04:10 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=y9NhXxuZ1WWdUL50OZ4Jdj1DM1DGjo1wY9IGKFjVnI0vwqZYMCvshmU3MEcY4Mn5pHQ8533WZoNd8tENlrOb/fqp1HQjoNBam6nDjjvAnI0W4IanGlr6kRAS9B7L;
+        Expires=Wed, 04 May 2022 06:20:17 GMT; Path=/
+      - AWSALBCORS=y9NhXxuZ1WWdUL50OZ4Jdj1DM1DGjo1wY9IGKFjVnI0vwqZYMCvshmU3MEcY4Mn5pHQ8533WZoNd8tENlrOb/fqp1HQjoNBam6nDjjvAnI0W4IanGlr6kRAS9B7L;
+        Expires=Wed, 04 May 2022 06:20:17 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBd52a324d9406c6071d389e582c63f71d
+      - NB0ab155c8a291fe6fde27f14f8f3c0394
       Pragma:
       - no-cache
       Cache-Control:
@@ -54670,11 +55278,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - iRe-7WXxaUyAuYJvSx53fWEN5_pbMdUfNRHFiIvotVIArmz35ZESsQ==
+      - Kh5tZPOE_rj4SRlL5TzoNFAJMhsCNHv1G1njYYHFM0Y8-gZ-qYy9OQ==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -54721,7 +55329,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F3",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f5",
           "Name": "",
@@ -54780,7 +55388,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:10 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:17 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698fe
@@ -54796,9 +55404,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIDAoFLugdeyfVAj9Izjh+KPwt71qSW2HdOJf625fWT3aAiEAwDwlSIQKw4cgbvTXJcpxpl2P5abEHS1pJLin1Zjhgmo="
+        host date digest",signature="MEQCIHrujjd8PSvtwfgeu+BvdGeMc4MpR3N/43BOdEcE/i7BAiApq1+6ZlzBctnBpgMOPte5f5jqr0ozX8NAnk1kMRva2g=="
       Date:
-      - Tue, 26 Apr 2022 05:04:10 GMT
+      - Wed, 27 Apr 2022 06:20:17 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -54811,16 +55419,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:10 GMT
+      - Wed, 27 Apr 2022 06:20:17 GMT
       Set-Cookie:
-      - AWSALB=dd1qMBA7uByUdOWa8Z8v6+7Gz0gX5yupO6LTyCIQwCq6xrEPbn8xxz3Fgr35LuW2Lsj5+O6GY/Ls/RnKlkzM8COvUW6yFJJwZOUB+aHCSkW/KH/uG4yjlPi0wkC3;
-        Expires=Tue, 03 May 2022 05:04:10 GMT; Path=/
-      - AWSALBCORS=dd1qMBA7uByUdOWa8Z8v6+7Gz0gX5yupO6LTyCIQwCq6xrEPbn8xxz3Fgr35LuW2Lsj5+O6GY/Ls/RnKlkzM8COvUW6yFJJwZOUB+aHCSkW/KH/uG4yjlPi0wkC3;
-        Expires=Tue, 03 May 2022 05:04:10 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=6Yul+VJfaEh6ikOQuboTke0FyaxQpjdzRajKMTzoAOGX8hqSyHzHuGizAm4ctV2nfqftNWZl8jh+sJvoDIwvRseioTUabAF+Nbg242KJJxuC5sWStshsMYZruFJz;
+        Expires=Wed, 04 May 2022 06:20:17 GMT; Path=/
+      - AWSALBCORS=6Yul+VJfaEh6ikOQuboTke0FyaxQpjdzRajKMTzoAOGX8hqSyHzHuGizAm4ctV2nfqftNWZl8jh+sJvoDIwvRseioTUabAF+Nbg242KJJxuC5sWStshsMYZruFJz;
+        Expires=Wed, 04 May 2022 06:20:17 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB5999fdbfee2b0146962c1bf3c9841375
+      - NBc27e1f6addce5fffb63cfad71bc96de5
       Pragma:
       - no-cache
       Cache-Control:
@@ -54850,11 +55458,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - VUscElHTlAiiZYEMD8jwAo5Rw-Wz8MQK9kjfVxj33bTu_BrUGDUtHg==
+      - 3mLe5uwy4QnJQ3CHH3ZikzcjMyUhQpPh-vQShJpih2OpWUXMIYoGqg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -54901,7 +55509,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:94:08",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698fe",
           "Name": "",
@@ -54960,7 +55568,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:10 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:17 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166990c
@@ -54976,9 +55584,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCu2RVcMOGVkBRHMmuGJ1WNvWWoursrBwTy0ZNT/HMMzgIhAJocrDNn4hCIbBEx0/52asY82a0ZTzlz+MLFbAu6o5jl"
+        host date digest",signature="MEUCIQD7zAC2MzuMcDXoBNH678/XvBYQ0TUIOi0UuA3z8OrjXQIgJg0ImSUrc+2oWwX03M02eoJHcDtFenfhn9A1OfUxWr4="
       Date:
-      - Tue, 26 Apr 2022 05:04:10 GMT
+      - Wed, 27 Apr 2022 06:20:17 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -54991,16 +55599,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:11 GMT
+      - Wed, 27 Apr 2022 06:20:18 GMT
       Set-Cookie:
-      - AWSALB=RFZXRLoxAoOVZ61YZoh1HqpF6ohQHzkSaLyMZCA0TuCw2RrtC7ZhkpgLSv2hapL6CwjfNyLcToMQlbcDgZ8hlPgNbP0hckY63keVPr+IoKPjpJOr/MjQNTsNepfV;
-        Expires=Tue, 03 May 2022 05:04:11 GMT; Path=/
-      - AWSALBCORS=RFZXRLoxAoOVZ61YZoh1HqpF6ohQHzkSaLyMZCA0TuCw2RrtC7ZhkpgLSv2hapL6CwjfNyLcToMQlbcDgZ8hlPgNbP0hckY63keVPr+IoKPjpJOr/MjQNTsNepfV;
-        Expires=Tue, 03 May 2022 05:04:11 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=er3+itLV8jvVZu1Ws7f3ehN1iIsnIuZ8wbSxLKrIqZbnndfIuwwrMvN/KqIqwVUFe5euDIjvpS7PhR4q4FC7uAm2cQ6PXaIP76d+kxXPuH8mxa1PlDf8dBDPUNOI;
+        Expires=Wed, 04 May 2022 06:20:18 GMT; Path=/
+      - AWSALBCORS=er3+itLV8jvVZu1Ws7f3ehN1iIsnIuZ8wbSxLKrIqZbnndfIuwwrMvN/KqIqwVUFe5euDIjvpS7PhR4q4FC7uAm2cQ6PXaIP76d+kxXPuH8mxa1PlDf8dBDPUNOI;
+        Expires=Wed, 04 May 2022 06:20:18 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB98d388c815f8533f6050f691240a5c5c
+      - NB727b5c047b39b763d9642039ae2c75a7
       Pragma:
       - no-cache
       Cache-Control:
@@ -55030,11 +55638,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - aqGkUshq4T5Jp4vpss1fgSVp5RjlqNfT7llPJcGrjgZGMrY6wmIopA==
+      - SyLvRBcJYJ42ohvQaLjh1Qda5RTr_SwwLO1p8W0m7irIjVjUIoxa4A==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -55081,7 +55689,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D4",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166990c",
           "Name": "",
@@ -55140,7 +55748,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:11 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:18 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669910
@@ -55156,9 +55764,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCgWZwhz86ai66ikomKnd/Uj0qO3RAnPNFpwcvvZeeowAIhAPSXezxq+JYjaBJI6TpjYDaq/bJzJixr5w8RhQ9NMfUa"
+        host date digest",signature="MEQCIBu5RmWlg6cbFbIQOqpB4gdrIyfumvwETIdh4Cn2f16GAiARFXOVbifK7hfElFjBqM+YX5Ysqhv0AlVWW0rkPKg2Ng=="
       Date:
-      - Tue, 26 Apr 2022 05:04:11 GMT
+      - Wed, 27 Apr 2022 06:20:18 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -55171,16 +55779,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:11 GMT
+      - Wed, 27 Apr 2022 06:20:18 GMT
       Set-Cookie:
-      - AWSALB=ge7UAea31JTmrxi3ckFFRmmho/cH3Gm7hZbvSpi2sQJ1vuup5D6O0E1RcPJqsI0mFO+8cSdyrpXEyVYaPSX5tsW7wJiStDQMxoSaRELiyv1nUFsbpMM0Tv8ZoWA8;
-        Expires=Tue, 03 May 2022 05:04:11 GMT; Path=/
-      - AWSALBCORS=ge7UAea31JTmrxi3ckFFRmmho/cH3Gm7hZbvSpi2sQJ1vuup5D6O0E1RcPJqsI0mFO+8cSdyrpXEyVYaPSX5tsW7wJiStDQMxoSaRELiyv1nUFsbpMM0Tv8ZoWA8;
-        Expires=Tue, 03 May 2022 05:04:11 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=QdcgkUfN6hmFB7ymel3T1gXMNtamHw9yMTeUrpfc4P703GXINqeUm7cz3ODgwuqs7S1p1lR/X64/oXTCuf5ctaDj90HAQMSSYoDoFBG559h2CexU209PXXEiHCM4;
+        Expires=Wed, 04 May 2022 06:20:18 GMT; Path=/
+      - AWSALBCORS=QdcgkUfN6hmFB7ymel3T1gXMNtamHw9yMTeUrpfc4P703GXINqeUm7cz3ODgwuqs7S1p1lR/X64/oXTCuf5ctaDj90HAQMSSYoDoFBG559h2CexU209PXXEiHCM4;
+        Expires=Wed, 04 May 2022 06:20:18 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBa0e1e8605a199d084ecdcd4c2cc2a519
+      - NB4fc63ed0a1adff010826854509d78126
       Pragma:
       - no-cache
       Cache-Control:
@@ -55210,11 +55818,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - Mk-rdOZu4t5u2e9G2VCblopUDK5xRnMBMBfU1lKNqh4vgKT4CRj70g==
+      - "-pGHyReiERoPvigoKIjl93zL3Am56fTeZ57FEQ4ONnx8XHit8A90eQ=="
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -55261,7 +55869,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:D8",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25d4630312d41669910",
           "Name": "",
@@ -55320,7 +55928,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:11 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:18 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ed
@@ -55336,9 +55944,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIBCr6ClkCWQwfs8nYGBe9WBt5IKiwaDUm2Kz/8/f8Oe0AiBOgwS2gRKHMgSb0jwN7Lahk/Zgm16NMs8SXYYx84BD3w=="
+        host date digest",signature="MEQCIApepGE/VNxNH7R22ovxiBxZ1FzPhEbKvPizt2wVN/h8AiAY3189+AN4KQ8F3gxCtKRHdUB/nSCWfvNt8/bhDDTcAQ=="
       Date:
-      - Tue, 26 Apr 2022 05:04:11 GMT
+      - Wed, 27 Apr 2022 06:20:18 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -55351,16 +55959,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:11 GMT
+      - Wed, 27 Apr 2022 06:20:18 GMT
       Set-Cookie:
-      - AWSALB=nYZ9MdZOCv1taPpkAR2Xh3lGm2RMz3rT6Q282W2AA3uPxKOfsmt89IUJTT+LqIBdPJ/ipvpCS3DKEF5eDmPgxzaqnp79/LKeUyU2ISKqfutQTv34bB4mF56RcjZN;
-        Expires=Tue, 03 May 2022 05:04:11 GMT; Path=/
-      - AWSALBCORS=nYZ9MdZOCv1taPpkAR2Xh3lGm2RMz3rT6Q282W2AA3uPxKOfsmt89IUJTT+LqIBdPJ/ipvpCS3DKEF5eDmPgxzaqnp79/LKeUyU2ISKqfutQTv34bB4mF56RcjZN;
-        Expires=Tue, 03 May 2022 05:04:11 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=5R8Th97llhrN0xvcDQgUa5JcHCtG9XP9p2bRg8gGXMDZk0r3XHeoMpyx87Fu0J3zE2yGOJGtWGu7PLKERYs6OdZed44yWVix0Kc/Q+CcH4jVkDsunbN0B/5TBXEP;
+        Expires=Wed, 04 May 2022 06:20:18 GMT; Path=/
+      - AWSALBCORS=5R8Th97llhrN0xvcDQgUa5JcHCtG9XP9p2bRg8gGXMDZk0r3XHeoMpyx87Fu0J3zE2yGOJGtWGu7PLKERYs6OdZed44yWVix0Kc/Q+CcH4jVkDsunbN0B/5TBXEP;
+        Expires=Wed, 04 May 2022 06:20:18 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB0aef0bfd377ed148c8669f5bbb4ff5cb
+      - NBb1523e9a70f9726e376d4e6c49e37e1c
       Pragma:
       - no-cache
       Cache-Control:
@@ -55390,11 +55998,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - WLsrvdlAGAp-0EBlnd22llMl-DzZTn5sr-1NY1Q35UA5TZQMHCHU1w==
+      - mc0h7gH5lChX5acIa7_k_nOCBNN4-TfjqUIRmfPUhln24P2vvrN9aw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -55441,7 +56049,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:EB",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ed",
           "Name": "",
@@ -55500,7 +56108,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:11 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:18 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698ef
@@ -55516,9 +56124,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIAOLxLYTw24L8Us+K3WFTLlBD2rHBs0G8LtKsHJTidQEAiEAmp3H8F07aJrX9QA6EGqOulDmulrxR1G6khpFiFQgoAE="
+        host date digest",signature="MEQCIAwUcRtI1X8FS9SGZhvJbsF/g39aIM4beoMj2usCsxNPAiBO70z5Y7f1HR42DuIfGzwoJ+rTE/rjTdq2qLw3yYS6LA=="
       Date:
-      - Tue, 26 Apr 2022 05:04:11 GMT
+      - Wed, 27 Apr 2022 06:20:18 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -55531,16 +56139,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:11 GMT
+      - Wed, 27 Apr 2022 06:20:18 GMT
       Set-Cookie:
-      - AWSALB=ueZwJx9wQ7qNXNERmQLtDYggo9ivXtHj/oTroQ2SXAIxvY2f+mv7aircPD4IyHNngEuR1ZUPRcozlp2AxgrGKIxJEnLEfM5/DL7LCK2jqYMZYBQaNcVedZNPIt4I;
-        Expires=Tue, 03 May 2022 05:04:11 GMT; Path=/
-      - AWSALBCORS=ueZwJx9wQ7qNXNERmQLtDYggo9ivXtHj/oTroQ2SXAIxvY2f+mv7aircPD4IyHNngEuR1ZUPRcozlp2AxgrGKIxJEnLEfM5/DL7LCK2jqYMZYBQaNcVedZNPIt4I;
-        Expires=Tue, 03 May 2022 05:04:11 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=ExlhNFEPGiUQtd7Vfp0HEkFfj2ABN49wTOf56av5CMhedQBYxHr8TrF49XgkvqhoRnq3uj7yvyQUcS/8ShBsa60zvc07uvqYNRVdhoT2X83r1heBXDEp+EJyZAB2;
+        Expires=Wed, 04 May 2022 06:20:18 GMT; Path=/
+      - AWSALBCORS=ExlhNFEPGiUQtd7Vfp0HEkFfj2ABN49wTOf56av5CMhedQBYxHr8TrF49XgkvqhoRnq3uj7yvyQUcS/8ShBsa60zvc07uvqYNRVdhoT2X83r1heBXDEp+EJyZAB2;
+        Expires=Wed, 04 May 2022 06:20:18 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB58e2642c9d8c4f2ef859d0b66de0c2c7
+      - NB27acbfb9784b81a073789cd6ee477a89
       Pragma:
       - no-cache
       Cache-Control:
@@ -55570,11 +56178,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - DI6y8nPF_TNWPfFp6YOZEeNIvh_oHqqWiCWfripNkTAFbTahWbyd7g==
+      - MBcv4xW_7YIACgcBYeWUNIvK6K9_qlrDqZg5_2Rshyzh6uwDyDML-A==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -55621,7 +56229,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:ED",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698ef",
           "Name": "",
@@ -55680,7 +56288,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:11 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:18 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d416698f9
@@ -55696,9 +56304,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIA0NLMhE1YGva03aH+UiZ8Kz3qRsM/fSyMt61dJV7D5IAiBtq9c31Y9g9uLuNwkiUqi6z0w9DUCcMUvkHCvQrBR83w=="
+        host date digest",signature="MEUCIHMprG300G6QTLs5C+KoyCW3sLFxP8W0P43PjlbFg72EAiEArpFgUIA4Auxc24Ckt/V7dNzxIg63kHbsU705Qt0EqXA="
       Date:
-      - Tue, 26 Apr 2022 05:04:11 GMT
+      - Wed, 27 Apr 2022 06:20:18 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -55711,16 +56319,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:12 GMT
+      - Wed, 27 Apr 2022 06:20:19 GMT
       Set-Cookie:
-      - AWSALB=EvhUmcLt9KuGF1oXAA2sIR59JAi/3yhF9n45JN31aiWyVXWBA4Y3uY94Z9Bg3qPhz/IHtNyqf4+/nx3RTRR3GO2eUIvPwuVjNn//UtAHQaGzwDf2aQb+NKOVtJDg;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/
-      - AWSALBCORS=EvhUmcLt9KuGF1oXAA2sIR59JAi/3yhF9n45JN31aiWyVXWBA4Y3uY94Z9Bg3qPhz/IHtNyqf4+/nx3RTRR3GO2eUIvPwuVjNn//UtAHQaGzwDf2aQb+NKOVtJDg;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=kJfdk69i1KlgTjMec/atn7aQUaufDoRuQlkVJoCdmEx8R2nxqQT5tj2Ph9GfXWnbcF0ISTru7vgC6QcI47OJ/pi1c5xJCiaeg7xZVfOoVxg2FEIaRR1B3NzqK2Kl;
+        Expires=Wed, 04 May 2022 06:20:19 GMT; Path=/
+      - AWSALBCORS=kJfdk69i1KlgTjMec/atn7aQUaufDoRuQlkVJoCdmEx8R2nxqQT5tj2Ph9GfXWnbcF0ISTru7vgC6QcI47OJ/pi1c5xJCiaeg7xZVfOoVxg2FEIaRR1B3NzqK2Kl;
+        Expires=Wed, 04 May 2022 06:20:19 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBcce4696e8937750193eb4acf26db4387
+      - NBe9c2d9997e9a037c33649a59e37f9275
       Pragma:
       - no-cache
       Cache-Control:
@@ -55750,11 +56358,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 5pc-iSxRcTZEAPgqag2Z10XCtMMZ5KBQqO0Vkqjy5LRkpt76qbTs6Q==
+      - pq-rHaRBw2uvcI5Z7848liPxmawF_fUIojsNOUZ3ubMLYZZb9kYLDg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -55801,7 +56409,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:F7",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d416698f9",
           "Name": "",
@@ -55860,7 +56468,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:12 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:19 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669912
@@ -55876,9 +56484,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQC0tzVDe4rtoHbWdMHoHDZW8gbHFEfu858yx+BAf2EYXwIgHcjwtUgrKI9Dh+I5WYZE/CnXkkrQoDbtmS+NUQXXVkg="
+        host date digest",signature="MEUCICdjy8ghYMm7ZO3tLIuYQHXpQFCCothpdUnj4y9AP2EAAiEAo4kfq0qCp5JG9e+5vuqm0/yR/pxNEaTYiuQGLBzrqSY="
       Date:
-      - Tue, 26 Apr 2022 05:04:12 GMT
+      - Wed, 27 Apr 2022 06:20:19 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -55891,16 +56499,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:12 GMT
+      - Wed, 27 Apr 2022 06:20:19 GMT
       Set-Cookie:
-      - AWSALB=5kaVHAglAuIj6T7uFVakK0+52huWjlpv/2ezF8+e4+EM4mbk2KeYAAMXXyhP0TotdxCwnFMp5uEctP/pMMyXG4ufoFC38hZtHwCDm3Sk5HALIi3JbbEHTb4yPfw5;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/
-      - AWSALBCORS=5kaVHAglAuIj6T7uFVakK0+52huWjlpv/2ezF8+e4+EM4mbk2KeYAAMXXyhP0TotdxCwnFMp5uEctP/pMMyXG4ufoFC38hZtHwCDm3Sk5HALIi3JbbEHTb4yPfw5;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=llX6ztFc+ClWz8RhH2c00dC3JmEooLX2NvhxxEdyfvGPTdqESrE7nyJR1CEeR0hKI812kunbaQ4fKPO1cb3onJh2UC0jkJKGe6KRTAPdmEeEnk0LVMw3z3jmcjLR;
+        Expires=Wed, 04 May 2022 06:20:19 GMT; Path=/
+      - AWSALBCORS=llX6ztFc+ClWz8RhH2c00dC3JmEooLX2NvhxxEdyfvGPTdqESrE7nyJR1CEeR0hKI812kunbaQ4fKPO1cb3onJh2UC0jkJKGe6KRTAPdmEeEnk0LVMw3z3jmcjLR;
+        Expires=Wed, 04 May 2022 06:20:19 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB5562a61752aff0b6291846990484f611
+      - NB854702ee71e44aa0bbd01d7948cc34a4
       Pragma:
       - no-cache
       Cache-Control:
@@ -55930,11 +56538,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - sm7VcknZoG4FiVTSSufkDthrNlOHQQ6gcECVdNxMuUfLy4AZNjVfjA==
+      - hVc5aqGcQRpsc9JOlrqh7wyk8jYGoGbcfbpeOmGI1266G31AASUQsw==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -55981,7 +56589,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DA",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25d4630312d41669912",
           "Name": "",
@@ -56040,7 +56648,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:12 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:19 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669919
@@ -56056,9 +56664,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIH9bdI7pODOigO72okameurMPnudTAWUbnYFFlAnxCoJAiBsIB1lPbwnlzQ1q64VvEmSBOfgUiX4DkUYk6z6DuBh2g=="
+        host date digest",signature="MEQCID1p8UMCWIGxwJHIZnggUuPM37AhlpWfC6LSA+y9098mAiA8hW1qGG21HCoK++87L/QZXLwy7bGOOuHj6cz+PS1fyg=="
       Date:
-      - Tue, 26 Apr 2022 05:04:12 GMT
+      - Wed, 27 Apr 2022 06:20:19 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -56071,16 +56679,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:12 GMT
+      - Wed, 27 Apr 2022 06:20:19 GMT
       Set-Cookie:
-      - AWSALB=D0EMVdD2bwB7reinC/0CWE8uRzIzmbTgvn1/SWHNS0N/QKUKCq+ZG3KLtHSrn6QZZbeVAhxDlTUpkATk49rBFkIcM0jVZhHjL7xQp1khh/Hvzhe3gTAC0iEO7ju1;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/
-      - AWSALBCORS=D0EMVdD2bwB7reinC/0CWE8uRzIzmbTgvn1/SWHNS0N/QKUKCq+ZG3KLtHSrn6QZZbeVAhxDlTUpkATk49rBFkIcM0jVZhHjL7xQp1khh/Hvzhe3gTAC0iEO7ju1;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=m7z8UCGvEf8hTeN9V4UCc/NwpooyyteulAOepXsl1b4HcfkK9XWjq+x7HjPNCPJHIe1068+9x28w7zhvNuPsBEOHbF9G89WmvWaQTJjamWBTnfoUeVsZMIb7z/92;
+        Expires=Wed, 04 May 2022 06:20:19 GMT; Path=/
+      - AWSALBCORS=m7z8UCGvEf8hTeN9V4UCc/NwpooyyteulAOepXsl1b4HcfkK9XWjq+x7HjPNCPJHIe1068+9x28w7zhvNuPsBEOHbF9G89WmvWaQTJjamWBTnfoUeVsZMIb7z/92;
+        Expires=Wed, 04 May 2022 06:20:19 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB806192dabf1bf1d5eac46ae3279d428a
+      - NBb6391c8eb8fb5b37fa69d1f686e3b6b6
       Pragma:
       - no-cache
       Cache-Control:
@@ -56110,11 +56718,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 63W4t3aiJM6lpv3iczyoQ6VfJs9NZSJ95wt4maMwk5mfDgZdlDHWbw==
+      - D5J6UBqn_VixF7dQRBJTlbNx2YB1Q1JtC6pV1R7nWBUazlquY4KlOg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -56161,7 +56769,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E1",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d41669919",
           "Name": "",
@@ -56220,7 +56828,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:12 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:19 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d4166991e
@@ -56236,9 +56844,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCeGgOF03afEDjlWerYXdsjUzkbkLu79Tf+mTJqzSO+fgIhAP8TF7HrlHE47W9VLh2LMHE4JLczmfBQRRwCjdZX4YQb"
+        host date digest",signature="MEYCIQC68CR0XDQPzbJKEAdR9GHdI693aE6bF2Zhnvee5U1cSwIhANjWuul6F4074Q9fr5NR/K3oUtChaJCMeCzFGZiim3NO"
       Date:
-      - Tue, 26 Apr 2022 05:04:12 GMT
+      - Wed, 27 Apr 2022 06:20:19 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -56251,16 +56859,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:12 GMT
+      - Wed, 27 Apr 2022 06:20:19 GMT
       Set-Cookie:
-      - AWSALB=P/YBJ/rke9MMeMrJqskINq/iTzwgaJLQdQ61cU4HCVJR2o+L+OesubvwXB3IG4n8sN3yzNlRhMdK+6hOjNMyT1BQbwix27+bNI0Vy33eRhbHyesQl8Z+uimML/ni;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/
-      - AWSALBCORS=P/YBJ/rke9MMeMrJqskINq/iTzwgaJLQdQ61cU4HCVJR2o+L+OesubvwXB3IG4n8sN3yzNlRhMdK+6hOjNMyT1BQbwix27+bNI0Vy33eRhbHyesQl8Z+uimML/ni;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=/JDV2mWUK4fb5Nh0Lqhaj2Gm1d+Bb8qAzTNyMTUZVAtTgmcEeX3DU6S95M6XqVqLy8He3RGZHF94LuVI7fVNoxzm4imRW2B3jbCuYuVgq+PmTbXjVDmD/QfDfrT2;
+        Expires=Wed, 04 May 2022 06:20:19 GMT; Path=/
+      - AWSALBCORS=/JDV2mWUK4fb5Nh0Lqhaj2Gm1d+Bb8qAzTNyMTUZVAtTgmcEeX3DU6S95M6XqVqLy8He3RGZHF94LuVI7fVNoxzm4imRW2B3jbCuYuVgq+PmTbXjVDmD/QfDfrT2;
+        Expires=Wed, 04 May 2022 06:20:19 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB731731e138025468b0b2d51006ad6e17
+      - NB57be307fb2d55fe6c1c68dc00750be02
       Pragma:
       - no-cache
       Cache-Control:
@@ -56290,11 +56898,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - bM35AiJrh2CfLnkhnFuWNxuKaeiPVqzdKtFedcS8a0_ZpHlc-fClwg==
+      - j_vRBzOFnycwgnqeHV1mJqCZRo0twyid5teeb9uNOieAnJusYKGB5w==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -56341,7 +56949,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:E6",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "614ce25d4630312d4166991e",
           "Name": "",
@@ -56400,7 +57008,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:12 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:19 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/614ce25d4630312d41669913
@@ -56416,9 +57024,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCvJ9Qsj16QOyjqWcJ0Po1MIzSmL1axWEKJ6g4ANhsPHwIgcIbHeqVTay0TG3I1VlGXAJdWse6cK0bBOtB2/zMfWsM="
+        host date digest",signature="MEYCIQCKxt3w7YdlXimlUO1/vaS1zU+2pzCW9jNzueP+293CnAIhAJRtyMLzy1qazXWFm1xzAzui0MM9Ten6yPbQtdVMl6iT"
       Date:
-      - Tue, 26 Apr 2022 05:04:12 GMT
+      - Wed, 27 Apr 2022 06:20:19 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -56431,16 +57039,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:12 GMT
+      - Wed, 27 Apr 2022 06:20:20 GMT
       Set-Cookie:
-      - AWSALB=cYdHrm/wDerYkP4Av5dCMzvB54vTQxYz72XZXtbK4tfuMXhR0HfQGPtMKojzkYH1rfkDu54qhttmUdiZ0lCyjaDlacb+IRnAu+EURCRbcT9CV5CIIogOpUsFm4sb;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/
-      - AWSALBCORS=cYdHrm/wDerYkP4Av5dCMzvB54vTQxYz72XZXtbK4tfuMXhR0HfQGPtMKojzkYH1rfkDu54qhttmUdiZ0lCyjaDlacb+IRnAu+EURCRbcT9CV5CIIogOpUsFm4sb;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=uGeO4RdPc9lL3V/cSfm5VdPQdb+1f1ww1ObauiCJFnA8hAEjkKUV3K2fSWjtc8+I0SAaZa+1F7kTmD2L3nv4Kj1NnPudsUQQy/BOxaU2/XNEZAUyOtNuvTfZSP6F;
+        Expires=Wed, 04 May 2022 06:20:19 GMT; Path=/
+      - AWSALBCORS=uGeO4RdPc9lL3V/cSfm5VdPQdb+1f1ww1ObauiCJFnA8hAEjkKUV3K2fSWjtc8+I0SAaZa+1F7kTmD2L3nv4Kj1NnPudsUQQy/BOxaU2/XNEZAUyOtNuvTfZSP6F;
+        Expires=Wed, 04 May 2022 06:20:19 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB2dbd0f03b4905bd76ea5f926cb764210
+      - NB3cabdf3b5323084dbfb5171b407778a0
       Pragma:
       - no-cache
       Cache-Control:
@@ -56470,11 +57078,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ML0ekMWpw77Z-_JAEBAkA06KkQufqLdKd0_G48hGX_Xv-FtIbtaR0A==
+      - ffO-mlph7_KIHlXho5DhkU4iMUuSpMKU81zaZoQmGAublIKdYZ-8FA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -56521,7 +57129,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:DB",
-          "ModTime": "2022-04-26T04:31:05.879Z",
+          "ModTime": "2022-04-27T06:19:06.586Z",
           "Mode": "fex-fabric",
           "Moid": "614ce25d4630312d41669913",
           "Name": "",
@@ -56580,7 +57188,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:12 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:20 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/62044b9c4630312d41c8a0c0
@@ -56596,9 +57204,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEYCIQCrMNELy/OGGi4Za8bUPSbkniKftYf7oTlHsEbGkxp6lgIhAJqRKvedH2dpSNS8Bvx3hf8HZGLzKJkAlWNwjN+blSYT"
+        host date digest",signature="MEQCIDS+tbm4nTzUaBMMewnKwuitFBdXuO2Al7uzwaAnSenAAiBUuY1QNERC5kn8SVVtP+r4wQhs1bXJghfG5aipu0b20w=="
       Date:
-      - Tue, 26 Apr 2022 05:04:12 GMT
+      - Wed, 27 Apr 2022 06:20:20 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -56611,16 +57219,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:13 GMT
+      - Wed, 27 Apr 2022 06:20:20 GMT
       Set-Cookie:
-      - AWSALB=PuwAPMtqyK8SPwo+EX/ZhwmsKGeOaFzcm3/6IO3jy/sLUi+LBnwFxrTaWn6t10EJg5t21zwleqbBVAUWsUkAxt12UYvBn2lmhhjOxPy1nMbcY6oMSTb1ShOznVQW;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/
-      - AWSALBCORS=PuwAPMtqyK8SPwo+EX/ZhwmsKGeOaFzcm3/6IO3jy/sLUi+LBnwFxrTaWn6t10EJg5t21zwleqbBVAUWsUkAxt12UYvBn2lmhhjOxPy1nMbcY6oMSTb1ShOznVQW;
-        Expires=Tue, 03 May 2022 05:04:12 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=/FKVAAHL+dUpBrda1ax5cQ3j10/DjJZRMxTnB0aRxeeOMtcdR9tu92Z/X0RqT/7QxbT9CPe2FLddoHotpQBg0SyjypH81CtLURdMXkfwWnVpSaimH4aliTPl3kQJ;
+        Expires=Wed, 04 May 2022 06:20:20 GMT; Path=/
+      - AWSALBCORS=/FKVAAHL+dUpBrda1ax5cQ3j10/DjJZRMxTnB0aRxeeOMtcdR9tu92Z/X0RqT/7QxbT9CPe2FLddoHotpQBg0SyjypH81CtLURdMXkfwWnVpSaimH4aliTPl3kQJ;
+        Expires=Wed, 04 May 2022 06:20:20 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBe2d5709f78fbec31e985c00130e75604
+      - NB52e07bf986e98b0857a8024b0c20ce9d
       Pragma:
       - no-cache
       Cache-Control:
@@ -56650,11 +57258,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - ODqZ1zR8vdOlpDJSyp7uIAq7_HtIQbhPw6sJG1dK-0grSsdFYq2ulA==
+      - c9a8cQ61NHSPCgX4Ac-k90EntCgIm97cNstxxPNQQpTNDhVNVA4dnA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -56701,7 +57309,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CB",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "62044b9c4630312d41c8a0c0",
           "Name": "",
@@ -56760,7 +57368,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:13 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:20 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/62044b9c4630312d41c8a0bf
@@ -56776,9 +57384,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEQCIA+tB3xzOF1Uv5wjAV8Kj2hCY47weJYgrOu1tzjDL2LMAiAg1vVC6G0gExO1Z2lTXHX8J3jMNi4mBtBC2cIED/1KJA=="
+        host date digest",signature="MEUCIH4UAKuhZgtngTOIOeXevdS2CtrALKb0UAIcoIUeyiUMAiEAjBYm730b5Y/40KED7/OmKdltjAip9mUr1diIFa6/jL4="
       Date:
-      - Tue, 26 Apr 2022 05:04:13 GMT
+      - Wed, 27 Apr 2022 06:20:20 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -56791,16 +57399,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:13 GMT
+      - Wed, 27 Apr 2022 06:20:20 GMT
       Set-Cookie:
-      - AWSALB=S0jJjWpNnQyxvlixAGSiQQydsfv3NaoFtvEaTlY2vXfj/QwnVvX57tl24Twxnqj7Qej8C24mPSx/l2IWzk5kQNkAlP5BVPFrouqC4pzqW8XaB9NmO3Nfn7hd0Ltr;
-        Expires=Tue, 03 May 2022 05:04:13 GMT; Path=/
-      - AWSALBCORS=S0jJjWpNnQyxvlixAGSiQQydsfv3NaoFtvEaTlY2vXfj/QwnVvX57tl24Twxnqj7Qej8C24mPSx/l2IWzk5kQNkAlP5BVPFrouqC4pzqW8XaB9NmO3Nfn7hd0Ltr;
-        Expires=Tue, 03 May 2022 05:04:13 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=rNBjCoB/nD8X2YtjgToK96fBlPXbpE1Ent/yTvtdsM4MiBWqeg5soLwZ62xv8tESpGaqEuzEAVLDDPC+1KwzJiAs5I6jFHY1kkBeY7VpWjFf6ubVi64hbrHl8esw;
+        Expires=Wed, 04 May 2022 06:20:20 GMT; Path=/
+      - AWSALBCORS=rNBjCoB/nD8X2YtjgToK96fBlPXbpE1Ent/yTvtdsM4MiBWqeg5soLwZ62xv8tESpGaqEuzEAVLDDPC+1KwzJiAs5I6jFHY1kkBeY7VpWjFf6ubVi64hbrHl8esw;
+        Expires=Wed, 04 May 2022 06:20:20 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBfdb0a65258e8d490b55b24cab2744b14
+      - NB16736d3b3213b41e7ce38e0b4c089b7f
       Pragma:
       - no-cache
       Cache-Control:
@@ -56830,11 +57438,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 0qeNq53VrauqArjF_IxQJhjBSiixqsEM9bu19EvV3cC23s8CUxJXLQ==
+      - 0M7SYZhaL_Vq52RuKzkDe5WbMT6UbIImWiDfU5IN72ub4KBoI2UANg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -56881,7 +57489,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:CA",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "62044b9c4630312d41c8a0bf",
           "Name": "",
@@ -56940,7 +57548,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:13 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:20 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/62044b9c4630312d41c8a0bd
@@ -56956,9 +57564,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCQMcMWvdwC13sD/omYumOKpjKFF/bVX8WDwnuX7U0g0QIgM+hPBUZpS43OyZL4ZuBnJGd9gvgVzZMqU+V9VF1nI/0="
+        host date digest",signature="MEUCIQDmzW6H7dXG9W+io6CCbTKKl3D79HkdKh2hYzWOhE3YEgIgfLjt6LSZ/DYanVvFsfbY7GjcaQeAIKpqvATV1kagpOQ="
       Date:
-      - Tue, 26 Apr 2022 05:04:13 GMT
+      - Wed, 27 Apr 2022 06:20:20 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -56971,16 +57579,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:13 GMT
+      - Wed, 27 Apr 2022 06:20:20 GMT
       Set-Cookie:
-      - AWSALB=tUMyYvUMZ8vlOYsXV7ZAGggS6n8a0blge3cM6jutIeD9yyMSm5cys+rlPVXhmfIkz07kfFLBEXwOXZExInDqMesibG6/qgKWSHyoA/bsqTyQc3wy38HXtMIv0mGC;
-        Expires=Tue, 03 May 2022 05:04:13 GMT; Path=/
-      - AWSALBCORS=tUMyYvUMZ8vlOYsXV7ZAGggS6n8a0blge3cM6jutIeD9yyMSm5cys+rlPVXhmfIkz07kfFLBEXwOXZExInDqMesibG6/qgKWSHyoA/bsqTyQc3wy38HXtMIv0mGC;
-        Expires=Tue, 03 May 2022 05:04:13 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=sv+gUEsa7sjQr7D5h3wzGEBT50lhiNFIHl9Tan4jJqKZefOkQ1SuqLZgA/glb1z//aC8MNND6785pd0Bw8GFuwLXbI5tl9vcrg1audy5Zwk+HfeFIKaGhwhhmt9F;
+        Expires=Wed, 04 May 2022 06:20:20 GMT; Path=/
+      - AWSALBCORS=sv+gUEsa7sjQr7D5h3wzGEBT50lhiNFIHl9Tan4jJqKZefOkQ1SuqLZgA/glb1z//aC8MNND6785pd0Bw8GFuwLXbI5tl9vcrg1audy5Zwk+HfeFIKaGhwhhmt9F;
+        Expires=Wed, 04 May 2022 06:20:20 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB7e09a57575d61185f3ffb38bbb91c2ca
+      - NB38d6977fa7a136f061aa8a355392c1af
       Pragma:
       - no-cache
       Cache-Control:
@@ -57010,11 +57618,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - _w7b97HcPUITiyzdByVMSolRFwb35nczLt2UpLzG4IGRpm_fAxkvCQ==
+      - tspj1bzcJBMfwcT1YYyjo57x_upeZWHOPo2g6fLesLsFEUvdmw97nA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -57061,7 +57669,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:C8",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "62044b9c4630312d41c8a0bd",
           "Name": "",
@@ -57120,7 +57728,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:13 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:20 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/ether/PhysicalPorts/62044b9c4630312d41c8a0be
@@ -57136,9 +57744,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBhdS8avtArXevOBTp2WySUTNKQtrjbuUC5i6KkvCxOaAiEAoTBaLi81IzH9Pk3MFRxgEnMD/cLLoqckchayzqa4o3Y="
+        host date digest",signature="MEUCIHATArK9oAlen7Hz8azDNlw/SJejnkZ3p9D0JnRxtP1lAiEApocBnOKjXQrH1dP6FtxavWxqXjr9pTZlY1vXeCTa7n0="
       Date:
-      - Tue, 26 Apr 2022 05:04:13 GMT
+      - Wed, 27 Apr 2022 06:20:20 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -57151,16 +57759,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:13 GMT
+      - Wed, 27 Apr 2022 06:20:20 GMT
       Set-Cookie:
-      - AWSALB=EfSIJZ+KgTu6oxHaj96pMBWnnMF5Pf3ILfX1JaIHoVSV5ZfJnAtZ+uNy6WYsh3PvdJ2rwKYzDJpUI+sUrX/omiGDEjPU0aERqf/d3lI0Bw6UV4T+3F8dpq6kA3MC;
-        Expires=Tue, 03 May 2022 05:04:13 GMT; Path=/
-      - AWSALBCORS=EfSIJZ+KgTu6oxHaj96pMBWnnMF5Pf3ILfX1JaIHoVSV5ZfJnAtZ+uNy6WYsh3PvdJ2rwKYzDJpUI+sUrX/omiGDEjPU0aERqf/d3lI0Bw6UV4T+3F8dpq6kA3MC;
-        Expires=Tue, 03 May 2022 05:04:13 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=zj8iAnrFa/HfvZinQfZGJVnWTsmAFx0nrrbP28X3yw/X0QUCHXo+mw14wXybX/0g3HYXNWZDQlzAnhbHVDGDPGu7CIRcfR3G5cajGs2MbURSr80cbnDg19SMc0Md;
+        Expires=Wed, 04 May 2022 06:20:20 GMT; Path=/
+      - AWSALBCORS=zj8iAnrFa/HfvZinQfZGJVnWTsmAFx0nrrbP28X3yw/X0QUCHXo+mw14wXybX/0g3HYXNWZDQlzAnhbHVDGDPGu7CIRcfR3G5cajGs2MbURSr80cbnDg19SMc0Md;
+        Expires=Wed, 04 May 2022 06:20:20 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB503236060844a089631f69e93a7cf9f0
+      - NB331de83bcb5430a7d7741a1cee0e5f49
       Pragma:
       - no-cache
       Cache-Control:
@@ -57190,11 +57798,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - 0FOgOdKMs3z8vQyyx1KaY4ySImxnoi-2ZCsVUtK3c-G75LSnJYmLIA==
+      - JnvWNlkCcHjIgwqjBINwcJZvKfWY33s7HrrLypATnM9HZpjTkpy9pg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -57241,7 +57849,7 @@ http_interactions:
           "LicenseGrace": "",
           "LicenseState": "",
           "MacAddress": "00:3A:9C:DA:93:C9",
-          "ModTime": "2022-04-26T04:31:05.881Z",
+          "ModTime": "2022-04-27T06:19:06.587Z",
           "Mode": "access",
           "Moid": "62044b9c4630312d41c8a0be",
           "Name": "",
@@ -57300,7 +57908,7 @@ http_interactions:
           "TransceiverType": "absent"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:13 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:20 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/port/Groups/614ce2a36176752d35a7eea3
@@ -57316,9 +57924,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIQCrwoX8SJz2rgsXjAp37w2HLRJ4vFwVGiYHxEI2/rgk6gIgEI9DvjiOZLoqbVYvs2cXnmstUymTPBLJUa2ZnywRGBU="
+        host date digest",signature="MEQCIFOYS9S5MSF1qRJpwIFKwelYapTeJkBHC0gAW3TYAwf+AiAdj0iv3vukP1N+Oq+5xmmklQByaKLTdlVO5BZmlJOcdA=="
       Date:
-      - Tue, 26 Apr 2022 05:04:13 GMT
+      - Wed, 27 Apr 2022 06:20:21 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -57331,16 +57939,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:13 GMT
+      - Wed, 27 Apr 2022 06:20:21 GMT
       Set-Cookie:
-      - AWSALB=1UkMfAM60gmfhDUmB1zavSmVx8FYspXgoqmpTkz4AixZ/tXmQfGrpzlzJSnS0W9eoDGCC8+HEauLic9q1VIMdwLf3U3lKH4isBYmVxPrYuqaPZz3msdE2xP+OEAT;
-        Expires=Tue, 03 May 2022 05:04:13 GMT; Path=/
-      - AWSALBCORS=1UkMfAM60gmfhDUmB1zavSmVx8FYspXgoqmpTkz4AixZ/tXmQfGrpzlzJSnS0W9eoDGCC8+HEauLic9q1VIMdwLf3U3lKH4isBYmVxPrYuqaPZz3msdE2xP+OEAT;
-        Expires=Tue, 03 May 2022 05:04:13 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=rAHraNZFNMz40Z22hP2huHWR3jeM+9lBfs8rz/MWNdUf8zADhDJXMbCvUL5ai4CqzZw6znOp3gLnkBAAv4gXTfZLHkGUYkJp+bRTETA33dfrwptJulJEwanoD14c;
+        Expires=Wed, 04 May 2022 06:20:21 GMT; Path=/
+      - AWSALBCORS=rAHraNZFNMz40Z22hP2huHWR3jeM+9lBfs8rz/MWNdUf8zADhDJXMbCvUL5ai4CqzZw6znOp3gLnkBAAv4gXTfZLHkGUYkJp+bRTETA33dfrwptJulJEwanoD14c;
+        Expires=Wed, 04 May 2022 06:20:21 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NB62194d6eeb3eafe1917f2edcb689d761
+      - NBcad670e74771cc80d858b80aec3623f4
       Pragma:
       - no-cache
       Cache-Control:
@@ -57370,11 +57978,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - h_eredUUu3jBEZSJn4U8KaeRDQdJaT__zqvg_s57HqOnD-Ag721ygQ==
+      - KkbG3XmL4oOYksZP0_oAuDlSemNdcY9tvyiStapQklQkPzKiL9iNzA==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -57449,7 +58057,7 @@ http_interactions:
           "Transport": "fc"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:13 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:21 GMT
 - request:
     method: get
     uri: https://intersight.com/api/v1/firmware/RunningFirmwares/614ce25d4630312d4166992b
@@ -57465,9 +58073,9 @@ http_interactions:
       - application/json
       Authorization:
       - Signature keyId="5ed10e437564612d3352cc2d/606616ad7564612d3042cdd0/6205497b7564612d301e04c8",algorithm="hs2019",headers="(request-target)
-        host date digest",signature="MEUCIBOPqmZuV3bJDkCU0n3+CZD5eFUuS0WrOiGZsDnhgH5SAiEAudw02I8yll3BlQm+nn4w7SMk3pfZwUZhMlmvH/UqRdc="
+        host date digest",signature="MEUCIQC6hWji2T0erJ9XCAhbLEj0YCnYAitO5lBUvtjLCr0UsAIgGeaKpuG3RpKxwMa+FXGiximdm6hji4OAqVDyTijfFrU="
       Date:
-      - Tue, 26 Apr 2022 05:04:13 GMT
+      - Wed, 27 Apr 2022 06:20:21 GMT
       Digest:
       - SHA-256=47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=
       Expect:
@@ -57480,16 +58088,16 @@ http_interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 26 Apr 2022 05:04:14 GMT
+      - Wed, 27 Apr 2022 06:20:21 GMT
       Set-Cookie:
-      - AWSALB=julVAtqwz63BuxFXs1rn9YPLgD40a8gubLbGOfnM5TLbe806h598da9GZdihoaL83kllWIluAnjqQktJybCZnnyrTDH2f+8ZgAHIRMQc7U/XwocnCjmtymFFNCnz;
-        Expires=Tue, 03 May 2022 05:04:14 GMT; Path=/
-      - AWSALBCORS=julVAtqwz63BuxFXs1rn9YPLgD40a8gubLbGOfnM5TLbe806h598da9GZdihoaL83kllWIluAnjqQktJybCZnnyrTDH2f+8ZgAHIRMQc7U/XwocnCjmtymFFNCnz;
-        Expires=Tue, 03 May 2022 05:04:14 GMT; Path=/; SameSite=None; Secure
+      - AWSALB=vRqAjbddbOdPNhSOW8sTRXc9fZLn9Hv3cSjCYL2laBCg9CHarmWAaR9FbbLtzUvO6jW/12nPri5ycRhDE1ESv7JV88Sa/t3dNjbQGRP8MjIowsK1asLSdjk+ETQf;
+        Expires=Wed, 04 May 2022 06:20:21 GMT; Path=/
+      - AWSALBCORS=vRqAjbddbOdPNhSOW8sTRXc9fZLn9Hv3cSjCYL2laBCg9CHarmWAaR9FbbLtzUvO6jW/12nPri5ycRhDE1ESv7JV88Sa/t3dNjbQGRP8MjIowsK1asLSdjk+ETQf;
+        Expires=Wed, 04 May 2022 06:20:21 GMT; Path=/; SameSite=None; Secure
       Server:
       - nginx
       X-Starship-Traceid:
-      - NBb99baf266b89d60608354098d6f5f0a4
+      - NBcc2da96b80405999b5ef924a2e2213d9
       Pragma:
       - no-cache
       Cache-Control:
@@ -57519,11 +58127,11 @@ http_interactions:
       X-Cache:
       - Miss from cloudfront
       Via:
-      - 1.1 b8c21c40c485a68c7663b93787f93464.cloudfront.net (CloudFront)
+      - 1.1 996a6dcadb486dbb9da5040a9ab13af2.cloudfront.net (CloudFront)
       X-Amz-Cf-Pop:
       - ZAG50-C1
       X-Amz-Cf-Id:
-      - cGr2qF4eoZ1c9FwZZzm8ZoRUppQ0yKlV8RKAuITdhCW_mvuWwNcJsg==
+      - pR8tXG0VmxA6Ws3NNsqCZ2gZ4zcHHYh3p7RcbbFz9GMRMs7S36HXpg==
     body:
       encoding: ASCII-8BIT
       string: |-
@@ -57558,7 +58166,7 @@ http_interactions:
             "ObjectType": "management.Controller",
             "link": "https://www.intersight.com/api/v1/management/Controllers/614ce2a36176752d35a7ee86"
           },
-          "ModTime": "2022-04-26T05:03:05.259Z",
+          "ModTime": "2022-04-27T06:15:05.815Z",
           "Moid": "614ce25d4630312d4166992b",
           "NetworkElements": [
             {
@@ -57611,5 +58219,5 @@ http_interactions:
           "Version": "9.3(5)I42(1f)"
         }
     http_version:
-  recorded_at: Tue, 26 Apr 2022 05:04:14 GMT
+  recorded_at: Wed, 27 Apr 2022 06:20:21 GMT
 recorded_with: VCR 5.1.0


### PR DESCRIPTION
This PR changes attribute `:name` for collection `physical_switches` in collector. To summarize changes with this PR:

- _Parser_: Before, name stored distinguished name (called `dn`) of Intersight object `NetworkElements`. Now, it stores `name` of Intersight object `NetworkElementSummary`. 
- _Collector_: `NetworkElements` and `NetworkElementSummary` have the same `moid`s ( = unique ID on the intersight side), so I add helper function `get_network_element_summary_by_moid`. In parser, `NetworkElementSummary` is obtained from `NetworkElements` (I store these two objects in variables `network_element` and `network_element_summary`, respectively)