### PR TITLE
[WIP] Support for provisioning bare metal resources from Service Catalogs

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/provision_bare_metal_server.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations/provision_bare_metal_server.rb
@@ -1,0 +1,3 @@
+# TODO
+
+# def submit_provision_bare_metal_server(server, server_profile, _options)


### PR DESCRIPTION
When implemented, this PR will provide the features to resolve #78:  from the list of decommissioned servers the user should be able to choose one server and assign it with an available Server Profile. The logic should recommission a server, assign it with the chosen server profile, and apply the server profile to the server.

This WIP PR only contains a stub for now. I am creating this PR only for planning this feature in this release cycle.