### PR TITLE
Add buttons for deploying and unassigning server profiles in physical servers view

### DIFF
--- a/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_servers_center.rb
+++ b/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_servers_center.rb
@@ -43,6 +43,33 @@ module ManageIQ
                     :onwhen  => "1+",
                     :options => {:feature => :recommission}
                   ),
+                  separator,
+                  button(
+                    :physical_server_profile_deploy_server,
+                    'pficon fa-lg',
+                    t = N_('Deploy Server Profile'),
+                    t,
+                    :data  => {'function'      => 'sendDataWithRx',
+                               'function-data' => {:controller     => 'provider_dialogs',
+                                                   :button         => :physical_server_profile_deploy_server,
+                                                   :modal_title    => N_('Deploy Server Profile'),
+                                                   :component_name => 'ServerProfileForm',
+                                                   :action         => 'deploy_server'}},
+                    :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                  ),
+                  button(
+                    :physical_server_profile_unassign_server,
+                    'pficon fa-lg',
+                    t = N_('Unassign Server Profile'),
+                    t,
+                    :data  => {'function'      => 'sendDataWithRx',
+                               'function-data' => {:controller     => 'provider_dialogs',
+                                                   :button         => :physical_server_profile_unassign_server,
+                                                   :modal_title    => N_('Unassign Server Profile'),
+                                                   :component_name => 'ServerProfileForm',
+                                                   :action         => 'unassign_server'}},
+                    :klass => ApplicationHelper::Button::ButtonWithoutRbacCheck
+                  )
                 ]
               )
             ]


### PR DESCRIPTION
This PR adds buttons for deploying and unassigning server profiles when viewing multiple physical servers in UI (this is done by going to "Physical Infrastructure" --> "Providers" --> Choosing a specific provider --> "Physical Servers").

Physical servers view before the the change:

<img width="1205" alt="image" src="https://user-images.githubusercontent.com/92620429/169538628-b1a5642b-28ad-44e7-8e85-2fd07935e372.png">

Physical servers view after the the change:

<img width="1206" alt="image" src="https://user-images.githubusercontent.com/92620429/169538287-43e5a629-174b-4789-adbf-009a7fc6545b.png">