### PR TITLE
Set minimum client version to a much faster and leaner 0.1.4

### DIFF
--- a/manageiq-providers-cisco_intersight.gemspec
+++ b/manageiq-providers-cisco_intersight.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "intersight_client"
+  spec.add_dependency "intersight_client", "~> 0.1", ">= 0.1.4"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
Before, with 0.1.3:

```
% ruby -e 'require "sys/proctable"; memory = Sys::ProcTable.ps(:pid => Process.pid).rss; time = Time.now; require "intersight_client"; puts "Require time: #{Time.now - time}"; GC.start; puts "memory growth: #{Sys::ProcTable.ps(:pid => Process.pid).rss - memory}"; puts "Version: #{IntersightClient::VERSION}"'
Require time: 7.306528
memory growth: 392_871_936
Version: 0.1.3
```

After, with 0.1.4:
```
% ruby -e 'require "sys/proctable"; memory = Sys::ProcTable.ps(:pid => Process.pid).rss; time = Time.now; require "intersight_client"; puts "Require time: #{Time.now - time}"; GC.start; puts "memory growth: #{Sys::ProcTable.ps(:pid => Process.pid).rss - memory}"; puts "Version: #{IntersightClient::VERSION}"'
Require time: 0.182657
memory growth: 20_295_680
Version: 0.1.4
```
0.1.4 is the first release with https://github.com/xlab-si/intersight-sdk-ruby/pull/14

cc @agrare 