### PR TITLE
Fix display_name for PhysicalServerProfileTemplate

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_server_profile_template.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_server_profile_template.rb
@@ -1,7 +1,7 @@
 module ManageIQ::Providers::CiscoIntersight
   class PhysicalInfraManager::PhysicalServerProfileTemplate < ::PhysicalServerProfileTemplate
     def self.display_name(number = 1)
-      n_('Physical Server Profile Template (CiscoIntersight)', 'Physical Server Profile Template (CiscoIntersight)', number)
+      n_('Physical Server Profile Template (Cisco Intersight)', 'Physical Server Profile Template (Cisco Intersight)', number)
     end
 
     def provider_object(connection)


### PR DESCRIPTION
The provider name should be `Cisco Intersight` not `CiscoIntersight` as this is user facing