### PR TITLE
Fix Cisco Intersight connection

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/manager_mixin.rb
+++ b/app/models/manageiq/providers/cisco_intersight/manager_mixin.rb
@@ -12,8 +12,6 @@ module ManageIQ::Providers::CiscoIntersight::ManagerMixin
 
     service = options.delete(:service)
     if service
-      require "intersight_client/#{service.underscore}"
-
       api_client_klass = "IntersightClient::#{service}".safe_constantize
       raise ArgumentError, _("Invalid service") if api_client_klass.nil?
 


### PR DESCRIPTION
The refactor introduced a small bug in the `with_provider_connection` as
it required a file based on the `:service`. In the code that actually
used this, this did not work.

This patch removes the unnecessary `require` statement.