### PR TITLE
Add server profile operations' dialogs

### DIFF
--- a/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb
+++ b/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb
@@ -53,7 +53,7 @@ module ManageIQ
                                                    :modal_title    => N_('Assign Server Profile'),
                                                    :component_name => 'ServerProfileForm',
                                                    :action         => 'assign_server'}},
-                    :klass          => ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssignServerProfileButton
+                    :klass => ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssignServerProfileButton
                   ),
                   button(
                     :physical_server_deploy_server_profile,
@@ -66,7 +66,7 @@ module ManageIQ
                                                    :modal_title    => N_('Deploy Server Profile'),
                                                    :component_name => 'ServerProfileForm',
                                                    :action         => 'deploy_server'}},
-                    :klass          => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                    :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck
                   ),
                   button(
                     :physical_server_unassign_server_profile,
@@ -79,7 +79,7 @@ module ManageIQ
                                                    :modal_title    => N_('Unassign Server Profile'),
                                                    :component_name => 'ServerProfileForm',
                                                    :action         => 'unassign_server'}},
-                    :klass          => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                    :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck
                   ),
                 ]
               )

--- a/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb
+++ b/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb
@@ -41,7 +41,7 @@ module ManageIQ
                     :enabled => true,
                     :options => {:feature => :recommission}
                   ),
-                  separator(),
+                  separator,
                   button(
                     :physical_server_assign_server_profile,
                     'pficon pficon-add-circle-o fa-lg',
@@ -53,7 +53,7 @@ module ManageIQ
                                                    :modal_title    => N_('Assign Server Profile'),
                                                    :component_name => 'ServerProfileForm',
                                                    :action         => 'assign_server'}},
-                                                   :klass          => ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssignServerProfileButton
+                    :klass          => ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssignServerProfileButton
                   ),
                   button(
                     :physical_server_deploy_server_profile,
@@ -66,7 +66,7 @@ module ManageIQ
                                                    :modal_title    => N_('Deploy Server Profile'),
                                                    :component_name => 'ServerProfileForm',
                                                    :action         => 'deploy_server'}},
-                                                   :klass          => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                    :klass          => ApplicationHelper::Button::ButtonWithoutRbacCheck
                   ),
                   button(
                     :physical_server_unassign_server_profile,
@@ -79,7 +79,7 @@ module ManageIQ
                                                    :modal_title    => N_('Unassign Server Profile'),
                                                    :component_name => 'ServerProfileForm',
                                                    :action         => 'unassign_server'}},
-                                                   :klass          => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                    :klass          => ApplicationHelper::Button::ButtonWithoutRbacCheck
                   ),
                 ]
               )

--- a/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb
+++ b/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb
@@ -53,7 +53,7 @@ module ManageIQ
                                                    :modal_title    => N_('Assign Server Profile'),
                                                    :component_name => 'ServerProfileForm',
                                                    :action         => 'assign_server'}},
-                                                   :klass          => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                                                   :klass          => ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssignServerProfileButton
                   ),
                   button(
                     :physical_server_deploy_server_profile,

--- a/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb
+++ b/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb
@@ -9,7 +9,7 @@ module ManageIQ
               select(
                 :physical_server_lifecycle_choice,
                 nil,
-                t = N_('Cisco Intersight'),
+                t = N_('Intersight'),
                 t,
                 :enabled => true,
                 :items   => [
@@ -40,6 +40,46 @@ module ManageIQ
                     :confirm => N_("Recommission this server?"),
                     :enabled => true,
                     :options => {:feature => :recommission}
+                  ),
+                  separator(),
+                  button(
+                    :physical_server_assign_server_profile,
+                    'pficon pficon-add-circle-o fa-lg',
+                    t = N_('Assign Server Profile'),
+                    t,
+                    :data  => {'function'      => 'sendDataWithRx',
+                               'function-data' => {:controller     => 'provider_dialogs',
+                                                   :button         => :physical_server_assign_server_profile,
+                                                   :modal_title    => N_('Assign Server Profile'),
+                                                   :component_name => 'ServerProfileForm',
+                                                   :action         => 'assign_server'}},
+                                                   :klass          => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                  ),
+                  button(
+                    :physical_server_deploy_server_profile,
+                    'pficon fa-lg',
+                    t = N_('Deploy Server Profile'),
+                    t,
+                    :data  => {'function'      => 'sendDataWithRx',
+                               'function-data' => {:controller     => 'provider_dialogs',
+                                                   :button         => :physical_server_deploy_server_profile,
+                                                   :modal_title    => N_('Deploy Server Profile'),
+                                                   :component_name => 'ServerProfileForm',
+                                                   :action         => 'deploy_server'}},
+                                                   :klass          => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                  ),
+                  button(
+                    :physical_server_unassign_server_profile,
+                    'pficon fa-lg',
+                    t = N_('Unassign Server Profile'),
+                    t,
+                    :data  => {'function'      => 'sendDataWithRx',
+                               'function-data' => {:controller     => 'provider_dialogs',
+                                                   :button         => :physical_server_unassign_server_profile,
+                                                   :modal_title    => N_('Unassign Server Profile'),
+                                                   :component_name => 'ServerProfileForm',
+                                                   :action         => 'unassign_server'}},
+                                                   :klass          => ApplicationHelper::Button::ButtonWithoutRbacCheck
                   ),
                 ]
               )

--- a/app/javascript/components/server-profile-form.js
+++ b/app/javascript/components/server-profile-form.js
@@ -28,14 +28,6 @@ const ServerProfileForm = ({ dispatch, modalData }) => {
     serverProfileVisible = true;
   } else {
     submitLabel = (modalData.action === 'deploy_server' ? __('Deploy') : __('Unassign'));
-
-    useEffect(() => {
-      API.get(
-        `/api/physical_servers/${ManageIQ.record.recordId}?attributes=name,assigned_server_profile.id`
-      ).then((data) => {
-        console.log(data);
-      });
-    });
   }
 
   const initialize = (formOptions) => {
@@ -61,8 +53,6 @@ const ServerProfileForm = ({ dispatch, modalData }) => {
       API.get(
         `/api/physical_servers/${ManageIQ.record.recordId}?attributes=assigned_server_profile.id`
       ).then((data) => {
-        console.log(data);
-
         API.post('/api/physical_server_profiles', {
           action: modalData.action,
           resources: [{ 

--- a/app/javascript/components/server-profile-form.js
+++ b/app/javascript/components/server-profile-form.js
@@ -1,0 +1,99 @@
+import React, { useEffect, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import MiqFormRenderer from '@@ddf';
+
+import createSchema from './server-profile-form.schema';
+
+const fetchServerProfiles = (serverId) =>
+  API.get(
+    '/api/physical_server_profiles?expand=resources&attributes=id,name'
+  ).then(({ resources }) =>
+    resources.map(({ id, name }) => ({ value: id, label: name })));
+
+const fetchPhysicalServers = () =>
+  API.get(
+    '/api/physical_servers?expand=resources&attributes=id,name'
+  ).then(({ resources }) =>
+    resources.map(({ id, name }) => ({ value: id, label: name })));
+
+const ServerProfileForm = ({ dispatch, modalData }) => {
+  const serverProfilesPromise = useMemo(() => fetchServerProfiles());
+  const physicalServersPromise = useMemo(() => fetchPhysicalServers());
+
+  let submitLabel = '';
+  let serverProfileVisible = false;
+  if (modalData.action === 'assign_server') {
+    submitLabel = __('Assign');
+    serverProfileVisible = true;
+  } else {
+    submitLabel = (modalData.action === 'deploy_server' ? __('Deploy') : __('Unassign'));
+
+    useEffect(() => {
+      API.get(
+        `/api/physical_servers/${ManageIQ.record.recordId}?attributes=name,assigned_server_profile.id`
+      ).then((data) => {
+        console.log(data);
+      });
+    });
+  }
+
+  const initialize = (formOptions) => {
+    dispatch({ type: 'FormButtons.init',        payload: { saveable: true }, });
+    dispatch({ type: "FormButtons.customLabel", payload: submitLabel, }); 
+    dispatch({ type: 'FormButtons.callbacks',   payload: { saveClicked: () => formOptions.submit() }, });
+  };
+
+  const submitValues = (values) => {
+    if (modalData.action === 'assign_server') {
+      API.post('/api/physical_server_profiles', {
+        action: modalData.action,
+        resources: [{ 
+          id:        values['server_profile'],
+          server_id: ManageIQ.record.recordId
+        }],
+      }).then(({ results }) =>
+        results.forEach((res) => window.add_flash(res.message, res.success ? "success" : "error"))
+      ).catch((err) => {
+        window.add_flash(err.data && err.data.error && err.data.error.message || __('Unknown API error'), "error");
+      });
+    } else {
+      API.get(
+        `/api/physical_servers/${ManageIQ.record.recordId}?attributes=assigned_server_profile.id`
+      ).then((data) => {
+        console.log(data);
+
+        API.post('/api/physical_server_profiles', {
+          action: modalData.action,
+          resources: [{ 
+            id: data.assigned_server_profile.id,
+          }],
+        }).then(({ results }) =>
+          results.forEach((res) => window.add_flash(res.message, res.success ? "success" : "error"))
+        ).catch((err) => {
+          window.add_flash(err.data && err.data.error && err.data.error.message || __('Unknown API error'), "error");
+        });
+      });
+    }
+  };
+
+  return (
+    <MiqFormRenderer
+      schema={createSchema(serverProfilesPromise, physicalServersPromise, serverProfileVisible)}
+      onSubmit={submitValues}
+      showFormControls={false}
+      initialize={initialize}
+    />
+  )
+};
+
+ServerProfileForm.propTypes = {
+  serverProfileId: PropTypes.string,
+  dispatch:        PropTypes.func.isRequired,
+};
+
+ServerProfileForm.defaultProps = {
+  server_profile_id: undefined
+};
+
+export default connect()(ServerProfileForm);

--- a/app/javascript/components/server-profile-form.schema.js
+++ b/app/javascript/components/server-profile-form.schema.js
@@ -1,0 +1,42 @@
+import { componentTypes, validatorTypes } from '@@ddf';
+
+const createSchema = (serverProfilesPromise, physicalServersPromise, serverProfileVisible) => {
+  return ({
+    fields: [
+      ...(serverProfileVisible ? [
+          {
+            component: componentTypes.SELECT,
+            id: 'server_profile',
+            name: 'server_profile',
+            label: __('Server Profile'),
+            placeholder: __('Server Profile'),
+            initialValue: null,
+            isRequired: true,
+            validate: [{
+              type: validatorTypes.REQUIRED,
+              message: __('Required'),
+            }],
+            loadOptions: () => serverProfilesPromise,
+          }]
+        : [
+          {
+            component: componentTypes.SELECT,
+            id: 'physical_server',
+            name: 'physical_server',
+            label: __('Physical Server'),
+            placeholder: __('Physical Server'),
+            initialValue: ManageIQ.record.recordId,
+            value: null,
+            isRequired: true,
+            validate: [{
+              type: validatorTypes.REQUIRED,
+              message: __('Required'),
+            }],
+            loadOptions: () => physicalServersPromise,
+          }]
+      )
+    ]
+  });
+};
+
+export default createSchema;

--- a/app/javascript/packs/component-definitions-common.js
+++ b/app/javascript/packs/component-definitions-common.js
@@ -1,0 +1,3 @@
+import ServerProfileForm from '../components/server-profile-form';
+
+ManageIQ.component.addReact('ServerProfileForm', ServerProfileForm);

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/assign_server_profile_button.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/assign_server_profile_button.rb
@@ -1,0 +1,7 @@
+class ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssignServerProfileButton < ApplicationHelper::Button::Basic
+  needs :@record
+
+  def disabled?
+    !@record.assigned_server_profile.nil?
+  end
+end

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/assign_server_profile_button.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/assign_server_profile_button.rb
@@ -2,6 +2,6 @@ class ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::AssignServerPr
   needs :@record
 
   def disabled?
-    !@record.assigned_server_profile.nil?
+    @record.assigned_server_profile.present?
   end
 end

--- a/package.json
+++ b/package.json
@@ -1,0 +1,3 @@
+{
+  "packageManager": "yarn@3.0.2"
+}


### PR DESCRIPTION
This commit adds support for three operations on top of server profiles:
assign server profile, unassign server profile and deploy server (i.e.
activate the assigned server profile for a chosen server). It extends
the toolbar for Intersight as well as adds a new dialog used to select
relecant information and request these operations.

Screenshots below show the effects.

Toolbar for Cisco Intersight Physical server:
<img width="1115" alt="Screenshot 2022-05-02 at 11 26 08" src="https://user-images.githubusercontent.com/1437960/166213420-82acd922-8fcc-418e-a5ab-9fb13fbd7d5f.png">

Assign Server Profile dialog
<img width="1184" alt="Screenshot 2022-05-02 at 11 26 55" src="https://user-images.githubusercontent.com/1437960/166213457-78582024-5ecd-4979-9c48-f355f4d2aaa3.png">


Deploy server profile:
<img width="928" alt="Screenshot 2022-05-02 at 11 27 24" src="https://user-images.githubusercontent.com/1437960/166213522-671a9ebb-ee07-4165-8303-60fce172cfb7.png">

Unassign server profile:
<img width="931" alt="Screenshot 2022-05-02 at 11 28 14" src="https://user-images.githubusercontent.com/1437960/166213602-2a514f32-fbab-456a-a5e9-62e0b8db86b3.png">

