### PR TITLE
Fix Network Port's port_status

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -413,7 +413,8 @@ module ManageIQ::Providers::CiscoIntersight
               :mac_address        => physical_port.mac_address,
               :port_index         => physical_port.port_id,
               :connected_port_uid => physical_port.moid,
-              :port_status        => physical_port.admin_state
+              :port_status        => physical_port.admin_state,
+              :peer_mac_address   => physical_port.role
             )
           end
         end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser/physical_infra_manager.rb
@@ -412,7 +412,8 @@ module ManageIQ::Providers::CiscoIntersight
               :port_type          => "ethernet",
               :mac_address        => physical_port.mac_address,
               :port_index         => physical_port.port_id,
-              :connected_port_uid => physical_port.moid
+              :connected_port_uid => physical_port.moid,
+              :port_status        => physical_port.admin_state
             )
           end
         end

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
@@ -475,7 +475,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
                                               :type               => nil,
                                               :port_name          => "switch-FDO244106VJ/slot-1/switch-ether/port-42",
                                               :port_type          => "ethernet",
-                                              :peer_mac_address   => nil,
+                                              :peer_mac_address   => "unknown",
                                               :vlan_key           => nil,
                                               :mac_address        => "00:3A:9C:DA:78:F1",
                                               :port_index         => 42,

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresher_spec.rb
@@ -481,7 +481,8 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager::Refresher d
                                               :port_index         => 42,
                                               :vlan_enabled       => nil,
                                               :guest_device_id    => nil,
-                                              :connected_port_uid => switch_uid_ems
+                                              :connected_port_uid => switch_uid_ems,
+                                              :port_status        => "Disabled"
                                             ))
   end
 


### PR DESCRIPTION
This PR adds port_status for switch's network ports and updates the tests accordingly. 

port_status will always hold just value of either `Enabled` or `Disabled`.