### PR TITLE
[WIP] Add connection to ServiceNow and support issuing a ticket associated to an Intersight server

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/servicenow_request.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/servicenow_request.rb
@@ -1,0 +1,2 @@
+# TODO
+# def submit_servicenow_request(server, _options)


### PR DESCRIPTION
When implemented, this PR will provide the features to resolve #76:
support for creating a ServiceNow ticket associated to a server on the ManageIQ UI.

For now, this only contains a stub. I am creating this PR only for planning this feature in this release cycle.