### PR TITLE
[WIP]: Added SupportsFeatures functionality to the overridden toolbar

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_server.rb
@@ -2,6 +2,16 @@ module ManageIQ::Providers::CiscoIntersight
   class PhysicalInfraManager::PhysicalServer < ::PhysicalServer
     include_concern 'Provisioning'
 
+    supports :decommission do
+      unsupported_reason_add(:decommission, _("You cannot decommission a server while it's not powerered off.")) unless power_state == "off"
+      # equivalently: ... if (power_state == "on" or power_state == "decomissioned")
+    end
+
+    supports :recommission do
+      unsupported_reason_add(:recommission, _("You cannot recommission a server if the server is active.")) unless power_state == "decomissioned"
+      # equivalently: ... if (power_state == "off" or power_state == "on"); meaning: The server is active
+    end
+
     def self.display_name(number = 1)
       n_('Physical Server (CiscoIntersight)', 'Physical Servers (CiscoIntersight)', number)
     end
@@ -19,3 +29,4 @@ module ManageIQ::Providers::CiscoIntersight
     end
   end
 end
+


### PR DESCRIPTION
This PR is going to add SupportFeatures functionality for `Decommission` and `Recommission` buttons when viewing a specific physical server; meaning: If a server doesn't fulfill a criteria for either being decommissioned or recommissioned, the user should not have the ability to press it (it shouldn't be enabled).

With the current changes of this PR, the button still looks like this:

<img width="1437" alt="image" src="https://user-images.githubusercontent.com/92620429/169612351-105b033d-b9c4-405d-82e4-3fa28637db2c.png">

as you can see, `Recommission` as well as `Decommission` buttons may be pressed, which is not what I want.

I've written the "`supports`" sentences for server's recommission and decommission (with the first commit in this PR: https://github.com/ManageIQ/manageiq-providers-cisco_intersight/commit/2bbb626adaefc8aef716bacf0c81111f40c91244) but got stuck at actually using this functionality in the actual button - I want to use this changes in [this file](https://github.com/tjazsch/manageiq-providers-cisco_intersight/blob/master/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb#L42); more specifically, in this file, changes should most likely come in the following two places:

- [Button, intended for recommission](https://github.com/tjazsch/manageiq-providers-cisco_intersight/blob/cc2ae92107d20762e6b5959933109dfbb102a9af/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb#L30-L43)
- [Button, intended for decommission](https://github.com/tjazsch/manageiq-providers-cisco_intersight/blob/cc2ae92107d20762e6b5959933109dfbb102a9af/app/helpers/manageiq/providers/cisco_intersight/toolbar_overrides/physical_server_center.rb#L16-L29)

more precisely, I assume buttons' values `:enabled` and `:options` should have been changes, but I don't know how.

Any help would be greatly appreciated. Thanks.