### PR TITLE
Redefine `since` in method poll

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/event_catcher/stream.rb
@@ -19,7 +19,7 @@ module ManageIQ::Providers::CiscoIntersight
     end
 
     def poll(&block)
-      since = 2.minutes.ago.utc.iso8601
+      since = @ems.ems_events.order(:timestamp).pluck(:timestamp).last&.utc&.iso8601 || Time.new(2000).utc.iso8601
       loop do
         @ems.with_provider_connection do |api_client|
           catch(:stop_polling) do

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/event_catcher/stream.rb
@@ -32,8 +32,8 @@ module ManageIQ::Providers::CiscoIntersight
               # Use only selected attributes. Validation of other within the SDK lib might fail:
               :select  => '$select=CreateTime,ModTime,Name,Status,Email,WorkflowCtx,ClassId,Message',
               :orderby => 'ModTime', # Orders elements in ascending order based on atribute ModTime
-              :top     => $top=100, # Specifies the maximum number of resources to return in the response.
-              :skip    => $skip=0, # Specifies the number of resources to skip in the response.
+              :top     => 100, # Specifies the maximum number of resources to return in the response.
+              :skip    => 0, # Specifies the number of resources to skip in the response.
             }
             workflow_infos = IntersightClient::WorkflowApi.new(api_client).get_workflow_workflow_info_list(workflow_api_opts).results
             since = workflow_infos.last&.mod_time || since # Detect the most recently caught event and use that timestamp for since

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/event_catcher/stream.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/event_catcher/stream.rb
@@ -31,7 +31,9 @@ module ManageIQ::Providers::CiscoIntersight
               :filter  => "ModTime gt #{since}",
               # Use only selected attributes. Validation of other within the SDK lib might fail:
               :select  => '$select=CreateTime,ModTime,Name,Status,Email,WorkflowCtx,ClassId,Message',
-              :orderby => 'ModTime' # Orders elements in ascending order based on atribute ModTime
+              :orderby => 'ModTime', # Orders elements in ascending order based on atribute ModTime
+              :top     => $top=100, # Specifies the maximum number of resources to return in the response.
+              :skip    => $skip=0, # Specifies the number of resources to skip in the response.
             }
             workflow_infos = IntersightClient::WorkflowApi.new(api_client).get_workflow_workflow_info_list(workflow_api_opts).results
             since = workflow_infos.last&.mod_time || since # Detect the most recently caught event and use that timestamp for since


### PR DESCRIPTION
This PR is a follow-up to https://github.com/ManageIQ/manageiq-providers-cisco_intersight/pull/55. Last time, polling did not take into consideration historical events and was not able to fetch them. This PR changes this by redefining variable since in the polling function.