### PR TITLE
Renamed button on server view from 'Cisco Intersight' to 'Intersight'

### DIFF
--- a/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_servers_center.rb
+++ b/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_servers_center.rb
@@ -9,7 +9,7 @@ module ManageIQ
               select(
                 :physical_server_lifecycle_choice,
                 nil,
-                t = N_('Cisco Intersight'),
+                t = N_('Intersight'),
                 t,
                 :enabled => true,
                 :items   => [


### PR DESCRIPTION
This PR renames button on server view from 'Cisco Intersight' to 'Intersight'