### PR TITLE
Bump minimum version of intersight_client to 0.1.5

### DIFF
--- a/manageiq-providers-cisco_intersight.gemspec
+++ b/manageiq-providers-cisco_intersight.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "intersight_client", "~> 0.1", ">= 0.1.4"
+  spec.add_dependency "intersight_client", "~> 0.1", ">= 0.1.5"
 
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "simplecov", ">= 0.21.2"


### PR DESCRIPTION
0.1.5 includes xlab-si/intersight-sdk-ruby#17 which lowers the disk space
usage of the gem by ~76MB

@agrare Please review.