### PR TITLE
Fix URL override not being used for API calls

### DIFF
--- a/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager_spec.rb
+++ b/spec/models/manageiq/providers/cisco_intersight/physical_infra_manager_spec.rb
@@ -15,8 +15,6 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
   context ".raw_connect" do
     it "connects with key_id and secret key" do
       expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
-      expect(config_mock).to receive(:scheme=).with("https")
-      expect(config_mock).to receive(:host=).with("intersight.com:443")
       expect(config_mock).to receive(:verify_ssl=).with(true)
       expect(config_mock).to receive(:api_key_id=).with("keyid")
       expect(config_mock).to receive(:api_key=).with("secretkey")
@@ -26,8 +24,6 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
 
     it "defaults to url=https://intersight.com and verify_ssl=true" do
       expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
-      expect(config_mock).to receive(:scheme=).with("https")
-      expect(config_mock).to receive(:host=).with("intersight.com:443")
       expect(config_mock).to receive(:verify_ssl=).with(true)
       expect(config_mock).to receive(:api_key_id=).with("keyid")
       expect(config_mock).to receive(:api_key=).with("secretkey")
@@ -61,13 +57,30 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
 
     it "connects with key_id and secret key" do
       expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
-      expect(config_mock).to receive(:scheme=).with("https")
-      expect(config_mock).to receive(:host=).with("intersight.com:443")
       expect(config_mock).to receive(:verify_ssl=).with(true)
       expect(config_mock).to receive(:api_key_id=).with("keyid")
       expect(config_mock).to receive(:api_key=).with("secretkey")
 
       ems.connect
+    end
+
+    context "with a variation of the default url" do
+      let(:url) { "https://intersight.com:443/" }
+      let(:ems) do
+        FactoryBot.create(:ems_cisco_intersight_physical_infra, :auth).tap do |ems|
+          ems.default_endpoint.url = url
+          ems.default_endpoint.verify_ssl = OpenSSL::SSL::VERIFY_NONE
+        end
+      end
+
+      it "connects with the default server" do
+        expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
+        expect(config_mock).to receive(:verify_ssl=).with(false)
+        expect(config_mock).to receive(:api_key_id=).with("keyid")
+        expect(config_mock).to receive(:api_key=).with("secretkey")
+
+        ems.connect
+      end
     end
 
     context "with an alternate URL" do
@@ -83,6 +96,7 @@ describe ManageIQ::Providers::CiscoIntersight::PhysicalInfraManager do
         expect(IntersightClient::Configuration).to receive(:new).and_yield(config_mock)
         expect(config_mock).to receive(:scheme=).with("http")
         expect(config_mock).to receive(:host=).with("intersight.localdomain:8080")
+        expect(config_mock).to receive(:server_index=).with(nil)
         expect(config_mock).to receive(:verify_ssl=).with(false)
         expect(config_mock).to receive(:api_key_id=).with("keyid")
         expect(config_mock).to receive(:api_key=).with("secretkey")


### PR DESCRIPTION
The openapi generated `ApiClient`/`Configuration` classes have a way to to pass scheme, host, and base_path but they are ignored and `Configuration#server_settings` is used unless server_index is set to `nil`

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
