### PR TITLE
Allow overriding the Cisco Intersight ApiClient scheme/host/verify_ssl for on-premise intersight controller

### DIFF
--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager_spec.rb
@@ -15,10 +15,24 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
   context ".raw_connect" do
     it "connects with key_id and secret key" do
       expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
+      expect(config_mock).to receive(:scheme=).with("https")
+      expect(config_mock).to receive(:host=).with("intersight.com:443")
+      expect(config_mock).to receive(:verify_ssl=).with(true)
       expect(config_mock).to receive(:api_key_id=).with("keyid")
       expect(config_mock).to receive(:api_key=).with("secretkey")
 
-      described_class.raw_connect("keyid", "secretkey")
+      described_class.raw_connect("https://intersight.com", OpenSSL::SSL::VERIFY_PEER, "keyid", "secretkey")
+    end
+
+    it "defaults to url=https://intersight.com and verify_ssl=true" do
+      expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
+      expect(config_mock).to receive(:scheme=).with("https")
+      expect(config_mock).to receive(:host=).with("intersight.com:443")
+      expect(config_mock).to receive(:verify_ssl=).with(true)
+      expect(config_mock).to receive(:api_key_id=).with("keyid")
+      expect(config_mock).to receive(:api_key=).with("secretkey")
+
+      described_class.raw_connect(nil, nil, "keyid", "secretkey")
     end
   end
 
@@ -37,17 +51,44 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
   end
 
   context "#connect" do
-    it "aborts on missing credentials" do
-      ems = FactoryBot.create(:ems_cisco_intersight_physical_infra)
-      expect { ems.connect }.to raise_error(MiqException::MiqHostError)
+    context "with missing credentials" do
+      let(:ems) { FactoryBot.create(:ems_cisco_intersight_physical_infra) }
+
+      it "aborts" do
+        expect { ems.connect }.to raise_error(MiqException::MiqHostError)
+      end
     end
 
     it "connects with key_id and secret key" do
       expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
+      expect(config_mock).to receive(:scheme=).with("https")
+      expect(config_mock).to receive(:host=).with("intersight.com:443")
+      expect(config_mock).to receive(:verify_ssl=).with(true)
       expect(config_mock).to receive(:api_key_id=).with("keyid")
       expect(config_mock).to receive(:api_key=).with("secretkey")
 
       ems.connect
+    end
+
+    context "with an alternate URL" do
+      let(:url) { "http://intersight.localdomain:8080" }
+      let(:ems) do
+        FactoryBot.create(:ems_cisco_intersight_physical_infra, :auth).tap do |ems|
+          ems.default_endpoint.url = url
+          ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
+        end
+      end
+
+      it "connects with the alternate host" do
+        expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
+        expect(config_mock).to receive(:scheme=).with("http")
+        expect(config_mock).to receive(:host=).with("intersight.localdomain:8080")
+        expect(config_mock).to receive(:verify_ssl=).with(false)
+        expect(config_mock).to receive(:api_key_id=).with("keyid")
+        expect(config_mock).to receive(:api_key=).with("secretkey")
+
+        ems.connect
+      end
     end
   end
 end


### PR DESCRIPTION
NOTE this will work without a default_endpoint at all but we should create a schema migration to set the default values for existing providers

Fixes https://github.com/ManageIQ/manageiq-providers-cisco_intersight/issues/103
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
