### PR TITLE
Provide default for display_name matching other provider patterns

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_server_profile.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_server_profile.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::CiscoIntersight
   class PhysicalInfraManager::PhysicalServerProfile < ::PhysicalServerProfile
-    def self.display_name(name)
-      n_('Physical Server Profile (CiscoIntersight)', 'Physical Server Profile (CiscoIntersight)', name)
+    def self.display_name(number = 1)
+      n_('Physical Server Profile (CiscoIntersight)', 'Physical Server Profile (CiscoIntersight)', number)
     end
 
     def provider_object(connection)


### PR DESCRIPTION
Fixes a bug extracting model translations from manageiq:

```
% be rake locale:update_all
** ManageIQ master, codename: Oparin
** Using session_store: ActionDispatch::Session::MemoryStore
** ManageIQ master, codename: Oparin
writing model translations to: /Users/joerafaniello/Code/manageiq/locale/model_attributes.rb
rake aborted!
ArgumentError: wrong number of arguments (given 0, expected 1)
/Users/joerafaniello/.gem/ruby/2.7.5/bundler/gems/manageiq-providers-cisco_intersight-948ac7a302da/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_server_profile.rb:3:in `display_name'
```

Note, all other provider's `display_name` method provide a default number for the argument so I copied that pattern.