### PR TITLE
Delay load the large intersight client

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/manager_mixin.rb
+++ b/app/models/manageiq/providers/cisco_intersight/manager_mixin.rb
@@ -1,9 +1,8 @@
-require 'intersight_client'
-
 module ManageIQ::Providers::CiscoIntersight::ManagerMixin
   extend ActiveSupport::Concern
 
   def connect(options = {})
+    require 'intersight_client'
     keyid = authentication_userid
     key = authentication_password
     raise MiqException::MiqHostError, "No credentials defined" if !keyid || !key
@@ -98,6 +97,7 @@ module ManageIQ::Providers::CiscoIntersight::ManagerMixin
     end
 
     def verify_provider_connection(api_client)
+      require 'intersight_client'
       IntersightClient::IamApi.new(api_client).get_iam_api_key_list({:count => true}).count > 0
     rescue IntersightClient::ApiError => err
       case err.code

--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager_spec.rb
@@ -1,3 +1,5 @@
+require 'intersight_client'
+
 describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
   it ".ems_type" do
     expect(described_class.ems_type).to eq("cisco_intersight")


### PR DESCRIPTION
Fixes #66

Related to https://github.com/xlab-si/intersight-sdk-ruby/issues/13

Delay loading the intersight client saves time booting the rails application
along with memory and required files:

% time bundle exec rails r 'ManageIQ::Providers::CiscoIntersight::ManagerMixin'

Before:
bundle exec rails r 'ManageIQ::Providers::CiscoIntersight::ManagerMixin'  15.39s user 6.63s system 92% cpu 23.869 total

After:
bundle exec rails r 'ManageIQ::Providers::CiscoIntersight::ManagerMixin'  4.86s user 2.28s system 98% cpu 7.215 total