### PR TITLE
Drop require_nested and include_concern

### DIFF
--- a/app/models/manageiq/providers/cisco_intersight/inventory.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory.rb
@@ -1,7 +1,4 @@
 module ManageIQ::Providers::CiscoIntersight
   class Inventory < ManageIQ::Providers::Inventory
-    require_nested :Collector
-    require_nested :Parser
-    require_nested :Persister
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/collector.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/collector.rb
@@ -1,5 +1,4 @@
 module ManageIQ::Providers::CiscoIntersight
   class Inventory::Collector < ManageIQ::Providers::Inventory::Collector
-    require_nested :PhysicalInfraManager
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/parser.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/parser.rb
@@ -1,5 +1,4 @@
 module ManageIQ::Providers::CiscoIntersight
   class Inventory::Parser < ManageIQ::Providers::Inventory::Parser
-    require_nested :PhysicalInfraManager
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/inventory/persister.rb
+++ b/app/models/manageiq/providers/cisco_intersight/inventory/persister.rb
@@ -1,5 +1,4 @@
 module ManageIQ::Providers::CiscoIntersight
   class Inventory::Persister < ManageIQ::Providers::Inventory::Persister
-    require_nested :PhysicalInfraManager
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager.rb
@@ -1,13 +1,5 @@
 module ManageIQ::Providers::CiscoIntersight
   class PhysicalInfraManager < ManageIQ::Providers::PhysicalInfraManager
-    require_nested :MetricsCapture
-    require_nested :MetricsCollectorWorker
-    require_nested :Refresher
-    require_nested :RefreshWorker
-    require_nested :EventCatcher
-    require_nested :EventParser
-    require_nested :PhysicalServer
-    require_nested :PhysicalServerProfileTemplate
     supports :catalog
 
     include Vmdb::Logging

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager.rb
@@ -12,7 +12,7 @@ module ManageIQ::Providers::CiscoIntersight
 
     include Vmdb::Logging
     include ManagerMixin
-    include_concern "Operations"
+    include Operations
 
     supports :create
 

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/event_catcher.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/event_catcher.rb
@@ -1,6 +1,5 @@
 module ManageIQ::Providers::CiscoIntersight
   class PhysicalInfraManager::EventCatcher \
       < ManageIQ::Providers::BaseManager::EventCatcher
-    require_nested :Runner
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/firmware_update_task.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/firmware_update_task.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::CiscoIntersight
   class PhysicalInfraManager::FirmwareUpdateTask \
       < ManageIQ::Providers::PhysicalInfraManager::FirmwareUpdateTask
-    include_concern 'StateMachine'
+    include StateMachine
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/metrics_collector_worker.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/metrics_collector_worker.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers::CiscoIntersight
   class PhysicalInfraManager::MetricsCollectorWorker < ManageIQ::Providers::BaseManager::MetricsCollectorWorker
-    require_nested :Runner
-
     self.default_queue_name = "cisco_intersight"
 
     def friendly_name

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/operations.rb
@@ -1,11 +1,10 @@
 module ManageIQ::Providers::CiscoIntersight
   module PhysicalInfraManager::Operations
     extend ActiveSupport::Concern
-
-    include_concern "Power"
-    include_concern "Led"
-    include_concern "Firmware"
-    include_concern "Lifecycle"
-    include_concern "ServerProfileAssignment"
+    include Power
+    include Led
+    include Firmware
+    include Lifecycle
+    include ServerProfileAssignment
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_server.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/physical_server.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::CiscoIntersight
   class PhysicalInfraManager::PhysicalServer < ::PhysicalServer
-    include_concern 'Provisioning'
+    include Provisioning
 
     def self.display_name(number = 1)
       n_('Physical Server (CiscoIntersight)', 'Physical Servers (CiscoIntersight)', number)

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/provision.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/provision.rb
@@ -1,6 +1,6 @@
 module ManageIQ::Providers::CiscoIntersight
   class PhysicalInfraManager::Provision \
       < ::PhysicalServerProvisionTask
-    include_concern 'StateMachine'
+    include StateMachine
   end
 end

--- a/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresh_worker.rb
+++ b/app/models/manageiq/providers/cisco_intersight/physical_infra_manager/refresh_worker.rb
@@ -1,7 +1,5 @@
 module ManageIQ::Providers::CiscoIntersight
   class PhysicalInfraManager::RefreshWorker < ::MiqEmsRefreshWorker
-    require_nested :Runner
-
     def self.settings_name
       :ems_refresh_worker_cisco_intersight_physical_infra
     end


### PR DESCRIPTION
Zeitwerk completely removes the need for these methods. See also: https://github.com/ManageIQ/manageiq/pull/22854